### PR TITLE
Add a link that shows off our image layer sharing

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.sh
+++ b/.template-helpers/generate-dockerfile-links-partial.sh
@@ -20,16 +20,26 @@ fi
 repoDirs=()
 declare -A repoDirTags=()
 
+latest=
+uniqImages=()
 for line in "${lines[@]}"; do
 	tag="$(echo "$line" | awk -F ': +' '{ print $1 }')"
+	if [ -z "$latest" -o "$tag" = 'latest' ]; then
+		latest="$tag"
+	fi
 	repoDir="$(echo "$line" | awk -F ': +' '{ print $2 }')"
 	if [ -z "${repoDirTags[$repoDir]}" ]; then
 		repoDirs+=( "$repoDir" )
+		uniqImages+=( "$repo:$tag" )
 	else
 		repoDirTags["$repoDir"]+=', '
 	fi
 	repoDirTags["$repoDir"]+='`'"$tag"'`'
 done
+
+IFS=','
+imageLayers="https://imagelayers.io/?images=${uniqImages[*]}"
+unset IFS
 
 for repoDir in "${repoDirs[@]}"; do
 	if [[ "$repoDir" != *github.com* ]]; then
@@ -59,4 +69,6 @@ for repoDir in "${repoDirs[@]}"; do
 	echo $'-\t['"${repoDirTags["$repoDir"]}"' (*'"${dir}Dockerfile"'*)]('"$url"')'
 done
 
+echo
+echo "[![](https://badge.imagelayers.io/$repo:$latest.svg)]($imageLayers)"
 echo


### PR DESCRIPTION
# Supported tags and respective `Dockerfile` links

-	[`1.4.3`, `1.4` (*1.4/Dockerfile*)](https://github.com/docker-library/golang/blob/a4f3927494b48c7bdb6ea6edac8f89818853b45b/1.4/Dockerfile)
-	[`1.4.3-onbuild`, `1.4-onbuild` (*1.4/onbuild/Dockerfile*)](https://github.com/docker-library/golang/blob/3427e88341de17a4d8921b859180a2649e1ab96e/1.4/onbuild/Dockerfile)
-	[`1.4.3-cross`, `1.4-cross` (*1.4/cross/Dockerfile*)](https://github.com/docker-library/golang/blob/3427e88341de17a4d8921b859180a2649e1ab96e/1.4/cross/Dockerfile)
-	[`1.4.3-wheezy`, `1.4-wheezy` (*1.4/wheezy/Dockerfile*)](https://github.com/docker-library/golang/blob/a4f3927494b48c7bdb6ea6edac8f89818853b45b/1.4/wheezy/Dockerfile)
-	[`1.4.3-alpine`, `1.4-alpine` (*1.4/alpine/Dockerfile*)](https://github.com/docker-library/golang/blob/5fc9acac9ae394e055cdc2e80400bf78e360cd2c/1.4/alpine/Dockerfile)
-	[`1.5.3`, `1.5`, `1`, `latest` (*1.5/Dockerfile*)](https://github.com/docker-library/golang/blob/1eab0db63794152b4516dbcb70270eb9dced4cbd/1.5/Dockerfile)
-	[`1.5.3-onbuild`, `1.5-onbuild`, `1-onbuild`, `onbuild` (*1.5/onbuild/Dockerfile*)](https://github.com/docker-library/golang/blob/f1f65c0ab0097a5e3d079d5a74e2468e8d47563d/1.5/onbuild/Dockerfile)
-	[`1.5.3-wheezy`, `1.5-wheezy`, `1-wheezy`, `wheezy` (*1.5/wheezy/Dockerfile*)](https://github.com/docker-library/golang/blob/1eab0db63794152b4516dbcb70270eb9dced4cbd/1.5/wheezy/Dockerfile)
-	[`1.5.3-alpine`, `1.5-alpine`, `1-alpine`, `alpine` (*1.5/alpine/Dockerfile*)](https://github.com/docker-library/golang/blob/1689df433a45bd787990f2982fb28345ec27f733/1.5/alpine/Dockerfile)
-	[`1.6rc1`, `1.6` (*1.6/Dockerfile*)](https://github.com/docker-library/golang/blob/de005b1ff6dc41f6c0f18ae06bbd2ef36da964bb/1.6/Dockerfile)
-	[`1.6rc1-onbuild`, `1.6-onbuild` (*1.6/onbuild/Dockerfile*)](https://github.com/docker-library/golang/blob/ce284e14cdee73fbaa8fb680011a812f272eae2e/1.6/onbuild/Dockerfile)
-	[`1.6rc1-wheezy`, `1.6-wheezy` (*1.6/wheezy/Dockerfile*)](https://github.com/docker-library/golang/blob/de005b1ff6dc41f6c0f18ae06bbd2ef36da964bb/1.6/wheezy/Dockerfile)
-	[`1.6rc1-alpine`, `1.6-alpine` (*1.6/alpine/Dockerfile*)](https://github.com/docker-library/golang/blob/de005b1ff6dc41f6c0f18ae06bbd2ef36da964bb/1.6/alpine/Dockerfile)

[![](https://badge.imagelayers.io/golang:latest.svg)](https://imagelayers.io/?images=golang:1.4.3,golang:1.4.3-onbuild,golang:1.4.3-cross,golang:1.4.3-wheezy,golang:1.4.3-alpine,golang:1.5.3,golang:1.5.3-onbuild,golang:1.5.3-wheezy,golang:1.5.3-alpine,golang:1.6rc1,golang:1.6rc1-onbuild,golang:1.6rc1-wheezy,golang:1.6rc1-alpine)

For more information about this image and its history, please see [the relevant manifest file (`library/golang`)](https://github.com/docker-library/official-images/blob/master/library/golang). This image is updated via pull requests to [the `docker-library/official-images` GitHub repo](https://github.com/docker-library/official-images).

For detailed information about the virtual/transfer sizes and individual layers of each of the above supported tags, please see [the `golang/tag-details.md` file](https://github.com/docker-library/docs/blob/master/golang/tag-details.md) in [the `docker-library/docs` GitHub repo](https://github.com/docker-library/docs).