### PR TITLE
variant-alpine: explain often missing tooling

### DIFF
--- a/.template-helpers/variant-alpine.md
+++ b/.template-helpers/variant-alpine.md
@@ -3,3 +3,5 @@
 This image is based on the popular [Alpine Linux project](http://alpinelinux.org), available in [the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
 
 This variant is highly recommended when final image size being as small as possible is desired. The only caveat to note is that it does use [musl libc](http://www.musl-libc.org) instead of [glibc and friends](http://www.etalabs.net/compare_libcs.html), so certain software might run into issues depending on the depth of their libc requirements. However, most software doesn't have an issue with this, so this variant is usually a very safe choice.
+
+To minimize image size, it's uncommon for additional related tools to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile.


### PR DESCRIPTION
As discussed in https://github.com/docker-library/golang/pull/69 -- try to explain that common tooling which is not strictly needed is often not included in Alpine images. (E.g. git in golang)

Closes docker-library/golang#69