### PR TITLE
Remove reference to knickers/mongo-express

### DIFF
--- a/mongo-express/content.md
+++ b/mongo-express/content.md
@@ -59,6 +59,6 @@ The following are only needed if `ME_CONFIG_MONGODB_ENABLE_ADMIN` is **"false"**
 	    -e ME_CONFIG_OPTIONS_EDITORTHEME="ambiance" \
 	    -e ME_CONFIG_BASICAUTH_USERNAME="user" \
 	    -e ME_CONFIG_BASICAUTH_PASSWORD="fairly long password" \
-	    knickers/mongo-express
+	    mongo-express
 
 This example links to a container name typical of `docker-compose`, changes the editor's color theme, and enables basic authentication.


### PR DESCRIPTION
This removes a reference to knickers/mongo-express I had missed in an example, and changes it to the official mongo-express.