### PR TITLE
Update link to osrf/ros packages

### DIFF
--- a/ros/README.md
+++ b/ros/README.md
@@ -56,7 +56,7 @@ The available tags include supported distros along with a hierarchy tags based o
 - `robot`: basic install for robots  
 - `perception`: basic install for perception tasks
 
-The rest of the common meta-packages such as `desktop` and `desktop-full` are hosted on automatic build repos under OSRF's Docker Hub profile [here](https://registry.hub.docker.com/u/osrf/ros). These meta-packages include graphical dependencies and hook a host of other large packages such as X11, X server, etc. So in the interest of keep the official images lean and secure, the desktop packages are just be hosted with OSRF's profile.
+The rest of the common meta-packages such as `desktop` and `desktop-full` are hosted on automatic build repos under OSRF's Docker Hub profile [here](https://hub.docker.com/r/osrf/ros/). These meta-packages include graphical dependencies and hook a host of other large packages such as X11, X server, etc. So in the interest of keep the official images lean and secure, the desktop packages are just be hosted with OSRF's profile.
 
 ### Volumes
 


### PR DESCRIPTION
Small fix to a broken link I stumbled upon while perusing the docs.