### PR TITLE
Reflow all the language stack `README-content.md` files to 80 columns and incorporate Fred's changes

### DIFF
--- a/README-footer.md
+++ b/README-footer.md
@@ -4,16 +4,17 @@
 ## Issues
 
 If you have any problems with, or questions about this image, please contact us
-%%MAILING_LIST%% through a [GitHub issue](%%REPO%%/issues) or via the IRC channel
-`#docker-library` on [Freenode](https://freenode.net).
+%%MAILING_LIST%% through a [GitHub issue](%%REPO%%/issues) or via the IRC
+channel `#docker-library` on [Freenode](https://freenode.net).
 
 ## Contributing
 
-You are invited to contribute new features, fixes, or updates, large or small; we are
-always thrilled to receive pull requests, and do our best to process them as fast as
-we can.
+You are invited to contribute new features, fixes, or updates, large or small;
+we are always thrilled to receive pull requests, and do our best to process them
+as fast as we can.
 
-Before you start to code, we recommend discussing your plans %%MAILING_LIST%% through a
-[GitHub issue](%%REPO%%/issues), especially for more ambitious contributions. This gives
-other contributors a chance to point you in the right direction, give you feedback on
-your design, and help you find out if someone else is working on the same thing.
+Before you start to code, we recommend discussing your plans %%MAILING_LIST%%
+through a [GitHub issue](%%REPO%%/issues), especially for more ambitious
+contributions. This gives other contributors a chance to point you in the right
+direction, give you feedback on your design, and help you find out if someone
+else is working on the same thing.

--- a/buildpack-deps/README-content.md
+++ b/buildpack-deps/README-content.md
@@ -1,3 +1,8 @@
-# What is buildpack-deps?
+# What is `buildpack-deps`?
 
-`buildpack-deps` is in spirit similar to [Heroku's stack images](https://github.com/heroku/stack-images/blob/master/bin/cedar.sh); it includes a huge number of "development header" packages needed by arbitrary things like Ruby Gems, PyPI modules, etc.  This makes it possible to do something like a `bundle install` in an arbitrary application directory without knowing beforehand that it needs `ssl.h` to build one of the modules depended on, for example.
+In spirit, `buildpack-deps` is similar to [Heroku's stack
+images](https://github.com/heroku/stack-images/blob/master/bin/cedar.sh). It
+includes a large number of "development header" packages needed by various
+things like Ruby Gems, PyPI modules, etc. For example, `buildpack-deps` would
+let you do a `bundle install` in an arbitrary application directory without
+knowing beforehand that `ssl.h` is required to build a dependent module.

--- a/clojure/README-content.md
+++ b/clojure/README-content.md
@@ -1,26 +1,37 @@
-What is Clojure?
+# What is Clojure?
 
-Clojure is a dialect of the Lisp programming language created by Rich Hickey. Clojure is a general-purpose programming language with an emphasis on functional programming. It runs on the Java Virtual Machine, Common Langauge Runtime, and JavaScript engines. Like other Lisps, Clojure treats code as data and has a macro system.
+Clojure is a dialect of the Lisp programming language. It is a general-purpose
+programming language with an emphasis on functional programming. It runs on the
+Java Virtual Machine, Common Langauge Runtime, and JavaScript engines. Like
+other Lisps, Clojure treats code as data and has a macro system.
 
->[wikipedia.org/wiki/Clojure](http://en.wikipedia.org/wiki/Clojure)
+> [wikipedia.org/wiki/Clojure](http://en.wikipedia.org/wiki/Clojure)
 
 # How to use this image
 
-## Start a Lein/Clojure instance running in your app.
+## Start a Lein/Clojure instance in your app
 
-As the most common way to use Clojure is in conjunction with [lein](http://leiningen.org/), the Clojure image assumes you are doing so. The most straight-forward way of using this image is adding a Dockerfile to an already existing Lein/Clojure project.
+Since the most common way to use Clojure is in conjunction with [Leiningen
+(`lein`)](http://leiningen.org/), this image assumes that's how you'll be
+working. The most straightforward way to use this image is to add a `Dockerfile`
+to an existing Leiningen/Clojure project:
 
     FROM clojure
     COPY . /usr/src/app
     WORKDIR /usr/src/app
     CMD ["lein", "run"]
 
-Then run the commands to build and run the image.
+Then, run these commands to build and run the image:
 
     docker build -t my-clojure-app .
     docker run -it --rm --name my-running-app my-clojure-app
 
-While the above is the most straight-forward example of a Dockerfile, it has several drawbacks. The `lein run` command will download your dependencies, compile the project, and then run it. That's a lot of work being done, and it may not be that you want that done every single time you run the image. We can download the dependencies ahead of time, as well as compile the project, so that when you run your image, the startup time is significantly reduced.
+While the above is the most straightforward example of a `Dockerfile`, it does
+have some drawbacks. The `lein run` command will download your dependencies,
+compile the project, and then run it. That's a lot of work, all of which you may
+not want done every time you run the image. To get around this, you can download
+the dependencies and compile the project ahead of time. This will significantly
+reduce startup time when you run your image.
 
     FROM clojure
     RUN mkdir -p /usr/src/app
@@ -31,17 +42,19 @@ While the above is the most straight-forward example of a Dockerfile, it has sev
     RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" app-standalone.jar
     CMD ["java", "-jar", "app-standalone.jar"]
 
-This Dockerfile will cause the dependencies to be downloaded (and cached so that they are only redownloaded when the dependencies change, rather than everytime the image is built) and compiled into a standalone jar when it is built rather than each time it is run.
+Writing the `Dockerfile` this way will download the dependencies (and cache
+them, so they are only re-downloaded when the dependencies change) and then
+compile them into a standalone jar ahead of time rather than each time the image
+is run.
 
-Then build and run the image.
+You can then build and run the image as above.
 
-    docker build -t my-clojure-app .
-    docker run -it --rm --name my-running-app my-clojure-app
+## Compile your Lein/Clojure project into a jar from within the container
 
-## Compile your Lein/Clojure project into a jar from within the container.
-
-If you have an existing Lein/Clojure project, it's fairly straightforward to compile your project into a jar from a container.
+If you have an existing Lein/Clojure project, it's fairly straightforward to
+compile your project into a jar from a container:
 
     docker run -it --rm -v "$(pwd)":/usr/src/app -w /usr/src/app clojure lein uberjar
 
-This will build your project into a jar file located in your project's target/uberjar directory for you to use.
+This will build your project into a jar file located in your project's
+`target/uberjar` directory.

--- a/gcc/README-content.md
+++ b/gcc/README-content.md
@@ -1,13 +1,20 @@
-# What is gcc?
-The GNU Compiler Collection (GCC) is a compiler system produced by the GNU Project supporting various programming languages. GCC is a key component of the GNU toolchain. The Free Software Foundation (FSF) distributes GCC under the GNU General Public License (GNU GPL). GCC has played an important role in the growth of free software, as both a tool and an example.
+# What is GCC?
+
+The GNU Compiler Collection (GCC) is a compiler system produced by the GNU
+Project that supports various programming languages. GCC is a key component of
+the GNU toolchain. The Free Software Foundation (FSF) distributes GCC under the
+GNU General Public License (GNU GPL). GCC has played an important role in the
+growth of free software, as both a tool and an example.
 
 > [wikipedia.org/wiki/GNU_Compiler_Collection](https://en.wikipedia.org/wiki/GNU_Compiler_Collection)
 
 # How to use this image
 
-## Start a gcc instance running your app.
+## Start a GCC instance running your app
 
-For this image, the most straight-forward use is to use a gcc container as both the build environment as well as the runtime environment. In your Dockerfile, you can do something along the lines of the following will compile and run your project.
+The most straightforward way to use this image is to use a gcc container as both
+the build and runtime environment. In your `Dockerfile`, writing something along
+the lines of the following will compile and run your project:
 
     FROM gcc:4.9
     COPY . /usr/src/myapp
@@ -15,17 +22,23 @@ For this image, the most straight-forward use is to use a gcc container as both 
     RUN gcc -o myapp main.c
     CMD ["./myapp"]
 
-Then run the commands to build and run the docker image.
+Then, build and run the Docker image:
 
     docker build -t my-gcc-app .
     docker run -it --rm --name my-running-app my-gcc-app
 
-## Compile your app inside the docker container.
+## Compile your app inside the Docker container
 
-It is not always appropriate to run your app inside a container. In instances where you only want to compile inside the docker instance, you can do something along the lines of the following.
+There may be occasions where it is not appropriate to run your app inside a
+container. To compile, but not run your app inside the Docker instance, you can
+write something like:
 
     docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp gcc:4.9 gcc -o myapp myapp.c
 
-This will add your current directory as a volume to the container, set the working directory to the volume, and run the command `gcc -o myapp myapp.c` which will tell gcc to compile the code in myapp.c and output the executable to myapp. Alternatively, if you have a make file, you can instead run the make command inside your container.
+This will add your current directory, as a volume, to the container, set the
+working directory to the volume, and run the command `gcc -o myapp myapp.c.`
+This tells gcc to compile the code in `myapp.c` and output the executable to
+myapp. Alternatively, if you have a `Makefile`, you can instead run the `make`
+command inside your container:
 
     docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp gcc:4.9 make

--- a/gcc/README-short.txt
+++ b/gcc/README-short.txt
@@ -1,1 +1,1 @@
-The GNU Compiler Collection (GCC) is a compiler system produced by the GNU Project supporting various programming languages.
+The GNU Compiler Collection (GCC) is a compiler system produced by the GNU Project that supports various programming languages.

--- a/golang/README-content.md
+++ b/golang/README-content.md
@@ -1,43 +1,60 @@
 # What is Go?
-Go, also called golang, is a programming language initially developed at Google in 2007 by Robert Griesemer, Rob Pike, and Ken Thompson. It is a statically-typed language with syntax loosely derived from that of C, adding garbage collection, type safety, some dynamic-typing capabilities, additional built-in types such as variable-length arrays and key-value maps, and a large standard library.
+
+Go (a.k.a., Golang) is a programming language first developed at Google. It is a
+statically-typed language with syntax loosely derived from C, but with
+additional features such as garbage collection, type safety, some dynamic-typing
+capabilities, additional built-in types (e.g., variable-length arrays and
+key-value maps), and a large standard library.
 
 > [wikipedia.org/wiki/Go_(programming_language)](http://en.wikipedia.org/wiki/Go_(programming_language))
 
 # How to use this image
 
-## Start a go instance running in your app.
+## Start a Go instance in your app
 
-For this image, the most straight-forward use is to use a golang container as both the build environment as well as the runtime environment. In your Dockerfile, you can do something along the lines of the following will compile and run your project.
+The most straightforward way to use this image is to use a Go container as both
+the build and runtime environment. In your `Dockerfile`, writing something along
+the lines of the following will compile and run your project:
 
-    FROM golang:1.3-onbuild
+    FROM golang:1.3.1-onbuild
     CMD ["./myapp"]
 
-This image includes multiple `ONBUILD` triggers so that should be all that you need for most applications. The build will `COPY . /usr/src/app`, `RUN go get -d -v`, and `RUN go build -v`.
+This image includes multiple `ONBUILD` triggers which should cover most
+applications. The build will `COPY . /usr/src/app`, `RUN go get -d -v`, and `RUN
+go build -v`.
 
-Then run and build the docker image.
+You can then run and build the Docker image:
 
     docker build -t my-golang-app
     docker run -it --rm --name my-running-app my-golang-app
 
-## Compile your app inside the docker container.
+## Compile your app inside the Docker container
 
-It is not always appropriate to run your app inside a container. In instances where you only want to compile inside the docker instance, you can do something along the lines of the following.
+There may be occasions where it is not appropriate to run your app inside a
+container. To compile, but not run your app inside the Docker instance, you can
+write something like:
 
-    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3 go build -v
+    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3.1 go build -v
 
-This will add your current directory as a volume to the container, set the working directory to the volume, and run the command `go build` which will tell go to compile the project in the working directory and output the executable to myapp. Alternatively, if you have a make file, you can instead run the make command inside your container.
+This will add your current directory as a volume to the container, set the
+working directory to the volume, and run the command `go build` which will tell
+go to compile the project in the working directory and output the executable to
+`myapp`. Alternatively, if you have a `Makefile`, you can run the `make` command
+inside your container.
 
-    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3 make
+    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3.1 make
 
-## Cross-compile your app inside the docker container.
+## Cross-compile your app inside the Docker container
 
-If you need to compile your application for a platform other than `linux/amd64` (like `windows/386`, for example), the provided `cross` tags can be used to accomplish this with minimal friction:
+If you need to compile your application for a platform other than `linux/amd64`
+(such as `windows/386`), this can be easily accomplished with the provided
+`cross` tags:
 
-    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp -e GOOS=windows -e GOARCH=386 golang:1.3-cross go build -v
+    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp -e GOOS=windows -e GOARCH=386 golang:1.3.1-cross go build -v
 
-Alternatively, build for multiple platforms at once:
+Alternatively, you can build for multiple platforms at once:
 
-    docker run --rm -it -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3-cross bash
+    docker run --rm -it -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3.1-cross bash
     $ for GOOS in darwin linux; do
     >   for GOARCH in 386 amd64; do
     >     go build -v -o myapp-$GOOS-$GOARCH

--- a/hylang/README-content.md
+++ b/hylang/README-content.md
@@ -1,25 +1,33 @@
-# What is hylang?
+# What is Hy?
 
-Hy (alternately, Hylang) is a dialect of the Lisp programming language designed to interoperate with Python by translating expressions into Python's abstract syntax tree (AST). Similar to Clojure's mapping of s-expressions onto the JVM, Hy is meant to operate as a transparent Lisp front end to Python's abstract syntax. Hy also allows for Python libraries (include the standard library) to be imported and accessed alongside Hy code with a compilation step, converting the data structure of both into Python's AST.
+Hy (a.k.a., Hylang) is a dialect of the Lisp programming language designed to
+interoperate with Python by translating expressions into Python's abstract
+syntax tree (AST). Similar to Clojure's mapping of s-expressions onto the JVM,
+Hy is meant to operate as a transparent Lisp front end to Python's abstract
+syntax. Hy also allows for Python libraries (including the standard library) to
+be imported and accessed alongside Hy code with a compilation step, converting
+the data structure of both into Python's AST.
 
-> [hy.readthedocs.org/en/latest/](http://hy.readthedocs.org/en/latest/)
+> [wikipedia.org/wiki/Hy](https://en.wikipedia.org/wiki/Hy)
 
 # How to use this image
 
-## Create a `Dockerfile` in your hylang project.
+## Create a `Dockerfile` in your Hy project
 
-    FROM hylang:0.10.0
+    FROM hylang:0.10
     COPY . /usr/src/myapp
     WORKDIR /usr/src/myapp
     CMD [ "hy", "./your-daemon-or-script.hy" ]
 
-Then build and run the docker image.
+You can then build and run the Docker image:
 
     docker build -t my-hylang-app
     docker run -it --rm --name my-running-app my-hylang-app
 
-## Run a single hylang script.
+## Run a single Hy script
 
-For many single file projects, it may not be convenient to write a `Dockerfile` for your project. In such cases, you can run a hylang script by using the hylang docker image directly.
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Hy script by using the Hy
+Docker image directly:
 
-    docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp hylang:0.10.0 hy your-daemon-or-script.hy
+    docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp hylang:0.10 hy your-daemon-or-script.hy

--- a/java/README-content.md
+++ b/java/README-content.md
@@ -1,6 +1,9 @@
 # What is Java?
 
-Java is a concurrent, class-based, object-oriented language specifically designed to have as few implementation dependencies as possible. It is intended to allow application developers to "write once, run anywhere", meaning that code that runs on one platform does not need to be recompiled to run on another.
+Java is a concurrent, class-based, object-oriented language specifically
+designed to have as few implementation dependencies as possible. It is intended
+to allow application developers to "write once, run anywhere", meaning that code
+that runs on one platform does not need to be recompiled to run on another.
 
 Java is a registered trademark of Oracle and/or its affiliates.
 
@@ -8,9 +11,11 @@ Java is a registered trademark of Oracle and/or its affiliates.
 
 # How to use this image
 
-## Start a java instance running your app
+## Start a Java instance in your app
 
-For this image, the most straight-forward use is to use a java container as both the build environment as well as the runtime environment. In your Dockerfile, you can do something along the lines of the following will compile and run your project.
+The most straightforward way to use this image is to use a Java container as
+both the build and runtime environment. In your `Dockerfile`, writing something
+along the lines of the following will compile and run your project:
 
     FROM java:7
     COPY . /usr/src/myapp
@@ -18,17 +23,20 @@ For this image, the most straight-forward use is to use a java container as both
     RUN javac Main.java
     CMD ["java", "Main"]
 
-Then run the commands to build and run the docker image.
+You can then run and build the Docker image:
 
     docker build -t my-java-app .
     docker run -it --rm --name my-running-app my-java-app
 
-## Compile your app inside the docker container.
+## Compile your app inside the Docker container
 
-It is not always appropriate to run your app inside a container. In instances where you only want to compile inside the docker instance, you can do something along the lines of the following.
+There may be occasions where it is not appropriate to run your app inside a
+container. To compile, but not run your app inside the Docker instance, you can
+write something like:
 
     docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp java:7 javac Main.java
 
-This will add your current directory as a volume to the container, set the working directory to the volume, and run the command `javac Main.java` which will tell java to compile the code in Main.java and output the java class file to Main.class. Alternatively, if you have a make file, you can instead run the make command inside your container.
-
-    docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp java:7 make
+This will add your current directory as a volume to the container, set the
+working directory to the volume, and run the command `javac Main.java` which
+will tell Java to compile the code in `Main.java` and output the Java class file
+to `Main.class`.

--- a/node/README-content.md
+++ b/node/README-content.md
@@ -1,31 +1,47 @@
 # What is Node.js?
-Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript, and can be run within the Node.js runtime on Mac OS X, Windows and Linux with no changes.
 
-Node.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real time applications due to its asynchronous nature.
+Node.js is a software platform for scalable server-side and networking
+applications. Node.js applications are written in JavaScript and can be run
+within the Node.js runtime on Mac OS X, Windows, and Linux without changes.
 
-Node.js internally uses the Google V8 JavaScript engine to execute code, and a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in asynchronous I/O library for file, socket and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional web server software such as Apache.
+Node.js applications are designed to maximize throughput and efficiency, using
+non-blocking I/O and asynchronous events. Node.js applications run
+single-threaded, although Node.js uses multiple threads for file and network
+events. Node.js is commonly used for real-time applications due to its
+asynchronous nature.
+
+Node.js internally uses the Google V8 JavaScript engine to execute code; a large
+percentage of the basic modules are written in JavaScript. Node.js contains a
+built-in, asynchronous I/O library for file, socket, and HTTP communication. The
+HTTP and socket support allows Node.js to act as a web server without additional
+software such as Apache.
 
 > [wikipedia.org/wiki/Node.js](https://en.wikipedia.org/wiki/Node.js)
 
 # How to use this image
 
-## Create a `Dockerfile` in your nodejs app project.
+## Create a `Dockerfile` in your Node.js app project
 
-    FROM node:0.10.31-onbuild
+    FROM node:0.10-onbuild
     # replace this with your application's default port
     EXPOSE 8888
 
-Then build and run the docker image.
+You can then build and run the Docker image:
 
     docker build -t my-nodejs-app
     docker run -it --rm --name my-running-app my-nodejs-app
 
 ### Notes
 
-The image assumes that your application has a file named [`package.json`](https://www.npmjs.org/doc/json.html) listing its dependencies and defining its [start script](https://www.npmjs.org/doc/misc/npm-scripts.html#default-values).
+The image assumes that your application has a file named
+[`package.json`](https://www.npmjs.org/doc/json.html) listing its dependencies
+and defining its [start
+script](https://www.npmjs.org/doc/misc/npm-scripts.html#default-values).
 
-## Run a single nodejs script
+## Run a single Node.js script
 
-For many single file projects, it may not be convenient to write a `Dockerfile` for your project. In such cases, you can run a nodejs script by using the nodejs docker image directly.
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Node.js script by using the
+Node.js Docker image directly:
 
-    docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp node:0.10.31 node your-daemon-or-script.js
+    docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp node:0.10 node your-daemon-or-script.js

--- a/node/README-short.txt
+++ b/node/README-short.txt
@@ -1,1 +1,1 @@
-The Official Build of Node.js. Node.js is a platform for scalable server-side and networking applications.
+Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and run within the Node.js runtime on Mac OS X, Windows, and Linux.

--- a/perl/README-content.md
+++ b/perl/README-content.md
@@ -1,24 +1,29 @@
 # What is Perl?
-Perl is a family of high-level, general-purpose, interpreted, dynamic programming language. The Perl languages borrow freatures from other programming languages including C, shell scripting (sh), AWK, and sed.
+
+Perl is a high-level, general-purpose, interpreted, dynamic programming
+language. The Perl language borrows features from other programming languages,
+including C, shell scripting (sh), AWK, and sed.
 
 > [wikipedia.org/wiki/Perl](https://en.wikipedia.org/wiki/Perl)
 
 # How to use this image
 
-## Create a `Dockerfile` in your perl app project.
+## Create a `Dockerfile` in your Perl app project
 
     FROM perl:5.20
     COPY . /usr/src/myapp
     WORKDIR /usr/src/myapp
     CMD [ "perl", "./your-daemon-or-script.pl" ]
 
-Then build and run the docker image.
+Then, build and run the Docker image:
 
     docker build -t my-perl-app
     docker run -it --rm --name my-running-app my-perl-app
 
-## Run a single perl script.
+## Run a single Perl script
 
-For many single file projects, it may not be convenient to write a `Dockerfile` for your project. In such cases, you can run a perl script by using the perl docker image directly.
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Perl script by using the
+Perl Docker image directly:
 
     docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp perl:5.20 perl your-daemon-or-script.pl

--- a/perl/README-short.txt
+++ b/perl/README-short.txt
@@ -1,1 +1,1 @@
-Perl is a family of high-level, general-purpose, interpreted, dynamic programming language.
+Perl is a high-level, general-purpose, interpreted, dynamic programming language.

--- a/php/README-content.md
+++ b/php/README-content.md
@@ -1,48 +1,60 @@
 # What is PHP?
-PHP is a server-side scripting language designed for web development but also used as a general-purpose programming language. As of January 2013, PHP was installed on more than 240 million websites and 2.1 million web servers.
 
->[wikipedia.org/wiki/PHP](http://en.wikipedia.org/wiki/PHP)
+PHP is a server-side scripting language designed for web development, but which
+can also be used as a general-purpose programming language. PHP can be added to
+straight HTML or it can be used with a variety of templating engines and web
+frameworks. PHP code is usually processed by an interpreter, which is either
+implemented as a native module on the web-server or as a common gateway
+interface (CGI).
+
+> [wikipedia.org/wiki/PHP](http://en.wikipedia.org/wiki/PHP)
 
 # How to use this image.
 
-## Commandline
+## With Command Line
 
-In the case that you have a PHP project run through the command line interface, you can do the following.
+For PHP projects run through the command line interface (CLI), you can do the
+following.
 
-### Create a `Dockerfile` in your php project.
+### Create a `Dockerfile` in your PHP project
 
     FROM php:5.6-cli
     COPY . /usr/src/myapp
     WORKDIR /usr/src/myapp
     CMD [ "php", "./your-script.php" ]
 
-Then run the commands to build and run the docker image.
+Then, run the commands to build and run the Docker image:
 
     docker build -t my-php-app .
     docker run -it --rm --name my-running-app my-php-app
 
-### Run a single PHP script.
+### Run a single PHP script
 
-For many single file projects, it may not be convenient to write a `Dockerfile` for your project. In such cases, you can run a php script by using the php docker image directly.
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a PHP script by using the PHP
+Docker image directly:
 
     docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp php:5.6-cli php your-script.php
 
 ## With Apache
 
-In the more common case, you will probably want to run PHP in conjunction with Apache httpd. Conveniently, there's a version of the php container that's packaged with the apache web server.
+More commonly, you will probably want to run PHP in conjunction with Apache
+httpd. Conveniently, there's a version of the PHP container that's packaged with
+the Apache web server.
 
-### Create a `Dockerfile` in your php project.
+### Create a `Dockerfile` in your PHP project
 
     FROM php:5.6-apache
     COPY . /var/www/html
 
-Then run the commands to build and run the docker image.
+Then, run the commands to build and run the Docker image:
 
     docker build -t my-php-app .
     docker run -it --rm --name my-running-app my-php-app
 
-### Without a Dockerfile
+### Without a `Dockerfile`
 
-If you don't want to include a `Dockerfile` in your project, then it is sufficient to do the following.
+If you don't want to include a `Dockerfile` in your project, it is sufficient to
+do the following:
 
     docker run -it --rm --name my-apache-php-app -v "$(pwd)":/var/www/html php:5.6-apache

--- a/php/README-short.txt
+++ b/php/README-short.txt
@@ -1,1 +1,1 @@
-PHP is a server-side scripting language designed for web development but also used as a general-purpose programming language.
+PHP is a server-side scripting language designed for web development, but which can also be used as a general-purpose programming language.

--- a/python/README-content.md
+++ b/python/README-content.md
@@ -1,12 +1,19 @@
 # What is Python?
 
-Python is a widely used general-purpose, high-level programming language. Its design philosophy emphasizes code readability, and its syntax allows programmers to express concepts in fewer lines of code than would be possible in languages such as C. The language provides constructs intended to enable clear programs on both a small and large scale.
+Python is an interpreted, interactive, object-oriented, open-source programming
+language. It incorporates modules, exceptions, dynamic typing, very high level
+dynamic data types, and classes. Python combines remarkable power with very
+clear syntax. It has interfaces to many system calls and libraries, as well as
+to various window systems, and is extensible in C or C++. It is also usable as
+an extension language for applications that need a programmable interface.
+Finally, Python is portable: it runs on many Unix variants, on the Mac, and on
+Windows 2000 and later.
 
 > [wikipedia.org/wiki/Python_(programming_language)](https://en.wikipedia.org/wiki/Python_(programming_language))
 
 # How to use this image
 
-## Create a `Dockerfile` in your python app project.
+## Create a `Dockerfile` in your Python app project
 
     FROM python:3
     COPY . /usr/src/myapp
@@ -20,14 +27,16 @@ or (if you need to use Python 2):
     WORKDIR /usr/src/myapp
     CMD [ "python", "./your-daemon-or-script.py" ]
 
-Then build and run the docker image.
+You can then build and run the Docker image:
 
     docker build -t my-python-app
     docker run -it --rm --name my-running-app my-python-app
 
-## Run a single python script.
+## Run a single Python script
 
-For many single file projects, it may not be convenient to write a `Dockerfile` for your project. In such cases, you can run a python script by using the python docker image directly.
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Python script by using the
+Python Docker image directly:
 
     docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp python:3 python your-daemon-or-script.py
 

--- a/python/README-short.txt
+++ b/python/README-short.txt
@@ -1,1 +1,1 @@
-Python is a widely used general-purpose, high-level programming language.
+Python is an interpreted, interactive, object-oriented, open-source programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes.

--- a/rails/README-content.md
+++ b/rails/README-content.md
@@ -1,25 +1,35 @@
 # What is Ruby on Rails?
 
-Ruby on Rails, often simply referred to as Rails, is an open source web application framework which runs via the Ruby programming language. It is a full-stack framework: it allows creating pages and applications that gather information from the web server, talk to or query the database, and render templates out of the box. As a result, Rails features a routing system that is independent of the web server.
+Ruby on Rails or, simply, Rails is an open source web application framework
+which runs on the Ruby programming language. It is a full-stack framework. This
+means that "out of the box", Rails can create pages and applications that gather
+information from a web server, talk to or query a database, and render
+templates. As a result, Rails features a routing system that is independent of
+the web server.
 
 > [wikipedia.org/wiki/Ruby_on_Rails](https://en.wikipedia.org/wiki/Ruby_on_Rails)
 
 # How to use this image
 
-## Create a `Dockerfile` in your rails app project
+## Create a `Dockerfile` in your Rails app project
+
     FROM rails:onbuild
 
 Put this file in the root of your app, next to the `Gemfile`.
 
-This image includes multiple `ONBUILD` triggers so that should be all that you need for most applications. The build will `COPY . /usr/src/app`, `RUN bundle install`, `EXPOSE 3000`, and set the default command to `rails server`.
+This image includes multiple `ONBUILD` triggers which should cover most
+applications. The build will `COPY . /usr/src/app`, `RUN bundle install`,
+`EXPOSE 3000`, and set the default command to `rails server`.
 
-Then build and run the docker image.
+You can then build and run the Docker image:
 
     docker build -t my-rails-app .
     docker run --name some-rails-app -d my-rails-app
 
-Test it by visiting `http://container-ip:3000` in a browser. On the other hand, if you need access outside the host on port 8080:
+You can test it by visiting `http://container-ip:3000` in a browser or, if you
+need access outside the host, on port 8080:
 
     docker run --name some-rails-app -p 8080:3000 -d my-rails-app
 
-Then hit `http://localhost:8080` or `http://host-ip:8080` in a browser.
+You can then go to `http://localhost:8080` or `http://host-ip:8080` in a
+browser.

--- a/ruby/README-content.md
+++ b/ruby/README-content.md
@@ -1,29 +1,35 @@
 # What is Ruby?
 
-Ruby is a dynamic, reflective, object-oriented, general-purpose programming language. It was designed and developed in the mid-1990s by Yukihiro "Matz" Matsumoto in Japan.
-
-According to its authors, Ruby was influenced by Perl, Smalltalk, Eiffel, Ada, and Lisp. It supports multiple programming paradigms, including functional, object-oriented, and imperative. It also has a dynamic type system and automatic memory management.
+Ruby is a dynamic, reflective, object-oriented, general-purpose, open-source
+programming language. According to its authors, Ruby was influenced by Perl,
+Smalltalk, Eiffel, Ada, and Lisp. It supports multiple programming paradigms,
+including functional, object-oriented, and imperative. It also has a dynamic
+type system and automatic memory management.
 
 > [wikipedia.org/wiki/Ruby_(programming_language)](https://en.wikipedia.org/wiki/Ruby_(programming_language))
 
 # How to use this image
 
-## Create a `Dockerfile` in your ruby app project
+## Create a `Dockerfile` in your Ruby app project
 
     FROM ruby:2.1.2-onbuild
     CMD ["./your-daemon-or-script.rb"]
 
 Put this file in the root of your app, next to the `Gemfile`.
 
-This image includes multiple `ONBUILD` triggers so that should be all that you need to bootstrap most applications.  The build will `COPY . /usr/src/app` and `RUN bundle install`.
+This image includes multiple `ONBUILD` triggers which should be all you need to
+bootstrap most applications.  The build will `COPY . /usr/src/app` and `RUN
+bundle install`.
 
-Then build and run the ruby image.
+You can then build and run the Ruby image:
 
     docker build -t my-ruby-app .
     docker run -it --name my-running-script my-ruby-app
 
-## Run a single ruby script
+## Run a single Ruby script
 
-For many single file projects, it may not be convenient to write a `Dockerfile` for your project. In such cases, you can run a ruby script by using the ruby docker image directly.
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Ruby script by using the
+Ruby Docker image directly:
 
     docker run -it --rm --name my-running-script -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp ruby:2.1.2 ruby your-daemon-or-script.rb

--- a/ruby/README-short.txt
+++ b/ruby/README-short.txt
@@ -1,1 +1,1 @@
-Ruby is a dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
+Ruby is a dynamic, reflective, object-oriented, general-purpose, open-source programming language. It supports multiple programming paradigms, including functional, object-oriented, and imperative.


### PR DESCRIPTION
This also includes Fred's updates to the `README-short.txt` files, and a bunch of very minor changes for consistency (using "PHP" instead of "php", ending sentences that describe and lead into a code block with a ":", using "Go" instead of "Golang" and "Hy" instead of "Hylang" within prose, not using periods at the end of headlines, etc).

A really fun one included here is that Java mentioned both using GNU Make inside the container (and `java` doesn't include `make` presently), and some of the prose mentioned `go build` after we ran `javac`, which was extra neat.

I've also reflowed the footer here, since it looks like Fred's got his reflow set at 90 columns, not 80 (which is half the reason I made this PR, the other half being that I wanted to go over them all one more time myself to fix more minor inconsistencies).

cc @fredlf (would you mind taking one last gander over these to make sure I haven't missed anything that sticks out to you on a last read-over?)

Closes #7
Closes #8
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21

(To make reviewing this simple, I haven't run `./update.sh` yet - once it's been reviewed and we're all happy with it and thus have merged it, I'll run `./update.sh` to update all the `README.md` files too.)
