### PR TITLE
Update onbuild instructions

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -130,14 +130,6 @@ It's also possible to develop custom extensions within your `onbuild` package. I
 
 See the [official Sentry documentation](https://docs.getsentry.com/on-premise/server/installation/) for more information.
 
-To create your custom `sentry:onbuild` package, simply do the following:
-
-1. Create a Dockerfile containing `FROM sentry:onbuild`
-2. In the same directory, add your custom configuration files.
-3. You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
-4. Build your image: `docker build -t mysentry .`
-5. Run your custom image using `mysentry` instead of `sentry`.
-
 # License
 
 View [license information](https://github.com/getsentry/sentry/blob/master/LICENSE) for the software contained in this image.

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -130,6 +130,14 @@ It's also possible to develop custom extensions within your `onbuild` package. I
 
 See the [official Sentry documentation](https://docs.getsentry.com/on-premise/server/installation/) for more information.
 
+To create your custom `sentry:onbuild` package, simply do the following:
+
+1. Create a Dockerfile containing `FROM sentry:onbuild`
+2. In the same directory, add your custom configuration files.
+3. You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
+4. Build your image: `docker build -t mysentry .`
+5. Run your custom image using `mysentry` instead of `sentry`.
+
 # License
 
 View [license information](https://github.com/getsentry/sentry/blob/master/LICENSE) for the software contained in this image.

--- a/sentry/variant-onbuild.md
+++ b/sentry/variant-onbuild.md
@@ -5,3 +5,11 @@ This image makes it easy to custom build your own Sentry instance by copying in 
 It's also possible to develop custom extensions within your `onbuild` package. If the build directory contains a `setup.py` file, this will also get installed.
 
 See the [official Sentry documentation](https://docs.getsentry.com/on-premise/server/installation/) for more information.
+
+To create your custom `sentry:onbuild` package, simply do the following:
+
+1. Create a Dockerfile containing `FROM sentry:onbuild`
+2. In the same directory, add your custom configuration files.
+3. You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
+4. Build your image: `docker build -t mysentry .`
+5. Run your custom image using `mysentry` instead of `sentry`.

--- a/sentry/variant-onbuild.md
+++ b/sentry/variant-onbuild.md
@@ -8,8 +8,8 @@ See the [official Sentry documentation](https://docs.getsentry.com/on-premise/se
 
 To create your custom `sentry:onbuild` package, simply do the following:
 
-1.  Create a Dockerfile containing `FROM sentry:onbuild`
-2.  In the same directory, add your custom configuration files.
-3.  You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
-4.  Build your image: `docker build -t mysentry .`
-5.  Run your custom image using `mysentry` instead of `sentry`.
+1.	Create a Dockerfile containing `FROM sentry:onbuild`
+2.	In the same directory, add your custom configuration files.
+3.	You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
+4.	Build your image: `docker build -t mysentry .`
+5.	Run your custom image using `mysentry` instead of `sentry`.

--- a/sentry/variant-onbuild.md
+++ b/sentry/variant-onbuild.md
@@ -8,8 +8,8 @@ See the [official Sentry documentation](https://docs.getsentry.com/on-premise/se
 
 To create your custom `sentry:onbuild` package, simply do the following:
 
-1. Create a Dockerfile containing `FROM sentry:onbuild`
-2. In the same directory, add your custom configuration files.
-3. You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
-4. Build your image: `docker build -t mysentry .`
-5. Run your custom image using `mysentry` instead of `sentry`.
+1.  Create a Dockerfile containing `FROM sentry:onbuild`
+2.  In the same directory, add your custom configuration files.
+3.  You can get copies of those files to use as templates from the [docker-sentry GitHub repo](https://github.com/getsentry/docker-sentry/).
+4.  Build your image: `docker build -t mysentry .`
+5.  Run your custom image using `mysentry` instead of `sentry`.


### PR DESCRIPTION
Hi,

I'm guessing there's a fair chance that the venn diagram of sentry users and docker users doesn't have too much overlap. I've updated the onbuild image documentation to help people get started with a little more information.

I hope you find my additions to the readme helpful.

Thanks.