### PR TITLE
Reorganize "push.pl" to put the "vimdiff" logic in one place for cool dispatch-conf-alike behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM perl:5.20
 
+RUN apt-get update && apt-get install -y git vim --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 # secure by default ♥ (thanks to sri!)
 ENV PERL_CPANM_OPT --verbose --mirror https://cpan.metacpan.org
 # TODO find a way to make --mirror-only / SSL work with backpan too :(
@@ -17,9 +19,7 @@ RUN cpanm IO::Socket::IP
 RUN cpanm --notest IO::Socket::SSL
 # the tests for IO::Socket::SSL like to hang... :(
 
-RUN cpanm Term::ReadKey
-
-RUN apt-get update && apt-get install -y git vim --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN cpanm Term::UI
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
```console
$ ./push.sh ...
diff --git a/tmp/XfqXvwAiit.md b/wordpress/README.md
index df290e6..ad31c26 100644
--- a/tmp/XfqXvwAiit.md
+++ b/wordpress/README.md
@@ -69,7 +69,7 @@ The following Docker Hub features can help with the task of keeping your depende
 
 # Supported Docker versions
 
-This image is officially supported on Docker version 1.5.0.
+This image is officially supported on Docker version 1.6.0.
 
 Support for older versions (down to 1.0) is provided on a best-effort basis.
 

  1> yes
  2> vimdiff
  3> no

Apply changes? [1]: 
updating wordpress
```