### PR TITLE
Updated the Oracle Linux documentation

### DIFF
--- a/oraclelinux/README.md
+++ b/oraclelinux/README.md
@@ -40,11 +40,21 @@ View the [Oracle Linux End-User License Agreement](https://oss.oracle.com/ol6/EU
 
 # Supported Docker versions
 
-This image is officially supported on Docker version 1.9.1.
+This image is officially supported for Oracle Linux customers with an active Oracle Linux Basic or Premier support subscription on both Oracle Linux 6 and Oracle Linux 7 running the Unbreakable Enterprise Kernel Release 4 and Docker Engine version 1.9 installed from the Oracle Linux Yum Server.
 
-Support for older versions (down to 1.6) is provided on a best-effort basis.
+Oracle Linux users without an active support subscription can use either the Oracle distributed version of Docker Engine or the upstream version distributed by Docker. Support is limited to the community-based options outlined below.
 
-Please see [the Docker installation documentation](https://docs.docker.com/installation/) for details on how to upgrade your Docker daemon.
+## Oracle Linux 7
+
+Please review the [additional Linux programs supported under Oracle Linux support](https://docs.oracle.com/cd/E52668_01/E63013/html/ol7-lic-addl-packages.html) chapter for more information on the scope of support for Docker.
+
+Please review [Chapter 29 of the Oracle Linux 7 Administrator&apos;s Guide](https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-docker.html) for details on how to install or upgrade the Unbreakable Enterprise Kernel and Docker Engine packages.
+
+## Oracle Linux 6
+
+Please review the [additional Linux programs supported under Oracle Linux support](http://docs.oracle.com/cd/E37670_01/E63012/html/ol6-lic-addl-packages.html) chapter for more information on the scope of support for Docker.
+
+Please review [Chapter 10 of the Oracle Linux 6 Administrator&apos;s Solutions Guide](http://docs.oracle.com/cd/E37670_01/E37355/html/ol_docker.html) for details on how to install or upgrade the Unbreakable Enterprise Kernel and Docker Engine packages.
 
 # User Feedback
 

--- a/oraclelinux/docker-versions.md
+++ b/oraclelinux/docker-versions.md
@@ -1,0 +1,15 @@
+This image is officially supported for Oracle Linux customers with an active Oracle Linux Basic or Premier support subscription on both Oracle Linux 6 and Oracle Linux 7 running the Unbreakable Enterprise Kernel Release 4 and Docker Engine version 1.9 installed from the Oracle Linux Yum Server.
+
+Oracle Linux users without an active support subscription can use either the Oracle distributed version of Docker Engine or the upstream version distributed by Docker. Support is limited to the community-based options outlined below.
+
+## Oracle Linux 7
+
+Please review the [additional Linux programs supported under Oracle Linux support](https://docs.oracle.com/cd/E52668_01/E63013/html/ol7-lic-addl-packages.html) chapter for more information on the scope of support for Docker.
+
+Please review [Chapter 29 of the Oracle Linux 7 Administrator&apos;s Guide](https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-docker.html) for details on how to install or upgrade the Unbreakable Enterprise Kernel and Docker Engine packages.
+
+## Oracle Linux 6
+
+Please review the [additional Linux programs supported under Oracle Linux support](http://docs.oracle.com/cd/E37670_01/E63012/html/ol6-lic-addl-packages.html) chapter for more information on the scope of support for Docker.
+
+Please review [Chapter 10 of the Oracle Linux 6 Administrator&apos;s Solutions Guide](http://docs.oracle.com/cd/E37670_01/E37355/html/ol_docker.html) for details on how to install or upgrade the Unbreakable Enterprise Kernel and Docker Engine packages.


### PR DESCRIPTION
Thanks to @tianon's tips in #404 (which is a great issue number), I've added `docker-versions.md` and rebuilt `README.md` using `update.sh`.

The new text provides more accurate support information for both Oracle support customers and users without a paid support subscription.

Signed-off-by: Avi Miller <avi.miller@oracle.com>