### PR TITLE
amend centos systemd document

### DIFF
--- a/centos/README.md
+++ b/centos/README.md
@@ -60,7 +60,8 @@ rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*;
+rm -f /lib/systemd/system/anaconda.target.wants/*;\
+rm -f /lib/systemd/system/*{,/}systemd-update-utmp*.service
 VOLUME [ "/sys/fs/cgroup" ]
 CMD ["/usr/sbin/init"]
 ```
@@ -90,13 +91,13 @@ $ docker build --rm -t local/c7-systemd-httpd
 
 ## Running a systemd enabled app container
 
-In order to run a container with systemd, you will need to mount the cgroups volumes from the host. Below is an example command that will run the systemd enabled httpd container created earlier.
+As systemd requiring the `CAP_SYS_ADMIN` capability,in order to run a container with systemd, you will need touse the `--privileged` option mentioned earlier, as well as mount the cgroups volumes from the host. Below is an example command that will run the systemd enabled httpd container created earlier.
 
 ```console
-$ docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p 80:80 local/c7-systemd-httpd
+$ docker run --privileged -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p 80:80 local/c7-systemd-httpd
 ```
 
-This container is running with systemd in a limited context, with the cgroups filesystem mounted. There have been reports that if you're using an Ubuntu host, you will need to add `-v /tmp/$(mktemp -d):/run` in addition to the cgroups mount.
+This container is running with systemd in a limited context,but it must always be run as a privileged container with the cgroups filesystem mounted. There have been reports that if you're using an Ubuntu host, you will need to add `-v /tmp/$(mktemp -d):/run` in addition to the cgroups mount.
 
 # Supported Docker versions
 

--- a/centos/content.md
+++ b/centos/content.md
@@ -42,7 +42,8 @@ rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*;
+rm -f /lib/systemd/system/anaconda.target.wants/*;\
+rm -f /lib/systemd/system/*{,/}systemd-update-utmp*.service
 VOLUME [ "/sys/fs/cgroup" ]
 CMD ["/usr/sbin/init"]
 ```
@@ -72,10 +73,10 @@ $ docker build --rm -t local/c7-systemd-httpd
 
 ## Running a systemd enabled app container
 
-In order to run a container with systemd, you will need to mount the cgroups volumes from the host. Below is an example command that will run the systemd enabled httpd container created earlier.
+As systemd requiring the `CAP_SYS_ADMIN` capability,in order to run a container with systemd, you will need touse the `--privileged` option mentioned earlier, as well as mount the cgroups volumes from the host. Below is an example command that will run the systemd enabled httpd container created earlier.
 
 ```console
-$ docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p 80:80 local/c7-systemd-httpd
+$ docker run --privileged -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p 80:80 local/c7-systemd-httpd
 ```
 
-This container is running with systemd in a limited context, with the cgroups filesystem mounted. There have been reports that if you're using an Ubuntu host, you will need to add `-v /tmp/$(mktemp -d):/run` in addition to the cgroups mount.
+This container is running with systemd in a limited context,but it must always be run as a privileged container with the cgroups filesystem mounted. There have been reports that if you're using an Ubuntu host, you will need to add `-v /tmp/$(mktemp -d):/run` in addition to the cgroups mount.


### PR DESCRIPTION
Systemd requires the CAP_SYS_ADMIN capability. This means running docker
with --privileged.If not running with --privileged or --caps-add SYS_ADMIN,will have error:
`Failed to mount tmpfs at /run: Operation not permitted
[!!!!!!] Failed to mount API filesystems, freezing.`

Remove the systemd-update-utmp*.service in the /lib/systemd/system dir.Because some warn output:
`[ INFO ] Update UTMP about System Boot/Shutdown is not active.
[DEPEND] Dependency failed for Update UTMP about System Runlevel Changes.`
