### PR TITLE
Some commands (e.g pwd) need bash

### DIFF
--- a/golang/content.md
+++ b/golang/content.md
@@ -39,7 +39,7 @@ $ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.3 go build
 This will add your current directory as a volume to the container, set the working directory to the volume, and run the command `go build` which will tell go to compile the project in the working directory and output the executable to `myapp`. Alternatively, if you have a `Makefile`, you can run the `make` command inside your container.
 
 ```console
-$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.3 make
+$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.3 bash -c make
 ```
 
 ## Cross-compile your app inside the Docker container


### PR DESCRIPTION
Hello!

If a Makefile contains shell command, we should use a shell to launch make process.