### PR TITLE
kibana documentation : environnement variable

### DIFF
--- a/kibana/README.md
+++ b/kibana/README.md
@@ -29,6 +29,11 @@ This image includes `EXPOSE 5601` ([default `port`](https://www.elastic.co/guide
 
 	docker run --name some-kibana --link some-elasticsearch:elasticsearch -p 5601:5601 -d kibana
 
+You can also provide the address of elasticsearch via `ELASTICSEARCH_URL` environnement variable:
+
+	docker run --name some-kibana -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 -p 5601:5601 -d kibana
+
+
 Then, access it via `http://localhost:5601` or `http://host-ip:5601` in a browser.
 
 # License

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -29,11 +29,6 @@ This image includes `EXPOSE 5601` ([default `port`](https://www.elastic.co/guide
 
 	docker run --name some-kibana --link some-elasticsearch:elasticsearch -p 5601:5601 -d kibana
 
-You can also provide the address of elasticsearch via `ELASTICSEARCH_URL` environnement variable:
-
-	docker run --name some-kibana -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 -p 5601:5601 -d kibana
-
-
 Then, access it via `http://localhost:5601` or `http://host-ip:5601` in a browser.
 
 # License

--- a/kibana/content.md
+++ b/kibana/content.md
@@ -21,5 +21,10 @@ You can also pass in additional flags to `%%REPO%%`:
 This image includes `EXPOSE 5601` ([default `port`](https://www.elastic.co/guide/en/kibana/current/_setting_kibana_server_properties.html)). If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 
 	docker run --name some-%%REPO%% --link some-elasticsearch:elasticsearch -p 5601:5601 -d %%REPO%%
+You can also provide the address of elasticsearch via `ELASTICSEARCH_URL` environnement variable:
+
+	docker run --name some-kibana -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 -p 5601:5601 -d kibana
+
+
 
 Then, access it via `http://localhost:5601` or `http://host-ip:5601` in a browser.


### PR DESCRIPTION
The official doc does not mention that you can pass the address of you elastic search instance with the `ELASTICSEARCH_URL` environment variable.

See https://github.com/docker-library/kibana/blob/master/4.1/docker-entrypoint.sh