### PR TITLE
Add warning for Encoding default

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -59,12 +59,6 @@ The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker r
 $ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ruby:2.1 bundle install
 ```
 
-### Encoding 
-
-If you need to use any encoding different than the default ``US-ASCII`` then make sure you specify on your Dockerfile the following: 
-
-``ENV LANG C.UTF-8``
-
 ## Run a single Ruby script
 
 For many simple, single file projects, you may find it inconvenient to write a complete `Dockerfile`. In such cases, you can run a Ruby script by using the Ruby Docker image directly:

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -59,6 +59,12 @@ The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker r
 $ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app ruby:2.1 bundle install
 ```
 
+### Encoding 
+
+If you need to use any encoding different than the default ``US-ASCII`` then make sure you specify on your Dockerfile the following: 
+
+``ENV LANG C.UTF-8``
+
 ## Run a single Ruby script
 
 For many simple, single file projects, you may find it inconvenient to write a complete `Dockerfile`. In such cases, you can run a Ruby script by using the Ruby Docker image directly:

--- a/ruby/content.md
+++ b/ruby/content.md
@@ -27,6 +27,12 @@ $ docker build -t my-ruby-app .
 $ docker run -it --name my-running-script my-ruby-app
 ```
 
+## Encoding
+
+If you need to use any encoding different than the default ``US-ASCII`` then make sure you specify on your Dockerfile the following:
+
+``ENV LANG C.UTF-8``
+
 ### Generate a `Gemfile.lock`
 
 The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:


### PR DESCRIPTION
Warning for users using different encodings than default US-ASCII

this solves  [issue#70](https://github.com/docker-library/ruby/issues/70)