### PR TITLE
[php] Fix php.ini COPY Documentation

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -58,7 +58,7 @@ We recommend that you add a custom `php.ini` configuration. `COPY` it into `/usr
 
 ```dockerfile
 FROM php:5.6-apache
-COPY config/php.ini /usr/local/etc/php
+COPY config/php.ini /usr/local/etc/php/
 COPY src/ /var/www/html/
 ```
 


### PR DESCRIPTION
Apparently COPY will expect a full target path nowadays:

```
Step 0 : FROM php:5.6-apache
 ---> 86db229ab259
Step 1 : COPY config/php.ini /usr/local/etc/php
stat /var/lib/docker/devicemapper/mnt/cb571a2599018afc008c08a509d201d4937eed74a22621efa94e3ef32bebc869/rootfs/usr/local/etc/php/php.ini: not a directory
```