### PR TITLE
Tweak the IRC language slightly by making it a separate paragraph

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -8,9 +8,11 @@
 
 ## Issues
 
-If you have any problems with, or questions about this image, please contact us
-%%MAILING_LIST%% through a [GitHub issue](%%REPO%%/issues) or via the IRC
-channel `#docker-library` on [Freenode](https://freenode.net).
+If you have any problems with or questions about this image, please contact us
+%%MAILING_LIST%% through a [GitHub issue](%%REPO%%/issues).
+
+You can also reach many of the official image maintainers via the
+`#docker-library` IRC channel on [Freenode](https://freenode.net).
 
 ## Contributing
 


### PR DESCRIPTION
This is especially useful for READMEs where %%MAILING_LIST%% is actually plugged in, making a three-part list that we can't easily add an Oxford comma to.

Also, this allows us to explain that not all the image maintainers will necessarily be in that IRC channel ("You can also reach _many_ ...").
