### PR TITLE
Point out that wordpress's own Dockerfile has an "extra libraries" example

### DIFF
--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -39,7 +39,7 @@ Run `docker-compose up`, wait for it to initialize completely, and visit `http:/
 
 This image does not provide any additional PHP extensions or other libraries, even if they are required by popular plugins. There are an infinite number of possible plugins, and they potentially require any extension PHP supports. Including every PHP extension that exists would dramatically increase the image size.
 
-If you need additional PHP extensions, you'll need to create your own image `FROM` this one. The [documentation of the `php` image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) explains how to compile additional extensions.
+If you need additional PHP extensions, you'll need to create your own image `FROM` this one. The [documentation of the `php` image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) explains how to compile additional extensions. Additionally, the [`wordpress` Dockerfile](https://github.com/docker-library/wordpress/blob/618490d4bdff6c5774b84b717979bfe3d6ba8ad1/apache/Dockerfile#L5-L9) has an example of doing this.
 
 The following Docker Hub features can help with the task of keeping your dependent images up-to-date:
 


### PR DESCRIPTION
As added in https://github.com/docker-library/docs/pull/219 for `drupal`.