### PR TITLE
Document correct COPY path for golang onbuild image

### DIFF
--- a/golang/content.md
+++ b/golang/content.md
@@ -16,7 +16,7 @@ The most straightforward way to use this image is to use a Go container as both 
 FROM golang:1.3-onbuild
 ```
 
-This image includes multiple `ONBUILD` triggers which should cover most applications. The build will `COPY . /usr/src/app`, `RUN go get -d -v`, and `RUN
+This image includes multiple `ONBUILD` triggers which should cover most applications. The build will `COPY . /usr/go/app`, `RUN go get -d -v`, and `RUN
 go install -v`.
 
 This image also includes the `CMD ["app"]` instruction which is the default command when running the image without arguments.


### PR DESCRIPTION
This PR replaces the documented `/usr/src/app` path with `/usr/go/app` which is the correct path according to the [latest onbuild Dockerfile](https://github.com/docker-library/golang/blob/master/1.5/onbuild/Dockerfile#L3) for the golang image.