### PR TITLE
Sentry with postgres

### DIFF
--- a/sentry/content.md
+++ b/sentry/content.md
@@ -59,6 +59,12 @@ Sentry is a realtime event logging and aggregation platform. It specializes in m
 		$ docker run -d --name sentry-celery-beat --link some-redis:redis sentry sentry celery beat
 		$ docker run -d --name sentry-celery1 --link some-redis:redis sentry sentry celery worker
 		```
+	-	using the celery bundled with sentry and postgres
+
+		```console
+		$ docker run -d --name sentry-celery-beat --link some-redis:redis --link some-postgres:postgres sentry sentry celery beat
+		$ docker run -d --name sentry-celery1 --link some-redis:redis --link some-postgres:postgres sentry sentry celery worker
+		```
 
 ### port mapping
 


### PR DESCRIPTION
Added remark that you will need to link the celery container to the postgres container otherwise celery wont be able to commit the results to your database