### PR TITLE
Add a notice for behavior on database initialization

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -75,6 +75,14 @@ a user/password was supplied (via the `MYSQL_USER` and `MYSQL_PASSWORD`
 environment variables) then that user account will be granted (`GRANT ALL`)
 access to this database.
 
+# Caveats
+
+If there is no database when `mysql` starts in a container, then `mysql` will
+create the default database for you. While this is the expected behavior of
+`mysql`, this means that it will not accept incoming connections during that
+time. This may cause issues when using automation tools, such as `fig`, that
+start several containers simultaneously.
+
 # User Feedback
 
 ## Issues

--- a/mysql/content.md
+++ b/mysql/content.md
@@ -62,3 +62,11 @@ This optional environment variable denotes the name of a database to create. If
 a user/password was supplied (via the `MYSQL_USER` and `MYSQL_PASSWORD`
 environment variables) then that user account will be granted (`GRANT ALL`)
 access to this database.
+
+# Caveats
+
+If there is no database when `mysql` starts in a container, then `mysql` will
+create the default database for you. While this is the expected behavior of
+`mysql`, this means that it will not accept incoming connections during that
+time. This may cause issues when using automation tools, such as `fig`, that
+start several containers simultaneously.

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -77,6 +77,14 @@ Postgres'' [single user
 mode](http://www.postgresql.org/docs/9.3/static/app-postgres.html#AEN90580) is
 highly recommended.
 
+# Caveats
+
+If there is no database when `postgres` starts in a container, then `postgres` will
+create the default database for you. While this is the expected behavior of
+`postgres`, this means that it will not accept incoming connections during that
+time. This may cause issues when using automation tools, such as `fig`, that
+start several containers simultaneously.
+
 # User Feedback
 
 ## Issues

--- a/postgres/content.md
+++ b/postgres/content.md
@@ -61,3 +61,11 @@ need to execute SQL commands as part of your initialization, the use of
 Postgres'' [single user
 mode](http://www.postgresql.org/docs/9.3/static/app-postgres.html#AEN90580) is
 highly recommended.
+
+# Caveats
+
+If there is no database when `postgres` starts in a container, then `postgres` will
+create the default database for you. While this is the expected behavior of
+`postgres`, this means that it will not accept incoming connections during that
+time. This may cause issues when using automation tools, such as `fig`, that
+start several containers simultaneously.


### PR DESCRIPTION
Documentation for the fact that the `postgres` and `mysql` images will be creating a default database if one doesn't already exist, and will be unavailable to connect to for a short while when this happens.
