### PR TITLE
Add capability for a simple deprecation notice, and add one for ubuntu-debootstrap and ubuntu-upstart

### DIFF
--- a/ubuntu-debootstrap/deprecated.md
+++ b/ubuntu-debootstrap/deprecated.md
@@ -1,0 +1,1 @@
+This image is officially deprecated in favor of [the standard `ubuntu` image](https://hub.docker.com/_/ubuntu/), and will receive no further updates. Please adjust your usage accordingly.

--- a/ubuntu-upstart/deprecated.md
+++ b/ubuntu-upstart/deprecated.md
@@ -1,0 +1,1 @@
+This image is officially deprecated (especially now that Upstart is no longer the default init system for Ubuntu) and will receive no further updates. Please adjust your usage accordingly.

--- a/update.sh
+++ b/update.sh
@@ -132,7 +132,14 @@ for repo in "${repos[@]}"; do
 			composeYml=$'```yaml\n'"$(cat "$repo/docker-compose.yml")"$'\n```'
 		fi
 		
-		cp -v "$helperDir/template.md" "$repo/README.md"
+		deprecated=
+		if [ -f "$repo/deprecated.md" ]; then
+			deprecated=$'# **DEPRECATED**\n\n'
+			deprecated+="$(cat "$repo/deprecated.md")"
+			deprecated+=$'\n\n'
+		fi
+		
+		{ echo -n "$deprecated"; cat "$helperDir/template.md"; } > "$repo/README.md"
 		
 		echo '  TAGS => generate-dockerfile-links-partial.sh'
 		partial="$("$helperDir/generate-dockerfile-links-partial.sh" "$repo")"


### PR DESCRIPTION
Visual difference between `# a` and `# **a**` in current Docker Hub rendering:
![image](https://cloud.githubusercontent.com/assets/161631/12397317/549144f6-bdc1-11e5-9e2b-afbb04e889ef.png)