### PR TITLE
Fix missing COPY, update.sh supported versions

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -1,18 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`2.6.17`, `2.6` (*2.6.17/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.6.17/Dockerfile)
-- [`2.8.10` (*2.8.10/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.10/Dockerfile)
-- [`2.8.11` (*2.8.11/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.11/Dockerfile)
-- [`2.8.12` (*2.8.12/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.12/Dockerfile)
-- [`2.8.13` (*2.8.13/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.13/Dockerfile)
-- [`2.8.14` (*2.8.14/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.14/Dockerfile)
-- [`2.8.15` (*2.8.15/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.15/Dockerfile)
-- [`2.8.16` (*2.8.16/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.16/Dockerfile)
-- [`2.8.17`, `2.8`, `latest` (*2.8.17/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.17/Dockerfile)
-- [`2.8.6` (*2.8.6/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.6/Dockerfile)
-- [`2.8.7` (*2.8.7/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.7/Dockerfile)
-- [`2.8.8` (*2.8.8/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.8/Dockerfile)
-- [`2.8.9` (*2.8.9/Dockerfile*)](https://github.com/docker-library/redis/blob/99c172e82ed81af441e13dd48dda2729e19493bc/2.8.9/Dockerfile)
+- [`2.6.17`, `2.6` (*2.6/Dockerfile*)](https://github.com/docker-library/redis/blob/9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6/2.6/Dockerfile)
+- [`2.8.17`, `2.8`, `2`, `latest` (*2.8/Dockerfile*)](https://github.com/docker-library/redis/blob/9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6/2.8/Dockerfile)
 
 For more information about this image and its history, please see the [relevant
 manifest file
@@ -67,14 +56,15 @@ You can create your own Dockerfile that adds a redis.conf from the context into
 /data/, like so.
 
     FROM redis
-    redis.conf /data/
-    CMD [ "redis-server", "/data/redis.conf" ]
+    COPY redis.conf /usr/local/etc/redis/redis.conf
+    CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
 
 Alternatively, you can specify something along the same lines with `docker run`
 options.
 
-    docker run --volumes-from datacontainer --name myredis redis
+    docker run -v /myredis/conf/redis.conf:/usr/local/etc/redis/redis.conf --name myredis redis /usr/local/etc/redis/redis.conf
 
+Where `/myredis/conf/` is a local directory containing your `redis.conf` file.
 Using this method means that there is no need for you to have a Dockerfile for
 your redis container.
 

--- a/redis/content.md
+++ b/redis/content.md
@@ -45,13 +45,14 @@ You can create your own Dockerfile that adds a redis.conf from the context into
 /data/, like so.
 
     FROM redis
-    redis.conf /data/
-    CMD [ "redis-server", "/data/redis.conf" ]
+    COPY redis.conf /usr/local/etc/redis/redis.conf
+    CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
 
 Alternatively, you can specify something along the same lines with `docker run`
 options.
 
-    docker run --volumes-from datacontainer --name myredis redis
+    docker run -v /myredis/conf/redis.conf:/usr/local/etc/redis/redis.conf --name myredis redis /usr/local/etc/redis/redis.conf
 
+Where `/myredis/conf/` is a local directory containing your `redis.conf` file.
 Using this method means that there is no need for you to have a Dockerfile for
 your redis container.


### PR DESCRIPTION
Should we adjust the recommended place to put the conf file while we are fixing this line?  Volumes can get hairy, especially if they bind mount something and a "where did my file go?" comes up.  Kind of like https://github.com/nginxinc/docker-nginx/issues/5.
