### PR TITLE
Added postgre example in doc

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -49,7 +49,14 @@ This optional environment variable is used in conjunction with `POSTGRES_PASSWOR
 
 # How to extend this image
 
-If you would like to do additional initialization in an image derived from this one, add a `*.sh` script under `/docker-entrypoint-initdb.d` (creating the directory if necessary). After the entrypoint calls `initdb` to create the default `postgres` user and database, it will source any `*.sh` script found in that directory to do further initialization before starting the service. If you need to execute SQL commands as part of your initialization, the use of Postgres'' [single user mode](http://www.postgresql.org/docs/9.3/static/app-postgres.html#AEN90580) is highly recommended.
+If you would like to do additional initialization in an image derived from this one, add a `*.sh` script under `/docker-entrypoint-initdb.d` (creating the directory if necessary). After the entrypoint calls `initdb` to create the default `postgres` user and database, it will source any `*.sh` script found in that directory to do further initialization before starting the service. If you need to execute SQL commands as part of your initialization, the use of Postgres'' [single user mode](http://www.postgresql.org/docs/9.3/static/app-postgres.html#AEN90580) is highly recommended. For example to add a user and database you could create a script `init-user-db.sh` with the following content:
+
+	#!/bin/bash
+	gosu postgres postgres --single <<- EOSQL
+		CREATE USER docker;
+		CREATE DATABASE docker;
+		GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
+	EOSQL
 
 You can also extend the image with a simple `Dockerfile` to set the locale. The folowing example will set the default locale to `de_DE.utf8`:
 

--- a/postgres/content.md
+++ b/postgres/content.md
@@ -38,7 +38,14 @@ This optional environment variable is used in conjunction with `POSTGRES_PASSWOR
 
 # How to extend this image
 
-If you would like to do additional initialization in an image derived from this one, add a `*.sh` script under `/docker-entrypoint-initdb.d` (creating the directory if necessary). After the entrypoint calls `initdb` to create the default `postgres` user and database, it will source any `*.sh` script found in that directory to do further initialization before starting the service. If you need to execute SQL commands as part of your initialization, the use of Postgres'' [single user mode](http://www.postgresql.org/docs/9.3/static/app-postgres.html#AEN90580) is highly recommended.
+If you would like to do additional initialization in an image derived from this one, add a `*.sh` script under `/docker-entrypoint-initdb.d` (creating the directory if necessary). After the entrypoint calls `initdb` to create the default `postgres` user and database, it will source any `*.sh` script found in that directory to do further initialization before starting the service. If you need to execute SQL commands as part of your initialization, the use of Postgres'' [single user mode](http://www.postgresql.org/docs/9.3/static/app-postgres.html#AEN90580) is highly recommended. For example to add a user and database you could create a script `init-user-db.sh` with the following content:
+
+	#!/bin/bash
+	gosu postgres postgres --single <<- EOSQL
+		CREATE USER docker;
+		CREATE DATABASE docker;
+		GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
+	EOSQL
 
 You can also extend the image with a simple `Dockerfile` to set the locale. The folowing example will set the default locale to `de_DE.utf8`:
 


### PR DESCRIPTION
Could be helpful to others (at least was to me)
http://stackoverflow.com/questions/26598738/how-to-create-user-database-in-script-for-docker-postgres

Maybe you also want to extend the example to show how to import a whole sql-file into a specific database