### PR TITLE
Link postgres as needed in sentry docs.

### DIFF
--- a/sentry/content.md
+++ b/sentry/content.md
@@ -49,15 +49,15 @@ Sentry is a realtime event logging and aggregation platform. It specializes in m
 	-	using the celery image:
 
 		```console
-		$ docker run -d --name celery-beat --link some-postgres:postgres --link some-redis:redis  -e CELERY_BROKER_URL=redis://redis celery celery beat
-		$ docker run -d --name celery-worker1  --link some-postgres:postgres --link some-redis:redis  -e CELERY_BROKER_URL=redis://redis celery
+		$ docker run -d --name celery-beat --link some-postgres:postgres --link some-redis:redis -e CELERY_BROKER_URL=redis://redis celery celery beat
+		$ docker run -d --name celery-worker1 --link some-postgres:postgres --link some-redis:redis -e CELERY_BROKER_URL=redis://redis celery
 		```
 
 	-	using the celery bundled with sentry
 
 		```console
-		$ docker run -d --name sentry-celery-beat --link some-redis:redis sentry sentry celery beat
-		$ docker run -d --name sentry-celery1 --link some-redis:redis sentry sentry celery worker
+		$ docker run -d --name sentry-celery-beat --link some-postgres:postgres --link some-redis:redis sentry sentry celery beat
+		$ docker run -d --name sentry-celery1 --link some-postgres:postgres --link some-redis:redis sentry sentry celery worker
 		```
 
 ### port mapping


### PR DESCRIPTION
Celery workers need to be linked to postgres; celery beat doesn't.

cc @mattrobenolt 