### PR TITLE
Remove extra dash from `-it` in example code

### DIFF
--- a/iojs/content.md
+++ b/iojs/content.md
@@ -27,4 +27,4 @@ Then simply run:
 
 To run a single script, you can mount it in a volume under `/usr/src/app`. From the root of your application directory (assuming your script is named `index.js`):
 
-	$ docker run -v ${PWD}:/usr/src/app -w /usr/src/app --it --rm iojs iojs index.js
+	$ docker run -v ${PWD}:/usr/src/app -w /usr/src/app -it --rm iojs iojs index.js


### PR DESCRIPTION
This PR removes the incorrect double dash from `-it` in one code snippet in the iojs README.