### PR TITLE
Update Jetty docs for CMD changes

### DIFF
--- a/jetty/content.md
+++ b/jetty/content.md
@@ -48,8 +48,7 @@ Configuration such as parameters and additional modules may also be passed in vi
 $ docker run -d %%REPO%%:9 --modules=jmx jetty.threadPool.maxThreads=500
 ```
 
-To update the server configuration in a derived Docker image, the `Dockerfile` may
-enable additional modules with `RUN` commands like:
+To update the server configuration in a derived Docker image, the `Dockerfile` may enable additional modules with `RUN` commands like:
 
 ```Dockerfile
 FROM jetty:9

--- a/jetty/content.md
+++ b/jetty/content.md
@@ -52,7 +52,8 @@ To update the server configuration in a derived Docker image, the `Dockerfile` m
 enable additional modules with `RUN` commands like:
 
 ```Dockerfile
-WORKDIR $JETTY_BASE
+FROM jetty:9
+
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,stats
 ```
 

--- a/jetty/content.md
+++ b/jetty/content.md
@@ -8,7 +8,7 @@ Jetty is a pure Java-based HTTP (Web) server and Java Servlet container. While W
 
 # How to use this image.
 
-Run the default Jetty server (`CMD ["jetty.sh", "run"]`):
+Run the default Jetty server (`CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]`):
 
 ```console
 $ docker run -d %%REPO%%:9
@@ -26,10 +26,10 @@ The default Jetty environment in the image is:
 
 	JETTY_HOME    =  /usr/local/jetty
 	JETTY_BASE    =  /var/lib/jetty
-	JETTY_CONF    =  /usr/local/jetty/etc/jetty.conf
-	JETTY_STATE   =  /run/jetty/jetty.state
-	JETTY_ARGS    =
-	JAVA_OPTIONS  =
+	JETTY_CONF    =  /usr/local/jetty/etc/jetty.conf # Deprecated
+	JETTY_STATE   =  /run/jetty/jetty.state          # Deprecated
+	JETTY_ARGS    =                                  # Deprecated
+	JAVA_OPTIONS  =                                  # Deprecated
 	TMPDIR        =  /tmp/jetty
 
 ## Deployment
@@ -37,6 +37,24 @@ The default Jetty environment in the image is:
 Webapps can be [deployed](https://www.eclipse.org/jetty/documentation/current/quickstart-deploying-webapps.html) under `/var/lib/jetty/webapps` in the usual ways (WAR file, exploded WAR directory, or context XML file). To deploy your application to the `/` context, use the name `ROOT.war`, the directory name `ROOT`, or the context file `ROOT.xml` (case insensitive).
 
 For older EOL'd images based on Jetty 7 or Jetty 8, please follow the [legacy instructions](https://wiki.eclipse.org/Jetty/Howto/Deploy_Web_Applications) on the Eclipse Wiki and deploy under `/usr/local/jetty/webapps` instead of `/var/lib/jetty/webapps`.
+
+## Configuration
+
+The configuration of the jetty server can be reported by running with the --list-config option:
+```console
+$ docker run -d %%REPO%%:9 --list-config
+```
+Configuration such as parameters and additional modules may also be passed in via the command line. For example
+```console
+$ docker run -d %%REPO%%:9 --modules=jmx jetty.threadPool.maxThreads=500
+```
+To update the server configuration in a new docker image, the Dockerfile may enamble additional modules with RUN commands like:
+```
+WORKDIR $JETTY_BASE
+RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,http2
+```
+Modules may be configured in a Dockerfile by editing the properties in corresponding `/var/lib/jetty/start.d/*.mod` file or the module can be deactivated by
+removing that file.
 
 ## Read-only container
 

--- a/jetty/content.md
+++ b/jetty/content.md
@@ -37,19 +37,25 @@ For older EOL'd images based on Jetty 7 or Jetty 8, please follow the [legacy in
 ## Configuration
 
 The configuration of the Jetty server can be reported by running with the `--list-config` option:
+
 ```console
 $ docker run -d %%REPO%%:9 --list-config
 ```
+
 Configuration such as parameters and additional modules may also be passed in via the command line. For example:
+
 ```console
 $ docker run -d %%REPO%%:9 --modules=jmx jetty.threadPool.maxThreads=500
 ```
+
 To update the server configuration in a derived Docker image, the `Dockerfile` may
 enable additional modules with `RUN` commands like:
-```
+
+```Dockerfile
 WORKDIR $JETTY_BASE
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,stats
 ```
+
 Modules may be configured in a `Dockerfile` by editing the properties in the corresponding `/var/lib/jetty/start.d/*.mod` file or the module can be deactivated by removing that file.
 
 ## Read-only container

--- a/jetty/content.md
+++ b/jetty/content.md
@@ -8,7 +8,7 @@ Jetty is a pure Java-based HTTP (Web) server and Java Servlet container. While W
 
 # How to use this image.
 
-Run the default Jetty server (`CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]`):
+Run the default Jetty server:
 
 ```console
 $ docker run -d %%REPO%%:9
@@ -26,10 +26,6 @@ The default Jetty environment in the image is:
 
 	JETTY_HOME    =  /usr/local/jetty
 	JETTY_BASE    =  /var/lib/jetty
-	JETTY_CONF    =  /usr/local/jetty/etc/jetty.conf # Deprecated
-	JETTY_STATE   =  /run/jetty/jetty.state          # Deprecated
-	JETTY_ARGS    =                                  # Deprecated
-	JAVA_OPTIONS  =                                  # Deprecated
 	TMPDIR        =  /tmp/jetty
 
 ## Deployment
@@ -40,21 +36,21 @@ For older EOL'd images based on Jetty 7 or Jetty 8, please follow the [legacy in
 
 ## Configuration
 
-The configuration of the jetty server can be reported by running with the --list-config option:
+The configuration of the Jetty server can be reported by running with the `--list-config` option:
 ```console
 $ docker run -d %%REPO%%:9 --list-config
 ```
-Configuration such as parameters and additional modules may also be passed in via the command line. For example
+Configuration such as parameters and additional modules may also be passed in via the command line. For example:
 ```console
 $ docker run -d %%REPO%%:9 --modules=jmx jetty.threadPool.maxThreads=500
 ```
-To update the server configuration in a new docker image, the Dockerfile may enamble additional modules with RUN commands like:
+To update the server configuration in a derived Docker image, the `Dockerfile` may
+enable additional modules with `RUN` commands like:
 ```
 WORKDIR $JETTY_BASE
-RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,http2
+RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,stats
 ```
-Modules may be configured in a Dockerfile by editing the properties in corresponding `/var/lib/jetty/start.d/*.mod` file or the module can be deactivated by
-removing that file.
+Modules may be configured in a `Dockerfile` by editing the properties in the corresponding `/var/lib/jetty/start.d/*.mod` file or the module can be deactivated by removing that file.
 
 ## Read-only container
 


### PR DESCRIPTION
Since @gregw will be unavailable to make updates to #327 for a few days, I'm opening a new PR with his changes plus the tweaks necessary to appease `markdownfmt` (along with a minor change to the example `Dockerfile` for adding new Jetty modules).

This PR goes along with https://github.com/docker-library/official-images/pull/1005 (which should be mergeable with passing tests if https://github.com/docker-library/official-images/pull/1010 is applied).

Closes #327.