### PR TITLE
Sentry Content.md added celery to Postgres link

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -65,6 +65,13 @@ Sentry is a realtime event logging and aggregation platform. It specializes in m
 		$ docker run -d --name sentry-celery-beat --link some-redis:redis sentry sentry celery beat
 		$ docker run -d --name sentry-celery1 --link some-redis:redis sentry sentry celery worker
 		```
+		
+	-	using the celery bundled with sentry and a database
+
+		```console
+		$ docker run -d --name sentry-celery-beat --link some-redis:redis --link some-postgres:postgres sentry sentry celery beat
+		$ docker run -d --name sentry-celery1 --link some-redis:redis --link some-postgres:postgres sentry sentry celery worker
+		```
 
 ### port mapping
 

--- a/sentry/content.md
+++ b/sentry/content.md
@@ -59,6 +59,13 @@ Sentry is a realtime event logging and aggregation platform. It specializes in m
 		$ docker run -d --name sentry-celery-beat --link some-redis:redis sentry sentry celery beat
 		$ docker run -d --name sentry-celery1 --link some-redis:redis sentry sentry celery worker
 		```
+		
+	-	using the celery bundled with sentry and database
+
+		```console
+		$ docker run -d --name sentry-celery-beat --link some-redis:redis --link some-postgres:postgres sentry sentry celery beat
+		$ docker run -d --name sentry-celery1 --link some-redis:redis --link some-postgres:postgres sentry sentry celery worker
+		```
 
 ### port mapping
 


### PR DESCRIPTION
I added a note saying that if you run your sentry on postgres/mysql you will need to link your celery to that database because otherwise celery will not be able to save the results to the postgres database