### PR TITLE
Fedora 22 and rel-eng issue tracker updates

### DIFF
--- a/fedora/README.md
+++ b/fedora/README.md
@@ -9,13 +9,13 @@ For more information about this image and its history, please see the [relevant 
 
 # Fedora
 
-This image serves as the `official Fedora image` for `Fedora 21` and as a semi-official image for Fedora 20 (heisenbug) and rawhide.
+This image serves as the `official Fedora image` for `Fedora 22`, `Fedora 21` and as a semi-official image for Fedora 20 (heisenbug) and rawhide.
 
 ![logo](https://raw.githubusercontent.com/docker-library/docs/master/fedora/logo.png)
 
-The `fedora:latest` tag will always point to the latest stable release, currently [Fedora 21](https://getfedora.org/). `fedora:latest` is now the same as `fedora:21`.
+The `fedora:latest` tag will always point to the latest stable release, currently [Fedora 22](https://getfedora.org/). `fedora:latest` is now the same as `fedora:22`.
 
-Fedora rawhide is available via `fedora:rawhide` and Fedora 20 via `fedora:20` and `fedora:heisenbug`.
+Fedora rawhide is available via `fedora:rawhide`, Fedora 21 via `fedora:21`, Fedora 20 via `fedora:20` and `fedora:heisenbug`.
 
 The metalink `http://mirrors.fedoraproject.org` is used to automatically select a mirror site (both for building the image as well as for the yum repos in the container image).
 
@@ -26,7 +26,7 @@ The metalink `http://mirrors.fedoraproject.org` is used to automatically select 
 
 # Supported Docker versions
 
-This image is officially supported on Docker version 1.6.2.
+This image is officially supported on Docker version 1.6.2 and later.
 
 Support for older versions (down to 1.0) is provided on a best-effort basis.
 
@@ -38,7 +38,7 @@ Documentation for this image is stored in the [`fedora/` directory](https://gith
 
 ## Issues
 
-If you have any problems with or questions about this image, please contact us by filing a bug on [Fedora's bugzilla page](https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora) (choose `docker-io` as component and include details about image problems in the description) or through a [GitHub issue](https://github.com/lsm5/docker-brew-fedora/issues).
+If you have any problems with or questions about this image, please file a ticket with [Fedora Release Engineering](https://fedorahosted.org/rel-eng/newticket) for `fedora:22` and `fedora:21` or file a [GitHub issue](https://github.com/fedora-cloud/docker-brew-fedora/issues/new) for `fedora:rawhide` and `fedora:20`.
 
 You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
 
@@ -46,4 +46,4 @@ You can also reach many of the official image maintainers via the `#docker-libra
 
 You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
 
-Before you start to code, we recommend discussing your plans by filing a bug on [Fedora's bugzilla page](https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora) (choose `docker-io` as component and include details about image problems in the description) or through a [GitHub issue](https://github.com/lsm5/docker-brew-fedora/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
+Before you start to code, we recommend discussing your plans by filing a ticket with [Fedora Release Engineering](https://fedorahosted.org/rel-eng/newticket). This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.


### PR DESCRIPTION
- fedora:latest points to fedora:22
- fedora rel-eng to be contacted in case of any troubles with
fedora:(22,21) and @fedora-cloud/docker-brew-fedora for fedora:(rawhide,20)

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>