### PR TITLE
Use official image for push script and specify mojo version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM tianon/mojo
+FROM perl:5.20
+
+# secure by default ♥ (thanks to sri!)
+ENV PERL_CPANM_OPT --verbose --mirror https://cpan.metacpan.org --mirror-only
+RUN cpanm Digest::SHA Module::Signature
+ENV PERL_CPANM_OPT $PERL_CPANM_OPT --verify
+
+# reinstall cpanm itself, for good measure
+RUN cpanm App::cpanminus
+
+RUN cpanm Mojolicious@5.80
+
+RUN cpanm EV
+RUN cpanm IO::Socket::IP
+RUN cpanm --notest IO::Socket::SSL
+# the tests for IO::Socket::SSL like to hang... :(
 
 RUN cpanm Term::ReadKey
 
@@ -7,4 +22,4 @@ RUN apt-get update && apt-get install -y vim && rm -rf /var/lib/apt/lists/*
 COPY . /usr/src/docker-library-docs
 WORKDIR /usr/src/docker-library-docs
 
-CMD ["./push.pl"]
+ENTRYPOINT ["./push.pl"]


### PR DESCRIPTION
Since we have a monkey patch on `Mojo::UserAgent::CookieJar` in push.pl (which broke recently), we need to specify a Mojolicious version.  And we should use an official image directly to show how easy it is.

Also, swap to entrypoint to make it easier to run.