### PR TITLE
Add reference to beta license

### DIFF
--- a/websphere-liberty/license.md
+++ b/websphere-liberty/license.md
@@ -1,12 +1,17 @@
-The Dockerfile and associated scripts are licensed under the [Apache License
-2.0][apache-license]. The IBM JRE and WebSphere Application Server for
-Developers are licensed under the IBM International License Agreement for
-Non-Warranted Programs. Those licenses may be viewed from the image using the
-`LICENSE=view` environment variable as described above or may be found online
-for the [IBM JRE][jre-license] and [IBM WebSphere Application Server for
-Developers][liberty-license]. Note that this license does not permit further
-distribution and that the image is for development use only.
+The Dockerfile and associated scripts are licensed under the [Apache
+License 2.0][apache-license]. The IBM JRE and WebSphere Application
+Server for Developers are licensed under the IBM International License
+Agreement for Non-Warranted Programs and the Beta under the IBM
+International License Agreement for Early Release of Programs. Those
+licenses may be viewed from the image using the `LICENSE=view`
+environment variable as described above or may be found online for the
+[IBM JRE][jre-license], [IBM WebSphere Application Server for
+Developers][liberty-license] and [IBM WebSphere Application Server
+Liberty v9 Beta with Java EE 7][beta-license]. Note that this license
+does not permit further distribution and that the image is for
+development use only.
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0.html
 [jre-license]: https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-EWOD-99YA4J&title=IBM%C2%AE+SDK%2C+Java+Technology+Edition%2C+Version+7+Release+1&l=en
-[liberty-license]: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.3/lafiles/runtime/en.html
+[liberty-license]: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.4/lafiles/runtime/en.html
+[beta-license]: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/beta/lafiles/en.html


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/487 adds a tag for an image for the WebSphere Liberty Beta and this PR updates the license information for the repo to reference the beta license.