### PR TITLE
update to centos documentation 

### DIFF
--- a/centos/README.md
+++ b/centos/README.md
@@ -38,19 +38,31 @@ reliable, predictable, and reproducible Linux environment.
 The `centos:latest` tag is always the most recent version currently
 available.
 
+## Rolling builds
+
 The CentOS Project offers regularly updated images for all active releases.
 These images will be updated monthly or as needed for emergency fixes. These
 rolling updates are tagged with the major version number only.
 For example: `docker pull centos:6` or `docker pull centos:7`
 
-Additionally, images that correspond to install media are also offered. These
-images DO NOT recieve updates as they are intended to match installation iso
-contents. If you choose to use these images it is highly recommended that you
-include `RUN yum -y update && yum clean all` in your Dockerfile, or otherwise
-address any potential security concerns. To use these images, please specify
-the minor version tag:
+## Minor tags
+
+Additionally, images with minor version tags that correspond to install media
+are also offered. **These images DO NOT recieve updates** as they are intended
+to match installation iso contents. If you choose to use these images it is
+highly recommended that you include `RUN yum -y update && yum clean all`
+in your Dockerfile, or otherwise address any potential security concerns.
+To use these images, please specify the minor version tag:
 
 For example: `docker pull centos:5.11` or `docker pull centos:6.6`
+
+# Package documentation
+
+By default, the CentOS containers are built using yum's `nodocs` option, which
+helps reduce the size of the image. If you install a package and discover
+files missing, please comment out the line `tsflags=nodocs` in `/etc/yum.conf`
+and reinstall your package.
+
 
 
 # Systemd integration
@@ -114,7 +126,7 @@ always be run as a privileged container with the cgroups filesystem mounted.
 
 # Supported Docker versions
 
-This image is officially supported on Docker version 1.4.1.
+This image is officially supported on Docker version 1.5.0.
 
 Support for older versions (down to 1.0) is provided on a best-effort basis.
 

--- a/centos/content.md
+++ b/centos/content.md
@@ -23,19 +23,31 @@ reliable, predictable, and reproducible Linux environment.
 The `centos:latest` tag is always the most recent version currently
 available.
 
+## Rolling builds
+
 The CentOS Project offers regularly updated images for all active releases.
 These images will be updated monthly or as needed for emergency fixes. These
 rolling updates are tagged with the major version number only.
 For example: `docker pull centos:6` or `docker pull centos:7`
 
-Additionally, images that correspond to install media are also offered. These
-images DO NOT recieve updates as they are intended to match installation iso
-contents. If you choose to use these images it is highly recommended that you
-include `RUN yum -y update && yum clean all` in your Dockerfile, or otherwise
-address any potential security concerns. To use these images, please specify
-the minor version tag:
+## Minor tags
+
+Additionally, images with minor version tags that correspond to install media
+are also offered. **These images DO NOT recieve updates** as they are intended
+to match installation iso contents. If you choose to use these images it is
+highly recommended that you include `RUN yum -y update && yum clean all`
+in your Dockerfile, or otherwise address any potential security concerns.
+To use these images, please specify the minor version tag:
 
 For example: `docker pull centos:5.11` or `docker pull centos:6.6`
+
+# Package documentation
+
+By default, the CentOS containers are built using yum's `nodocs` option, which
+helps reduce the size of the image. If you install a package and discover
+files missing, please comment out the line `tsflags=nodocs` in `/etc/yum.conf`
+and reinstall your package.
+
 
 
 # Systemd integration


### PR DESCRIPTION
separates rolling builds and minor tags for better clarity. 
Added documentation about the `nodocs` yum option for users reporting missing files after installing packages. 

Fixes https://github.com/docker-library/official-images/issues/478