### PR TITLE
elasticsearch: document exposed ports

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -33,7 +33,7 @@ This image comes with a default set of configuration files for `elasticsearch`, 
 This image is configured with a volume at `/usr/share/elasticsearch/data` to hold the persisted index data. Use that path if you would like to keep the data in a mounted volume:
 
 	docker run -d -v "$PWD/esdata":/usr/share/elasticsearch/data elasticsearch
-	
+
 This image includes `EXPOSE 9200 9300` ([default `http.port`](http://www.elastic.co/guide/en/elasticsearch/reference/1.5/modules-http.html)), so standard container linking will make it automatically available to the linked containers.
 
 # License

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -33,6 +33,8 @@ This image comes with a default set of configuration files for `elasticsearch`, 
 This image is configured with a volume at `/usr/share/elasticsearch/data` to hold the persisted index data. Use that path if you would like to keep the data in a mounted volume:
 
 	docker run -d -v "$PWD/esdata":/usr/share/elasticsearch/data elasticsearch
+	
+This image includes `EXPOSE 9200 9300` ([default `http.port`](http://www.elastic.co/guide/en/elasticsearch/reference/1.5/modules-http.html)), so standard container linking will make it automatically available to the linked containers.
 
 # License
 

--- a/elasticsearch/content.md
+++ b/elasticsearch/content.md
@@ -25,3 +25,5 @@ This image comes with a default set of configuration files for `elasticsearch`, 
 This image is configured with a volume at `/usr/share/elasticsearch/data` to hold the persisted index data. Use that path if you would like to keep the data in a mounted volume:
 
 	docker run -d -v "$PWD/esdata":/usr/share/elasticsearch/data elasticsearch
+
+This image includes `EXPOSE 9200 9300` ([default `http.port`](http://www.elastic.co/guide/en/elasticsearch/reference/1.5/modules-http.html)), so standard container linking will make it automatically available to the linked containers.


### PR DESCRIPTION
As I was reading the [Docker Compose overview](https://docs.docker.com/compose/), it wasn't immediately clear how the Python app knew which port to use for redis. Once I started reading the [public image for redis](https://registry.hub.docker.com/_/redis/), it became super clear.

> This image includes `EXPOSE 6379` (the redis port), so standard container linking will make it automatically available to the linked containers (as the following examples illustrate).

After finding [the elasticsearch image also exports default ports](https://github.com/docker-library/elasticsearch/blob/master/1.5/Dockerfile#L30), I thought this added documentation would be helpful.