### PR TITLE
celery workers also need the database connection

### DIFF
--- a/sentry/content.md
+++ b/sentry/content.md
@@ -49,8 +49,8 @@ Sentry is a realtime event logging and aggregation platform. It specializes in m
 	-	using the celery image:
 
 		```console
-		$ docker run -d --name celery-beat --link some-redis:redis  -e CELERY_BROKER_URL=redis://redis celery celery beat
-		$ docker run -d --name celery-worker1 --link some-redis:redis  -e CELERY_BROKER_URL=redis://redis celery
+		$ docker run -d --name celery-beat --link some-postgres:postgres --link some-redis:redis  -e CELERY_BROKER_URL=redis://redis celery celery beat
+		$ docker run -d --name celery-worker1  --link some-postgres:postgres --link some-redis:redis  -e CELERY_BROKER_URL=redis://redis celery
 		```
 
 	-	using the celery bundled with sentry


### PR DESCRIPTION
If the database is not linked, the workers do not find the tables.