### PR TITLE
Add docs for random and onetime root password

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -88,6 +88,8 @@ When you start the `mysql` image, you can adjust the configuration of the MySQL 
 
 This variable is mandatory and specifies the password that will be set for the MySQL `root` superuser account. In the above example, it was set to `my-secret-pw`.
 
+**Important note**: the root password is accessible within container as environment variable and `docker-compose` populates it to other linked containers aswell! See `MYSQL_RANDOM_ROOT_PASSWORD` for an alternative way of making the root account accessible.
+
 ### `MYSQL_DATABASE`
 
 This variable is optional and allows you to specify the name of a database to be created on image startup. If a user/password was supplied (see below) then that user will be granted superuser access ([corresponding to `GRANT ALL`](http://dev.mysql.com/doc/en/adding-users.html)) to this database.
@@ -96,11 +98,19 @@ This variable is optional and allows you to specify the name of a database to be
 
 These variables are optional, used in conjunction to create a new user and to set that user's password. This user will be granted superuser permissions (see above) for the database specified by the `MYSQL_DATABASE` variable. Both variables are required for a user to be created.
 
-Do note that there is no need to use this mechanism to create the root superuser, that user gets created by default with the password specified by the `MYSQL_ROOT_PASSWORD` variable.
+Do note that there is no need to use this mechanism to create the root superuser, that user gets created by default with a generated password (when using `MYSQL_RANDOM_ROOT_PASSWORD`) or the password specified by the `MYSQL_ROOT_PASSWORD` variable.
 
 ### `MYSQL_ALLOW_EMPTY_PASSWORD`
 
-This is an optional variable. Set to `yes` to allow the container to be started with a blank password for the root user. *NOTE*: Setting this variable to `yes` is not recommended unless you really know what you are doing, since this will leave your MySQL instance completely unprotected, allowing anyone to gain complete superuser access.
+This is an optional variable. Set to `yes` to allow the container to be started with a blank password for the root user.  *NOTE*: Setting this variable to `yes` is not recommended unless you really know what you are doing, since this will leave your MySQL instance completely unprotected, allowing anyone to gain complete superuser access.
+
+### `MYSQL_RANDOM_ROOT_PASSWORD`
+
+This is an optional variable. Set to `yes` to generate a random password (using pwgen). The generated root password will be printed to stdout ("GENERATED ROOT PASSWORD: .....")
+
+### `MYSQL_ONETIME_PASSWORD`
+
+Sets root (*not* the user specified in `MYSQL_USER`!) user as expired once init is complete, forcing a password change on first login. *NOTE*: This feature is supported on MySQL 5.6+ only. Using this option on MySQL 5.5 will throw an appropriate error during initialization.
 
 # Initializing a fresh instance
 


### PR DESCRIPTION
See PR docker-library/mysql#119 

IMO its unfortunate that there are different repositories: one containing the build definition, and this one containing the docker image README.md. Having this README.md in the build repository could help keeping the docs in sync with implementation. 

Additional change: add warning about root passwort getting published to env variable, see docker-library/mysql#88

