### PR TITLE
Update "Tags" section to be labelled "Supported tags" instead, to make it clear that this isn't the full list of tags, but is instead the list of tags that are currently supported for active usage

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 %%TAGS%%
 

--- a/buildpack-deps/README.md
+++ b/buildpack-deps/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`jessie`, `latest` (*jessie/Dockerfile*)](https://github.com/docker-library/docker-buildpack-deps/blob/c75f8bc5aac9e1f0c7bc4d262038247e6777e204/jessie/Dockerfile)
 - [`wheezy` (*wheezy/Dockerfile*)](https://github.com/docker-library/docker-buildpack-deps/blob/c75f8bc5aac9e1f0c7bc4d262038247e6777e204/wheezy/Dockerfile)

--- a/clojure/README.md
+++ b/clojure/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`latest` (*Dockerfile*)](https://github.com/Quantisan/docker-clojure/blob/30ed1b891ea059a33ca56f04ecf6f467bbbd2362/Dockerfile)
 

--- a/gcc/README.md
+++ b/gcc/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`4.6.4`, `4.6` (*4.6/Dockerfile*)](https://github.com/docker-library/gcc/blob/ba6f069df8e6c838d0465b09215e96f8d5d65269/4.6/Dockerfile)
 - [`4.7.4`, `4.7` (*4.7/Dockerfile*)](https://github.com/docker-library/gcc/blob/ba6f069df8e6c838d0465b09215e96f8d5d65269/4.7/Dockerfile)

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`1.2` (*1.2/Dockerfile*)](https://github.com/docker-library/golang/blob/887b0816c9480f83eb715350a32b6a3b4d331b1b/1.2/Dockerfile)
 - [`1.2-onbuild` (*1.2/onbuild/Dockerfile*)](https://github.com/docker-library/golang/blob/40bd84e4bcc278281595174a60e7b4451d972dee/1.2/onbuild/Dockerfile)

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`latest` (*Dockerfile*)](https://github.com/docker-library/hello-world/blob/b7a78b7ccca62cc478919b101f3ab1334899df2b/Dockerfile)
 

--- a/hylang/README.md
+++ b/hylang/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`latest`, `0`, `0.10`, `0.10.0` (*Dockerfile*)](https://github.com/hylang/hy/blob/1265f546d1fbcfa9c62b51f3e455c0709be7acc8/Dockerfile)
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`6b32`, `6` (*6/Dockerfile*)](https://github.com/docker-library/docker-java/blob/6cc25ee35281099423e521713f710d2549209600/6/Dockerfile)
 - [`7u65`, `7`, `latest` (*7/Dockerfile*)](https://github.com/docker-library/docker-java/blob/6cc25ee35281099423e521713f710d2549209600/7/Dockerfile)

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`2.2.7`, `2.2` (*2.2/Dockerfile*)](https://github.com/docker-library/mongo/blob/274cd39430c54babaec47225f5d2e77c8952d8d0/2.2/Dockerfile)
 - [`2.4.10`, `2.4` (*2.4/Dockerfile*)](https://github.com/docker-library/mongo/blob/274cd39430c54babaec47225f5d2e77c8952d8d0/2.4/Dockerfile)

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`5.6.20`, `5.6`, `5`, `latest` (*5.6/Dockerfile*)](https://github.com/docker-library/docker-mysql/blob/8f83313be73c8c294109d038aa2f921f6886b21c/5.6/Dockerfile)
 - [`5.7.4-m14`, `5.7.4`, `5.7` (*5.7/Dockerfile*)](https://github.com/docker-library/docker-mysql/blob/8f83313be73c8c294109d038aa2f921f6886b21c/5.7/Dockerfile)

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`latest`, `1`, `1.7`, `1.7.1` (*Dockerfile*)](https://github.com/docker-library/nginx/blob/d2c7eee53b81ae70f4eb9e3348575b35df136c95/Dockerfile)
 

--- a/node/README.md
+++ b/node/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`0.10.31`, `0.10`, `0`, `latest` (*0.10/Dockerfile*)](https://github.com/docker-library/node/blob/9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83/0.10/Dockerfile)
 - [`0.10.31-onbuild`, `0.10-onbuild`, `0-onbuild`, `onbuild` (*0.10/onbuild/Dockerfile*)](https://github.com/docker-library/node/blob/9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83/0.10/onbuild/Dockerfile)

--- a/perl/README.md
+++ b/perl/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`latest`, `5`, `5.20`, `5.20.0` (*5.020.000-64bit/Dockerfile*)](https://github.com/perl/docker-perl/blob/r20140804.0/5.020.000-64bit/Dockerfile)
 - [`5.18`, `5.18.2` (*5.018.002-64bit/Dockerfile*)](https://github.com/perl/docker-perl/blob/r20140804.0/5.018.002-64bit/Dockerfile)

--- a/php/README.md
+++ b/php/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`5.3.29-cli`, `5.3-cli` (*5.3/Dockerfile*)](https://github.com/docker-library/php/blob/e19f15271b1cbe9d3e5c9f0c552beca9579f0677/5.3/Dockerfile)
 - [`5.3.29-apache`, `5.3-apache` (*5.3/apache/Dockerfile*)](https://github.com/docker-library/php/blob/e19f15271b1cbe9d3e5c9f0c552beca9579f0677/5.3/apache/Dockerfile)

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`8.4.22`, `8.4`, `8` (*8.4/Dockerfile*)](https://github.com/docker-library/postgres/blob/d74b69598c835fe15eac39a26b5c61058f99c3db/8.4/Dockerfile)
 - [`9.0.18`, `9.0` (*9.0/Dockerfile*)](https://github.com/docker-library/postgres/blob/d74b69598c835fe15eac39a26b5c61058f99c3db/9.0/Dockerfile)

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`2.7.8`, `2.7`, `2` (*2/Dockerfile*)](https://github.com/docker-library/python/blob/660bda5ddf057e5cbcd130a75dd4ae935eba4e8d/2/Dockerfile)
 - [`2.7.8-onbuild`, `2.7-onbuild`, `2-onbuild` (*2/onbuild/Dockerfile*)](https://github.com/docker-library/python/blob/660bda5ddf057e5cbcd130a75dd4ae935eba4e8d/2/onbuild/Dockerfile)

--- a/rails/README.md
+++ b/rails/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`4.1.6`, `4.1`, `4`, `latest` (*Dockerfile*)](https://github.com/docker-library/rails/blob/1e82b979cfb2f9b5e057bb8a9970038f46aa3d88/Dockerfile)
 - [`onbuild` (*onbuild/Dockerfile*)](https://github.com/docker-library/rails/blob/7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb/onbuild/Dockerfile)

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`2.6.17`, `2.6` (*2.6.17/Dockerfile*)](https://github.com/docker-library/redis/blob/02d9cd887a4e0d50db4bb085eab7235115a6fe4a/2.6.17/Dockerfile)
 - [`2.8.10` (*2.8.10/Dockerfile*)](https://github.com/docker-library/redis/blob/ffb29617e5dcfe71adf67842d18063c410beede7/2.8.10/Dockerfile)

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`1.9.3-p547`, `1.9.3`, `1.9`, `1` (*1.9/Dockerfile*)](https://github.com/docker-library/ruby/blob/2701609004b336feff4e88e73ef32e8700d1c668/1.9/Dockerfile)
 - [`1.9.3-p547-onbuild`, `1.9.3-onbuild`, `1.9-onbuild`, `1-onbuild` (*1.9/onbuild/Dockerfile*)](https://github.com/docker-library/ruby/blob/4938a7b4b5b62c90b5d387c9c286fd7749d9499e/1.9/onbuild/Dockerfile)

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`12.04.5`, `12.04`, `precise` (*precise/Dockerfile*)](https://github.com/tianon/docker-brew-ubuntu-core/blob/febe569d532a47c28da4a460eea5331b8dd5f564/precise/Dockerfile)
 - [`14.04.1`, `14.04`, `trusty`, `latest` (*trusty/Dockerfile*)](https://github.com/tianon/docker-brew-ubuntu-core/blob/febe569d532a47c28da4a460eea5331b8dd5f564/trusty/Dockerfile)

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,4 +1,4 @@
-# Tags and `Dockerfile` links
+# Supported tags and respective `Dockerfile` links
 
 - [`3.9.2`, `3.9`, `3`, `latest` (*Dockerfile*)](https://github.com/docker-library/wordpress/blob/69c6d14ae81392b39d1ded401da617ece7c10c5b/Dockerfile)
 


### PR DESCRIPTION
cc @yosifkit
