### PR TITLE
Added note for how to connect to mongo instance from Windows Command …

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -39,6 +39,8 @@ $ docker run --name some-app --link some-mongo:mongo -d application-that-uses-mo
 
 ## ... or via `mongo`
 
+(Replace `'` with `"` if running in Windows CMD)
+
 ```console
 $ docker run -it --link some-mongo:mongo --rm mongo sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'
 ```

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -39,8 +39,6 @@ $ docker run --name some-app --link some-mongo:mongo -d application-that-uses-mo
 
 ## ... or via `mongo`
 
-(Replace `'` with `"` if running in Windows CMD)
-
 ```console
 $ docker run -it --link some-mongo:mongo --rm mongo sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'
 ```

--- a/mongo/content.md
+++ b/mongo/content.md
@@ -26,6 +26,8 @@ $ docker run --name some-app --link some-mongo:mongo -d application-that-uses-mo
 
 ## ... or via `mongo`
 
+(Replace `'` with `"` if running in Windows CMD)
+
 ```console
 $ docker run -it --link some-mongo:mongo --rm mongo sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'
 ```


### PR DESCRIPTION
Running the command `docker run -it --link some-mongo:mongo --rm mongo sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'` doesn't work from windows CMD prompt and results in the output:

> mongo: 1: mongo: Syntax error: Unterminated quoted string

This pull request includes a small note for Windows users to help them avoid this problem.
