### PR TITLE
Documentation how to add extensions

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -56,6 +56,17 @@ Example `docker-compose.yml` for `wordpress`:
 
 Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
 
+## Add additional libraries / extensions
+
+This image does not provide any additional php-extensions or other libraries, even if they are required by several plugins. That is because there are so many plugins, requiring so many extensions and libraries, that the image will dramatically increase in size.
+
+If you need one or several extensions or libraries, the easiest way is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The 
+[documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
+
+In order to keep your image with the extensions you require up to date, there are features of Docker Hub which help you:
+-	[Automated Builds](https://docs.docker.com/docker-hub/builds/): Let Docker Hub automatically create a new image from your Dockerfile each time you push changes to it.
+-	[Repository Links](https://docs.docker.com/docker-hub/builds/#repository-links): Link your docker image to `library/wordpress` so it is automatically rebuild once the official wordpress image is rebuild.
+
 # Supported Docker versions
 
 This image is officially supported on Docker version 1.5.0.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -60,10 +60,10 @@ Run `docker-compose up`, wait for it to initialize completely, and visit `http:/
 
 This image does not provide any additional php-extensions or other libraries, even if they are required by several plugins. That is because there are so many plugins, requiring so many extensions and libraries, that the image will dramatically increase in size.
 
-If you need one or several extensions or libraries, the easiest way is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The 
-[documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
+If you need one or several extensions or libraries, the easiest way is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The [documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
 
 In order to keep your image with the extensions you require up to date, there are features of Docker Hub which help you:
+
 -	[Automated Builds](https://docs.docker.com/docker-hub/builds/): Let Docker Hub automatically create a new image from your Dockerfile each time you push changes to it.
 -	[Repository Links](https://docs.docker.com/docker-hub/builds/#repository-links): Link your docker image to `library/wordpress` so it is automatically rebuild once the official wordpress image is rebuild.
 

--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -39,7 +39,7 @@ Run `docker-compose up`, wait for it to initialize completely, and visit `http:/
 
 This image does not provide any additional php-extensions or other libraries, even if they are required by several plugins. That is because there are so many plugins, requiring so many extensions and libraries, that the image will dramatically increase in size.
 
-If you need one or several extensions or libraries, the easiest was is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The 
+If you need one or several extensions or libraries, the easiest way is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The 
 [documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
 
 In order to keep your image with the extensions you require up to date, there are features of Docker Hub which help you:

--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -34,3 +34,14 @@ If you'd like to use an external database instead of a linked `mysql` container,
 ## %%COMPOSE%%
 
 Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
+
+## Add additional libraries / extensions
+
+This image does not provide any additional php-extensions or other libraries, even if they are required by several plugins. That is because there are so many plugins, requiring so many extensions and libraries, that the image will dramatically increase in size.
+
+If you need one or several extensions or libraries, the easiest was is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The 
+[documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
+
+In order to keep your image with the extensions you require up to date, there are features of Docker Hub which help you:
+-	[Automated Builds](https://docs.docker.com/docker-hub/builds/): Let Docker Hub automatically create a new image from your Dockerfile each time you push changes to it.
+-	[Repository Links](https://docs.docker.com/docker-hub/builds/#repository-links): Link your docker image to `library/wordpress` so it is automatically rebuild once the official wordpress image is rebuild.

--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -39,9 +39,9 @@ Run `docker-compose up`, wait for it to initialize completely, and visit `http:/
 
 This image does not provide any additional php-extensions or other libraries, even if they are required by several plugins. That is because there are so many plugins, requiring so many extensions and libraries, that the image will dramatically increase in size.
 
-If you need one or several extensions or libraries, the easiest way is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The 
-[documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
+If you need one or several extensions or libraries, the easiest way is to create your own image. Base it on the version of the official wordpress image you need and add the extensions you need. The [documentation of the php image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) shows how to accomplish that in detail.
 
 In order to keep your image with the extensions you require up to date, there are features of Docker Hub which help you:
+
 -	[Automated Builds](https://docs.docker.com/docker-hub/builds/): Let Docker Hub automatically create a new image from your Dockerfile each time you push changes to it.
 -	[Repository Links](https://docs.docker.com/docker-hub/builds/#repository-links): Link your docker image to `library/wordpress` so it is automatically rebuild once the official wordpress image is rebuild.


### PR DESCRIPTION
Based on the discussion in docker-library/wordpress#68 the process to add php-extensions was added. Focus is to make it as easy as possible for the user of the image to create and maintain its own extended image based on docker-library/wordpress.

Not sure whether it makes sense to restrict this description to the wordpress image. Maybe it makes sense to at least partially add the description to all images in docker-library.

However, this should be done once we agree on the documentation for wordpress.