### PR TITLE
Update a number of short descriptions to be 100 characters or less to reflect the new Hub length restriction

### DIFF
--- a/buildpack-deps/README-short.txt
+++ b/buildpack-deps/README-short.txt
@@ -1,1 +1,1 @@
-A collection of common build dependencies, especially useful for installing arbitrary modules such as gems where build dependencies can't easily be determined beforehand.
+A collection of common build dependencies used for installing various modules, e.g., gems.

--- a/clojure/README-short.txt
+++ b/clojure/README-short.txt
@@ -1,1 +1,1 @@
-Clojure is a dialect of the Lisp programming language designed to run atop of the Java Virtual Machine. Clojure is a general-purpose programming language with an emphasis on functional programming.
+Clojure is a dialect of Lisp that runs on the JVM.

--- a/gcc/README-short.txt
+++ b/gcc/README-short.txt
@@ -1,1 +1,1 @@
-The GNU Compiler Collection (GCC) is a compiler system produced by the GNU Project that supports various programming languages.
+The GNU Compiler Collection is a compiling system that supports several languages.

--- a/hylang/README-short.txt
+++ b/hylang/README-short.txt
@@ -1,1 +1,1 @@
-Hy is a dialect of the Lisp programming language designed to interoperate with Python by translating expressions into Python's abstract syntax tree (AST).
+Hy is a Lisp dialect that translates expressions into Python's abstract syntax tree.

--- a/java/README-short.txt
+++ b/java/README-short.txt
@@ -1,1 +1,1 @@
-Java is a computer programming language that is concurrent, class-based, object-oriented, and specifically designed to have as few implementation dependencies as possible.
+Java is a concurrent, class-based, and object-oriented programming language.

--- a/mongo/README-short.txt
+++ b/mongo/README-short.txt
@@ -1,1 +1,1 @@
-MongoDB is a document database that provides high performance, high availability, and easy scalability.
+MongoDB document databases provide high availability and easy scalability.

--- a/mysql/README-short.txt
+++ b/mysql/README-short.txt
@@ -1,1 +1,1 @@
-MySQL is the world's second most widely used open-source relational database management system (RDBMS).
+MySQL is a widely used, open-source relational database management system (RDBMS).

--- a/node/README-short.txt
+++ b/node/README-short.txt
@@ -1,1 +1,1 @@
-Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and run within the Node.js runtime on Mac OS X, Windows, and Linux.
+Node.js is a JavaScript-based platform for server-side and networking applications.

--- a/php/README-short.txt
+++ b/php/README-short.txt
@@ -1,1 +1,1 @@
-PHP is a server-side scripting language designed for web development, but which can also be used as a general-purpose programming language.
+While designed for web development, the PHP scripting language also provides general-purpose use.

--- a/postgres/README-short.txt
+++ b/postgres/README-short.txt
@@ -1,1 +1,1 @@
-PostgreSQL is a powerful, open source object-relational database system. It has a proven architecture that has earned it a strong reputation for reliability, data integrity, and correctness.
+The PostgreSQL object-relational database system provides reliability and data integrity.

--- a/python/README-short.txt
+++ b/python/README-short.txt
@@ -1,1 +1,1 @@
-Python is an interpreted, interactive, object-oriented, open-source programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes.
+Python is an interpreted, interactive, object-oriented, open-source programming language.

--- a/rails/README-short.txt
+++ b/rails/README-short.txt
@@ -1,1 +1,1 @@
-Ruby on Rails is an open-source application framework written in Ruby. It emphasizes best practices such as convention over configuration, active record pattern, and the model-view-controller pattern.
+Rails is an open-source web application framework written in Ruby.

--- a/redis/README-short.txt
+++ b/redis/README-short.txt
@@ -1,1 +1,1 @@
-Redis is an open source, BSD licensed, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
+Redis is an open source key-value store that functions as a data structure server.

--- a/ruby/README-short.txt
+++ b/ruby/README-short.txt
@@ -1,1 +1,1 @@
-Ruby is a dynamic, reflective, object-oriented, general-purpose, open-source programming language. It supports multiple programming paradigms, including functional, object-oriented, and imperative.
+Ruby is a dynamic, reflective, object-oriented, general-purpose, open-source programming language.

--- a/wordpress/README-short.txt
+++ b/wordpress/README-short.txt
@@ -1,1 +1,1 @@
-WordPress started as just a blogging system, but has evolved to be used as full content management system and so much more through thousands of plugins, widgets, and themes.
+The WordPress rich content management system can utilize plugins, widgets, and themes.


### PR DESCRIPTION
@fredlf if you have time to glance over these and make sure I've done a decent job, that'd be appreciated (but if not, that's OK too, just let us know)

Here's the relevant character counts after this change:

``` console
$ wc -L */README-short.txt | sort -n
  12 hello-world/README-short.txt
  19 busybox/README-short.txt
  24 nginx/README-short.txt
  26 mageia/README-short.txt
  26 ubuntu/README-short.txt
  29 centos/README-short.txt
  29 jenkins/README-short.txt
  29 registry/README-short.txt
  34 debian/README-short.txt
  34 fedora/README-short.txt
  59 cirros/README-short.txt
  71 opensuse/README-short.txt
  72 scratch/README-short.txt
  76 crux/README-short.txt
  80 golang/README-short.txt
  81 clojure/README-short.txt
  81 perl/README-short.txt
  81 rails/README-short.txt
  84 java/README-short.txt
  84 mongo/README-short.txt
  86 redis/README-short.txt
  89 python/README-short.txt
  92 gcc/README-short.txt
  92 node/README-short.txt
  94 neurodebian/README-short.txt
  94 ubuntu-upstart/README-short.txt
  95 mysql/README-short.txt
  96 buildpack-deps/README-short.txt
  96 hylang/README-short.txt
  96 jruby/README-short.txt
  97 docker-dev/README-short.txt
  98 ruby/README-short.txt
  99 hipache/README-short.txt
  99 postgres/README-short.txt
  99 wordpress/README-short.txt
 100 php/README-short.txt
 100 ubuntu-debootstrap/README-short.txt
```

I realize we lose quite a bit of information in some places with this change, but it's information that's duplicated in the long description too, so should be generally OK.
