### PR TITLE
Document changes to allow Jetty to run --read-only

### DIFF
--- a/jetty/README.md
+++ b/jetty/README.md
@@ -30,12 +30,20 @@ The default Jetty environment in the image is:
 	JETTY_HOME    =  /usr/local/jetty
 	JETTY_BASE    =  /var/lib/jetty
 	JETTY_CONF    =  /usr/local/jetty/etc/jetty.conf
-	JETTY_STATE   =  /var/lib/jetty/jetty.state
+	JETTY_STATE   =  /run/jetty/jetty.state
 	JETTY_ARGS    =
 	JAVA_OPTIONS  =
-	TMPDIR        =  /tmp
+	TMPDIR        =  /tmp/jetty
 
 Webapps can be [deployed](https://wiki.eclipse.org/Jetty/Howto/Deploy_Web_Applications) in `/var/lib/jetty/webapps`.
+
+## Read-only container
+
+To run `jetty` as a read-only container, have Docker create the `/tmp/jetty` and `/run/jetty` directories as volumes:
+
+	docker run -d --read-only -v /tmp/jetty -v /run/jetty jetty:9
+
+Since the container is read-only, you'll need to either mount in your webapps directory with `-v /path/to/my/webapps:/var/lib/jetty/webapps` or by populating `/var/lib/jetty/webapps` in a derived image.
 
 # Security
 

--- a/jetty/README.md
+++ b/jetty/README.md
@@ -1,7 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
--	[`9.2.9-jre7`, `9.2-jre7`, `9-jre7`, `jre7`, `9.2.9`, `9.2`, `9`, `latest` (*9-jre7/Dockerfile*)](https://github.com/md5/docker-jetty/blob/4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05/9-jre7/Dockerfile)
--	[`9.2.9-jre8`, `9.2-jre8`, `9-jre8`, `jre8` (*9-jre8/Dockerfile*)](https://github.com/md5/docker-jetty/blob/4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05/9-jre8/Dockerfile)
+-	[`9.2.9-jre7`, `9.2-jre7`, `9-jre7`, `jre7`, `9.2.9`, `9.2`, `9`, `latest` (*9-jre7/Dockerfile*)](https://github.com/md5/docker-jetty/blob/346cf67904dc0e0e0a47ea7796baa769ad76e4b1/9-jre7/Dockerfile)
+-	[`9.2.9-jre8`, `9.2-jre8`, `9-jre8`, `jre8` (*9-jre8/Dockerfile*)](https://github.com/md5/docker-jetty/blob/346cf67904dc0e0e0a47ea7796baa769ad76e4b1/9-jre8/Dockerfile)
 
 For more information about this image and its history, please see the [relevant manifest file (`library/jetty`)](https://github.com/docker-library/official-images/blob/master/library/jetty) in the [`docker-library/official-images` GitHub repo](https://github.com/docker-library/official-images).
 

--- a/jetty/content.md
+++ b/jetty/content.md
@@ -23,12 +23,20 @@ The default Jetty environment in the image is:
 	JETTY_HOME    =  /usr/local/jetty
 	JETTY_BASE    =  /var/lib/jetty
 	JETTY_CONF    =  /usr/local/jetty/etc/jetty.conf
-	JETTY_STATE   =  /var/lib/jetty/jetty.state
+	JETTY_STATE   =  /run/jetty/jetty.state
 	JETTY_ARGS    =
 	JAVA_OPTIONS  =
-	TMPDIR        =  /tmp
+	TMPDIR        =  /tmp/jetty
 
 Webapps can be [deployed](https://wiki.eclipse.org/Jetty/Howto/Deploy_Web_Applications) in `/var/lib/jetty/webapps`.
+
+## Read-only container
+
+To run `jetty` as a read-only container, have Docker create the `/tmp/jetty` and `/run/jetty` directories as volumes:
+
+	docker run -d --read-only -v /tmp/jetty -v /run/jetty jetty:9
+
+Since the container is read-only, you'll need to either mount in your webapps directory with `-v /path/to/my/webapps:/var/lib/jetty/webapps` or by populating `/var/lib/jetty/webapps` in a derived image.
 
 # Security
 


### PR DESCRIPTION
This goes along with docker-library/official-images#547. I'll update this PR with the latest refs and amend once the other PR is merged.