### PR TITLE
Update variant.sh with a bit more flexibility (so we can have "variant override" files per-image)

### DIFF
--- a/redis/content.md
+++ b/redis/content.md
@@ -43,3 +43,7 @@ Alternatively, you can specify something along the same lines with `docker run` 
 	docker run -v /myredis/conf/redis.conf:/usr/local/etc/redis/redis.conf --name myredis redis redis-server /usr/local/etc/redis/redis.conf
 
 Where `/myredis/conf/` is a local directory containing your `redis.conf` file. Using this method means that there is no need for you to have a Dockerfile for your redis container.
+
+## `32bit` variant
+
+This variant is *not* a 32bit image (and will not run on 32bit hardware), but includes Redis compiled as a 32bit binary, especially for users who need the decreased memory requirements associated with that. See ["Using 32 bit instances"](http://redis.io/topics/memory-optimization#using-32-bit-instances) in the Redis documentation for more information.


### PR DESCRIPTION
See also https://github.com/docker-library/redis/pull/28, https://github.com/docker-library/official-images/pull/897, and http://redis.io/topics/memory-optimization#using-32-bit-instances.