### PR TITLE
Small docs fix, onbuid to onbuild

### DIFF
--- a/jruby/README.md
+++ b/jruby/README.md
@@ -40,7 +40,7 @@ You can then build and run the Ruby image:
 
 ### Generate a `Gemfile.lock`
 
-The `onbuid` tag expects a `Gemfile.lock` in your app directory. This `docker
+The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker
 run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
 
 	docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app jruby:1.7 bundle install --system

--- a/jruby/content.md
+++ b/jruby/content.md
@@ -29,7 +29,7 @@ You can then build and run the Ruby image:
 
 ### Generate a `Gemfile.lock`
 
-The `onbuid` tag expects a `Gemfile.lock` in your app directory. This `docker
+The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker
 run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
 
 	docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app jruby:1.7 bundle install --system

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -42,7 +42,7 @@ You can then build and run the Ruby image:
 
 ### Generate a `Gemfile.lock`
 
-The `onbuid` tag expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
+The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
 
 	docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ruby:2.1 bundle install
 

--- a/ruby/content.md
+++ b/ruby/content.md
@@ -25,7 +25,7 @@ You can then build and run the Ruby image:
 
 ### Generate a `Gemfile.lock`
 
-The `onbuid` tag expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
+The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
 
 	docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ruby:2.1 bundle install
 


### PR DESCRIPTION
The jruby and ruby documentation had a typo in the onbuild tag details. This pull-request fixes them.