### PR TITLE
Move the theoretical best-effort support line from Docker 1.0 up to Docker 1.6

### DIFF
--- a/.template-helpers/docker-versions.md
+++ b/.template-helpers/docker-versions.md
@@ -1,3 +1,5 @@
 This image is officially supported on Docker version %%DOCKER-LATEST%%.
 
-Support for older versions (down to 1.0) is provided on a best-effort basis.
+Support for older versions (down to 1.6) is provided on a best-effort basis.
+
+Please see [the Docker installation documentation](https://docs.docker.com/installation/) for details on how to upgrade your Docker daemon.


### PR DESCRIPTION
Also, add a link to the Docker docs for installation.