### PR TITLE
Fix license link

### DIFF
--- a/swarm/README.md
+++ b/swarm/README.md
@@ -73,7 +73,7 @@ Note that Swarm certificates must be generated with `extendedKeyUsage = clientAu
 
 # License
 
-View [license information](https://github.com/docker/swarm/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/docker/swarm/blob/master/LICENSE.code) for the software contained in this image.
 
 # Supported Docker versions
 

--- a/swarm/license.md
+++ b/swarm/license.md
@@ -1,1 +1,1 @@
-View [license information](https://github.com/docker/swarm/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/docker/swarm/blob/master/LICENSE.code) for the software contained in this image.


### PR DESCRIPTION
The license links in the README and license markdown files went 404.  I linked them to the code section (seemed natural compared to the docs' license).