### PR TITLE
Complex configuration clarification

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -45,11 +45,6 @@ If you wish to adapt the default configuration, use something like the following
 
 	docker cp some-nginx:/etc/nginx/nginx.conf /some/nginx.conf
 
-As above, this can also be accomplished more cleanly using a simple `Dockerfile`:
-
-	FROM nginx
-	COPY nginx.conf /etc/nginx/nginx.conf
-
 Then, build with `docker build -t some-custom-nginx .` and run:
 
 	docker run --name some-nginx -d some-custom-nginx

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -45,10 +45,6 @@ If you wish to adapt the default configuration, use something like the following
 
 	docker cp some-nginx:/etc/nginx/nginx.conf /some/nginx.conf
 
-Then, build with `docker build -t some-custom-nginx .` and run:
-
-	docker run --name some-nginx -d some-custom-nginx
-
 # Supported Docker versions
 
 This image is officially supported on Docker version 1.6.1.

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -41,7 +41,7 @@ For information on the syntax of the Nginx configuration files, see [the officia
 
 Be sure to include `daemon off;` in your custom configuration to ensure that Nginx stays in the foreground so that Docker can track the process properly (otherwise your container will stop immediately after starting)!
 
-If you wish to adapt the default configuration, use something like the following to copy it from a running Nginx container:
+If you wish to adapt the default configuration, use something like the following to copy it from a running Nginx container to the host:
 
 	docker cp some-nginx:/etc/nginx/nginx.conf /some/nginx.conf
 


### PR DESCRIPTION
The provided `docker cp` command will successfully copy the configuration file from the container to the host, but the `COPY` line in the `Dockerfile` example will fail to do the same.

What is the goal of the section beginning with the "If you wish to adapt the default configuration" sentence?

You could always modify it on the host, then create a new container with the newly modified configuration file.  Or you could modify the file from within the container and then `docker commit` the changes.

If I know the goal, I will happily contribute to the documentation.
