### PR TITLE
Add a note about how to remove the spurious stderr blurb in golang:onbuild

### DIFF
--- a/golang/content.md
+++ b/golang/content.md
@@ -27,6 +27,8 @@ $ docker build -t my-golang-app .
 $ docker run -it --rm --name my-running-app my-golang-app
 ```
 
+*Note:* the default command in `%%REPO%%:onbuild` is actually `go-wrapper run`, which includes `set -x` so the binary name is printed to stderr on application startup. If this behavior is undesirable, then adding `CMD ["app"]` (or `CMD ["myapp"]` if a [Go custom import path](https://golang.org/s/go14customimport) is in use) will silence it by running the built binary directly.
+
 ## Compile your app inside the Docker container
 
 There may be occasions where it is not appropriate to run your app inside a container. To compile, but not run your app inside the Docker instance, you can write something like:


### PR DESCRIPTION
Fixes docker-library/golang#41