### PR TITLE
fix a typo

### DIFF
--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -102,7 +102,7 @@ This variable is for controlling which IP address to listen for incoming connect
 
 ### `CASSANDRA_BROADCAST_ADDRESS`
 
-This variable is for controlling which IP address to advertise to other nodes. The default value is the velue of `CASSANDRA_LISTEN_ADDRESS`. It will set the [`broadcast_address`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__broadcast_address) and [`broadcast_rpc_address`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__broadcast_rpc_address) options in `cassandra.yaml`.
+This variable is for controlling which IP address to advertise to other nodes. The default value is the value of `CASSANDRA_LISTEN_ADDRESS`. It will set the [`broadcast_address`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__broadcast_address) and [`broadcast_rpc_address`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__broadcast_rpc_address) options in `cassandra.yaml`.
 
 ### `CASSANDRA_RPC_ADDRESS`
 


### PR DESCRIPTION
Fixed "The default value is the vElue" -> "The default value is the value"