### PR TITLE
Fixed two issues in the 'Start a Go instance in your app' section

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -41,7 +41,7 @@ applications. The build will `COPY . /usr/src/app`, `RUN go get -d -v`, and `RUN
 go install -v`.
 
 This image also includes the `CMD ["app"]` instruction which is the default command 
-when running the image.
+when running the image without arguments.
 
 You can then build and run the Docker image:
 

--- a/golang/content.md
+++ b/golang/content.md
@@ -25,7 +25,7 @@ applications. The build will `COPY . /usr/src/app`, `RUN go get -d -v`, and `RUN
 go install -v`.
 
 This image also includes the `CMD ["app"]` instruction which is the default command 
-when running the image.
+when running the image without arguments.
 
 You can then build and run the Docker image:
 


### PR DESCRIPTION
- See Issue 24 @ https://github.com/docker-library/golang
- Altered the explanation to indicate the ONBUILD trigger does a go install rather than go build via the go-wrapper script.
- Added some content on the CMD instruction.
- Changed order so it is build and run image so it matches the commands that follow.
