### PR TITLE
add haskell docs

### DIFF
--- a/haskell/README-short.txt
+++ b/haskell/README-short.txt
@@ -1,1 +1,1 @@
-Haskell is an advanced purely-functional programming language.  This image contains a minimal Haskell (GHC) toolchain consisting of alex, cabal, ghc, and happy.
+Haskell is an advanced purely-functional programming language.

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -22,40 +22,32 @@ A large number of production-quality Haskell libraries are available from [Hacka
 
 This image ships a minimal Haskell toolchain with the following packages:
 
-| package         | version    |
-|-----------------|------------|
-| `alex`          | `3.1.3`    |
-| `cabal-install` | `1.20.0.3` |
-| `happy`         | `1.19.4`   |
-| `ghc`           | `7.8.3`    |
-
+* `ghc` 7.8.3
+* `alex` 3.1.3
+* `cabal-install` 1.20.0.3
+* `happy` 1.19.4
 
 ## Usage
 
 * Start an interactive interpreter session with `ghci`:
 
-```
     $ docker run -it --rm haskell:7.8
     GHCi, version 7.8.3: http://www.haskell.org/ghc/  :? for help
     Loading package ghc-prim ... linking ... done.
     Loading package integer-gmp ... linking ... done.
     Loading package base ... linking ... done.
     Prelude>
-```
 
 * Dockerize a [Hackage](http://hackage.haskell.org) app with a Dockerfile inheriting from the base image:
 
-```
     FROM haskell:7.8
     RUN cabal update && cabal install MazesOfMonad
     VOLUME /root/.MazesOfMonad
     ENTRYPOINT ["/root/.cabal/bin/mazesofmonad"]
-```
 
 * Iteratively develop then ship a Haskell app with a Dockerfile utilizing the
 build cache:
 
-```
     FROM haskell:7.8
 
     RUN cabal update
@@ -77,7 +69,6 @@ build cache:
     # Default Command for Container
     WORKDIR /opt/server
     CMD ["snap-example"]
-```
 
 ## Examples
 
@@ -88,9 +79,27 @@ See the application snippet above in more detail in the [example snap applicatio
 This image is licensed under the MIT License (see
 [LICENSE](https://github.com/darinmorrison/docker-haskell/blob/master/LICENSE)),
 and includes software licensed under the
-[Glasgow haskell Compiler License](https://www.haskell.org/ghc/license)
+[Glasgow Haskell Compiler License](https://www.haskell.org/ghc/license)
 (BSD-style).
 
 # User Feedback
 
-Please report issues on the [GitHub project](https://github.com/darinmorrison/docker-haskell)
+## Issues
+
+If you have any problems with or questions about this image, please contact us
+ through a [GitHub issue](https://github.com/darinmorrison/docker-haskell/issues).
+
+You can also reach many of the official image maintainers via the
+`#docker-library` IRC channel on [Freenode](https://freenode.net).
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small;
+we are always thrilled to receive pull requests, and do our best to process them
+as fast as we can.
+
+Before you start to code, we recommend discussing your plans 
+through a [GitHub issue](https://github.com/darinmorrison/docker-haskell/issues), especially for more ambitious
+contributions. This gives other contributors a chance to point you in the right
+direction, give you feedback on your design, and help you find out if someone
+else is working on the same thing.

--- a/haskell/content.md
+++ b/haskell/content.md
@@ -12,40 +12,32 @@ A large number of production-quality Haskell libraries are available from [Hacka
 
 This image ships a minimal Haskell toolchain with the following packages:
 
-| package         | version    |
-|-----------------|------------|
-| `alex`          | `3.1.3`    |
-| `cabal-install` | `1.20.0.3` |
-| `happy`         | `1.19.4`   |
-| `ghc`           | `7.8.3`    |
-
+* `ghc` 7.8.3
+* `alex` 3.1.3
+* `cabal-install` 1.20.0.3
+* `happy` 1.19.4
 
 ## Usage
 
 * Start an interactive interpreter session with `ghci`:
 
-```
     $ docker run -it --rm haskell:7.8
     GHCi, version 7.8.3: http://www.haskell.org/ghc/  :? for help
     Loading package ghc-prim ... linking ... done.
     Loading package integer-gmp ... linking ... done.
     Loading package base ... linking ... done.
     Prelude>
-```
 
 * Dockerize a [Hackage](http://hackage.haskell.org) app with a Dockerfile inheriting from the base image:
 
-```
     FROM haskell:7.8
     RUN cabal update && cabal install MazesOfMonad
     VOLUME /root/.MazesOfMonad
     ENTRYPOINT ["/root/.cabal/bin/mazesofmonad"]
-```
 
 * Iteratively develop then ship a Haskell app with a Dockerfile utilizing the
 build cache:
 
-```
     FROM haskell:7.8
 
     RUN cabal update
@@ -67,7 +59,6 @@ build cache:
     # Default Command for Container
     WORKDIR /opt/server
     CMD ["snap-example"]
-```
 
 ## Examples
 

--- a/haskell/license.md
+++ b/haskell/license.md
@@ -1,5 +1,5 @@
 This image is licensed under the MIT License (see
 [LICENSE](https://github.com/darinmorrison/docker-haskell/blob/master/LICENSE)),
 and includes software licensed under the
-[Glasgow haskell Compiler License](https://www.haskell.org/ghc/license)
+[Glasgow Haskell Compiler License](https://www.haskell.org/ghc/license)
 (BSD-style).

--- a/haskell/user-feedback.md
+++ b/haskell/user-feedback.md
@@ -1,1 +1,0 @@
-Please report issues on the [GitHub project](https://github.com/darinmorrison/docker-haskell)

--- a/update.sh
+++ b/update.sh
@@ -29,6 +29,7 @@ declare -A otherRepos=(
 	[debian]='https://github.com/tianon/docker-brew-debian'
 	[docker-dev]='https://github.com/docker/docker'
 	[fedora]='https://github.com/lsm5/docker-brew-fedora'
+	[haskell]='https://github.com/darinmorrison/docker-haskell'
 	[hipache]='https://github.com/dotcloud/hipache'
 	[hylang]='https://github.com/hylang/hy'
 	[jenkins]='https://github.com/cloudbees/jenkins-ci.org-docker'


### PR DESCRIPTION
Attempt to add Haskell docs, which I noticed are not currently live on DockerHub ( https://registry.hub.docker.com/_/haskell/ ).  Let me know if I have anything wrong and I'll fix it up.

ping @darinmorrison @ChristopherBiscardi
