### PR TITLE
Add "VSize" to "Supported tags and respective `Dockerfile` links"

### DIFF
--- a/generate-dockerfile-links-partial.sh
+++ b/generate-dockerfile-links-partial.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
 repo="$1"
 if [ -z "$repo" ]; then
 	echo >&2 "usage: $0 repo"
@@ -14,6 +16,7 @@ unset IFS
 
 repoDirs=()
 declare -A repoDirTags=()
+declare -A repoDirFirstTag=()
 
 for line in "${lines[@]}"; do
 	tag="$(echo "$line" | awk -F ': +' '{ print $1 }')"
@@ -24,6 +27,9 @@ for line in "${lines[@]}"; do
 		repoDirTags["$repoDir"]+=', '
 	fi
 	repoDirTags["$repoDir"]+='`'"$tag"'`'
+	if [ -z "${repoDirFirstTag[$repoDir]}" ]; then
+		repoDirFirstTag["$repoDir"]="$tag"
+	fi
 done
 
 for repoDir in "${repoDirs[@]}"; do
@@ -51,7 +57,7 @@ for repoDir in "${repoDirs[@]}"; do
 	
 	url="https://$gitUrl/blob/$commit/${dir}Dockerfile"
 	
-	echo '- ['"${repoDirTags["$repoDir"]}"' (*'"${dir}Dockerfile"'*)]('"$url"')'
+	echo '- ['"${repoDirTags["$repoDir"]}"' (*'"${dir}Dockerfile"'*)]('"$url"') [VSize: '"$("$thisDir/get-image-data.sh" vsize "$repo" "${repoDirFirstTag["$repoDir"]}")"']'
 done
 
 echo

--- a/get-image-data.sh
+++ b/get-image-data.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -e
+
+usage() {
+	echo "usage: $0 [options] data image [tag]"
+	echo "   ie: $0 vsize scratch"
+	echo "       $0 id debian latest"
+	echo "       $0 -v vsize golang cross"
+}
+
+opts="$(getopt -o 'h?v' --long 'help,verbose' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+verbose=
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+		--help|-h|'-?')
+			usage
+			exit 0
+			;;
+		--verbose|-v) verbose=1 ;;
+	--)
+		break
+		;;
+	*)
+		{
+			echo "error: unknown flag: $flag"
+			usage
+		} >&2
+		exit 1
+		;;
+	esac
+done
+
+data="$1"
+image="$2"
+tag="${3:-latest}"
+
+if [ -z "$data" -o -z "$image" -o -z "$tag" ]; then
+	usage >&2
+	exit 1
+fi
+
+humanSizeUnits=( B KB MB GB TB )
+[ "$verbose" ] && humanSizeScale=3 || humanSizeScale=1
+human_size() {
+	bytes="$1"
+	unit=0
+	unitBytes="$1"
+	while unitBytes="$(echo "scale=0; $bytes / (1000 ^ $unit)" | bc -l)" && [ "$unitBytes" -gt 1000 ]; do
+		if [ ! "${humanSizeUnits[$(( unit + 1 ))]}" ]; then
+			break
+		fi
+		unit="$(( unit + 1 ))"
+	done
+	echo "$(echo "scale=$humanSizeScale; $bytes / (1000 ^ $unit)" | bc -l) ${humanSizeUnits[$unit]}"
+}
+
+token="$(curl -sSL -o /dev/null -D- -H 'X-Docker-Token: true' "https://index.docker.io/v1/repositories/$image/images" | awk -F ':[[:space:]]*|\r' '$1 == "X-Docker-Token" { print $2 }')"
+
+imageId="$(curl -sSL -H "Authorization: Token $token" "https://registry-1.docker.io/v1/repositories/$image/tags/$tag")"
+imageId="${imageId%\"}"
+imageId="${imageId#\"}"
+
+case "$data" in
+	id)
+		echo "$imageId"
+		;;
+	vsize)
+		total="$(docker inspect -f '{{printf "%.0f" .VirtualSize}}' "$imageId" 2>/dev/null || true)"
+		if [ "$total" ]; then
+			echo "$(human_size $total)"
+			exit
+		fi
+		
+		ancestry=( $(curl -sSL -H "Authorization: Token $token" "https://registry-1.docker.io/v1/images/$imageId/ancestry" | sed -r 's/^\["|"\]//g; s/",[[:space:]]*"/ /g') )
+		
+		total=0
+		for ancestor in "${ancestry[@]}"; do
+			size="$(curl -sSL -H "Authorization: Token $token" "https://registry-1.docker.io/v1/images/$ancestor/json" | awk -F '"Size":[[:space:]]*' '{ sub(/(,|}).*/, "", $2); if ($2 == "") { print 0 } else { print $2 } }')"
+			total="$(echo "$total + $size" | bc)"
+			if [ "$verbose" ]; then
+				echo "${ancestor:0:12}: $(human_size $size)"
+			fi
+		done
+		if [ "$verbose" ]; then
+			echo -n 'total: '
+		fi
+		echo "$(human_size $total)"
+		;;
+	*)
+		echo >&2 "unknown data type requested: $data"
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Opening this for discussion.  It takes quite a long time to fetch the "virtual size", since it has to walk the entire ancestry and the registry is _really_ slow at handing back the JSON objects for each layer.

Fixes https://github.com/docker-library/java/issues/15

Here's an example from `debian`:

- [`jessie` (*jessie/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/jessie/Dockerfile) [VSize: 121.8 MB]
- [`oldstable` (*oldstable/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/oldstable/Dockerfile) [VSize: 78.4 MB]
- [`sid` (*sid/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/sid/Dockerfile) [VSize: 121.9 MB]
- [`6.0.10`, `6.0`, `6`, `squeeze` (*squeeze/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/squeeze/Dockerfile) [VSize: 78.4 MB]
- [`stable` (*stable/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/stable/Dockerfile) [VSize: 85.1 MB]
- [`testing` (*testing/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/testing/Dockerfile) [VSize: 121.8 MB]
- [`unstable` (*unstable/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/unstable/Dockerfile) [VSize: 121.9 MB]
- [`7.7`, `7`, `wheezy`, `latest` (*wheezy/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/b34a02cb006a698c1b4be59fb1d4ba8eabc502b6/wheezy/Dockerfile) [VSize: 85.1 MB]
- [`rc-buggy` (*debian/rc-buggy/Dockerfile*)](https://github.com/tianon/dockerfiles/blob/7ac078092e6e247b4df508c4838f314a3f749b94/debian/rc-buggy/Dockerfile) [VSize: 121.9 MB]
- [`experimental` (*debian/experimental/Dockerfile*)](https://github.com/tianon/dockerfiles/blob/7ac078092e6e247b4df508c4838f314a3f749b94/debian/experimental/Dockerfile) [VSize: 121.9 MB]

For comparison, here's `golang`:

- [`1.2.2`, `1.2` (*1.2/Dockerfile*)](https://github.com/docker-library/golang/blob/af4e450a47a99f9a4f56225cdf598f552907d946/1.2/Dockerfile) [VSize: 451.6 MB]
- [`1.2.2-onbuild`, `1.2-onbuild` (*1.2/onbuild/Dockerfile*)](https://github.com/docker-library/golang/blob/4d4b14164e50c089a09b9364697749dc7f764824/1.2/onbuild/Dockerfile) [VSize: 451.6 MB]
- [`1.2.2-cross`, `1.2-cross` (*1.2/cross/Dockerfile*)](https://github.com/docker-library/golang/blob/4d4b14164e50c089a09b9364697749dc7f764824/1.2/cross/Dockerfile) [VSize: 1.8 GB]
- [`1.3.3`, `1.3`, `1`, `latest` (*1.3/Dockerfile*)](https://github.com/docker-library/golang/blob/af4e450a47a99f9a4f56225cdf598f552907d946/1.3/Dockerfile) [VSize: 449.7 MB]
- [`1.3.3-onbuild`, `1.3-onbuild`, `1-onbuild`, `onbuild` (*1.3/onbuild/Dockerfile*)](https://github.com/docker-library/golang/blob/4d4b14164e50c089a09b9364697749dc7f764824/1.3/onbuild/Dockerfile) [VSize: 449.7 MB]
- [`1.3.3-cross`, `1.3-cross`, `1-cross`, `cross` (*1.3/cross/Dockerfile*)](https://github.com/docker-library/golang/blob/4d4b14164e50c089a09b9364697749dc7f764824/1.3/cross/Dockerfile) [VSize: 1.8 GB]
- [`1.3.3-wheezy`, `1.3-wheezy`, `1-wheezy`, `wheezy` (*1.3/wheezy/Dockerfile*)](https://github.com/docker-library/golang/blob/af4e450a47a99f9a4f56225cdf598f552907d946/1.3/wheezy/Dockerfile) [VSize: 374.4 MB]

And `java`:

- [`openjdk-6b32-jdk`, `openjdk-6b32`, `openjdk-6-jdk`, `openjdk-6`, `6b32-jdk`, `6b32`, `6-jdk`, `6` (*openjdk-6-jdk/Dockerfile*)](https://github.com/docker-library/java/blob/9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33/openjdk-6-jdk/Dockerfile) [VSize: 352.9 MB]
- [`openjdk-6b32-jre`, `openjdk-6-jre`, `6b32-jre`, `6-jre` (*openjdk-6-jre/Dockerfile*)](https://github.com/docker-library/java/blob/d2acc0356b5a68a4d168462a3f5f0e29444982b9/openjdk-6-jre/Dockerfile) [VSize: 203.0 MB]
- [`openjdk-7u65-jdk`, `openjdk-7u65`, `openjdk-7-jdk`, `openjdk-7`, `7u65-jdk`, `7u65`, `7-jdk`, `7`, `jdk`, `latest` (*openjdk-7-jdk/Dockerfile*)](https://github.com/docker-library/java/blob/9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33/openjdk-7-jdk/Dockerfile) [VSize: 562.7 MB]
- [`openjdk-7u65-jre`, `openjdk-7-jre`, `7u65-jre`, `7-jre`, `jre` (*openjdk-7-jre/Dockerfile*)](https://github.com/docker-library/java/blob/d2acc0356b5a68a4d168462a3f5f0e29444982b9/openjdk-7-jre/Dockerfile) [VSize: 308.5 MB]
- [`openjdk-8u40-jdk`, `openjdk-8u40`, `openjdk-8-jdk`, `openjdk-8`, `8u40-jdk`, `8u40`, `8-jdk`, `8` (*openjdk-8-jdk/Dockerfile*)](https://github.com/docker-library/java/blob/9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33/openjdk-8-jdk/Dockerfile) [VSize: 634.8 MB]
- [`openjdk-8u40-jre`, `openjdk-8-jre`, `8u40-jre`, `8-jre` (*openjdk-8-jre/Dockerfile*)](https://github.com/docker-library/java/blob/bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d/openjdk-8-jre/Dockerfile) [VSize: 284.2 MB]