### PR TITLE
Postgres link in Readme when starting celery worker and beat

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -65,6 +65,13 @@ Sentry is a realtime event logging and aggregation platform. It specializes in m
 		$ docker run -d --name sentry-celery-beat --link some-redis:redis sentry sentry celery beat
 		$ docker run -d --name sentry-celery1 --link some-redis:redis sentry sentry celery worker
 		```
+		
+	-	using the celery bundled with sentry and a database
+
+		```console
+		$ docker run -d --name sentry-celery-beat --link some-redis:redis --link some-postgres:postgres sentry sentry celery beat
+		$ docker run -d --name sentry-celery1 --link some-redis:redis --link some-postgres:postgres sentry sentry celery worker
+		```
 
 ### port mapping
 


### PR DESCRIPTION
Added a database link option to the celery run commad because it easily missed when first setting up the sentry container, that you need to link to your postgres container 