### PR TITLE
Add "DOCKER-VERSIONS" section to each README.md

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -10,6 +10,10 @@ repo](https://github.com/docker-library/official-images).
 
 %%CONTENT%%%%LICENSE%%
 
+# Docker Version Support
+
+%%DOCKER-VERSIONS%%
+
 # User Feedback
 
 %%USER-FEEDBACK%%

--- a/docker-versions.md
+++ b/docker-versions.md
@@ -1,0 +1,3 @@
+This image is officially supported on Docker version %%DOCKER-LATEST%%.
+
+Support for older versions (down to 1.0) is provided on a best-effort basis.

--- a/update.sh
+++ b/update.sh
@@ -48,6 +48,8 @@ declare -A otherRepos=(
 	[ubuntu]='https://github.com/tianon/docker-brew-ubuntu-core'
 )
 
+dockerLatest="$(curl -sSL 'https://get.docker.com/latest')"
+
 for repo in "${repos[@]}"; do
 	if [ -x "$repo/update.sh" ]; then
 		( set -x; "$repo/update.sh" )
@@ -65,6 +67,8 @@ for repo in "${repos[@]}"; do
 		else
 			mailingList=' '
 		fi
+		
+		dockerVersions="$(cat "$repo/docker-versions.md" 2>/dev/null || cat 'docker-versions.md')"
 		
 		userFeedback="$(cat "$repo/user-feedback.md" 2>/dev/null || cat 'user-feedback.md')"
 		
@@ -90,13 +94,19 @@ for repo in "${repos[@]}"; do
 		echo "  LOGO => $logo"
 		replace_field "$repo" 'LOGO' "$logo" '\s*'
 		
+		echo '  DOCKER-VERSIONS => '"$repo"'/docker-versions.md'
+		replace_field "$repo" 'DOCKER-VERSIONS' "$dockerVersions"
+		
+		echo '  DOCKER-LATEST => "'"$dockerLatest"'"'
+		replace_field "$repo" 'DOCKER-LATEST' "$dockerLatest"
+		
 		echo '  LICENSE => '"$repo"'/license.md'
 		replace_field "$repo" 'LICENSE' "$license"
 		
 		echo '  USER-FEEDBACK => '"$repo"'/user-feedback.md'
 		replace_field "$repo" 'USER-FEEDBACK' "$userFeedback"
 		
-		echo '  MAILING-LIST => "'"$mailingList"'"'
+		echo '  MAILING-LIST => '"$repo"'/mailing-list.md'
 		replace_field "$repo" 'MAILING-LIST' "$mailingList" '\s*'
 		
 		echo '  REPO => "'"$repo"'"'


### PR DESCRIPTION
Fixes https://github.com/docker-library/official-images/issues/258

An example:
# Docker Version Support

This image is officially supported on Docker version 1.4.1.

Support for older versions (down to 1.0) is provided on a best-effort basis.
