### PR TITLE
Updating the TICK stack documentation

### DIFF
--- a/chronograf/content.md
+++ b/chronograf/content.md
@@ -19,20 +19,21 @@ You can also use a custom configuration file or environment variables to modify 
 A sample configuration file can be obtained by:
 
 ```console
-$ docker run --rm chronograf -sample-config > chronograf.toml
+$ docker run --rm chronograf -sample-config > chronograf.conf
 ```
 
 Once you've customized `chronograf.conf`, you can run the Chronograf container with it mounted in the expected location (note the name change!):
 
 ```console
-$ docker run -d \
-      -p 10000:10000 \
-      -v /path/to/chronograf.toml:/opt/chronograf/config.toml
+$ docker run -p 10000:10000 \
+      -v $PWD/chronograf.conf:/etc/chronograf/chronograf.conf:ro
 ```
+
+Modify `$PWD` to the directory where you want to store the configuration file.
 
 ### Using environment variables (preferred)
 
-You may have noticed that the default `Bind` value in the configuration is set to `127.0.0.1:10000`, though the container will listen on `0.0.0.0:10000` instead. This is due to a `CHRONOGRAF_BIND` environment variable being set in the Dockerfile to provide a sensible default within the Docker context. Other environment variables can override configuration settings following the `CamelCase` to `CHRONOGRAF_CAMEL_CASE` pattern:
+You may have noticed that the default `Bind` value in the configuration is set to `127.0.0.1:10000`, though the container will listen on `0.0.0.0:10000` instead. This is due to a default configuration file being provided inside of the image. You can override values inside of the configuration file using environment variables following the `CamelCase` to `CHRONOGRAF_CAMEL_CASE` pattern:
 
 | SETTING                 | ENV VAR                               |
 |-------------------------|---------------------------------------|

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -13,9 +13,9 @@ InfluxDB is a time series database built from the ground up to handle high write
 The InfluxDB image exposes a shared volume under `/var/lib/influxdb`, so you can mount a host directory to that point to access persisted container data. A typical invocation of the container might be:
 
 ```console
-docker run -p 8083:8083 -p 8086:8086 \
-    -v $PWD:/var/lib/influxdb \
-    influxdb
+$ docker run -p 8083:8083 -p 8086:8086 \
+      -v $PWD:/var/lib/influxdb \
+      influxdb
 ```
 
 Modify `$PWD` to the directory where you want to store data associated with the InfluxDB container.
@@ -23,9 +23,9 @@ Modify `$PWD` to the directory where you want to store data associated with the 
 You can also have Docker control the volume mountpoint by using a named volume.
 
 ```console
-docker run -p 8083:8083 -p 8086:8086 \
-    -v influxdb:/var/lib/influxdb \
-    influxdb
+$ docker run -p 8083:8083 -p 8086:8086 \
+      -v influxdb:/var/lib/influxdb \
+      influxdb
 ```
 
 ### Exposed Ports
@@ -38,7 +38,6 @@ The following ports are important and will be automatically exposed when using `
 Other important ports that aren't exposed by default:
 
 -	8091 Meta service port
--	8088 Clustering (raft) port
 
 These two ports do not need to be exposed in a single server configuration.
 
@@ -58,7 +57,7 @@ Modify the default configuration, which will now be available under `$PWD`. Then
 
 ```console
 $ docker run -p 8083:8083 -p 8086:8086 \
-      -v $PWD:/etc/influxdb:ro \
+      -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
       influxdb -config /etc/influxdb/influxdb.conf
 ```
 
@@ -78,7 +77,15 @@ Find more about configuring InfluxDB [here](https://docs.influxdata.com/influxdb
 
 ### Graphite
 
-InfluxDB supports the Graphite line protocol, but the service and ports are not exposed by default. To run InfluxDB with Graphite support enabled, you can either use a configuration file or set the appropriate environment variables.
+InfluxDB supports the Graphite line protocol, but the service and ports are not exposed by default. To run InfluxDB with Graphite support enabled, you can either use a configuration file or set the appropriate environment variables. Run InfluxDB with the default Graphite configuration:
+
+```console
+docker run -p 8083:8083 -p 8086:8086 \
+    -e INFLUXDB_GRAPHITE_ENABLED=true \
+    influxdb
+```
+
+See the [README on GitHub](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) for more detailed documentation to set up the Graphite service. In order to take advantage of graphite templates, you should use a configuration file by outputting a default configuration file using the steps above and modifying the `[[graphite]]` section.
 
 ### HTTP API
 

--- a/kapacitor/content.md
+++ b/kapacitor/content.md
@@ -29,7 +29,7 @@ Modify `$PWD` to the directory where you want to store data associated with the 
 You can also have Docker control the volume mountpoint by using a named volume.
 
 ```console
-# docker run -p 9092:9092 \
+$ docker run -p 9092:9092 \
       -v kapacitor:/var/lib/kapacitor \
       kapacitor
 ```
@@ -48,8 +48,8 @@ Modify the default configuration, which will now be available under `$PWD`. Then
 
 ```console
 $ docker run -p 9092:9092 \
-      -v $PWD:/etc/kapacitor:ro \
-      kapacitord -config /etc/kapacitor/kapacitor.conf
+      -v $PWD/kapacitor.conf:/etc/kapacitor/kapacitor.conf:ro \
+      kapacitord
 ```
 
 Modify `$PWD` to the directory where you want to store the configuration file.

--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -41,8 +41,10 @@ $ docker run --rm telegraf -sample-config > telegraf.conf
 Once you've customized `telegraf.conf`, you can run the Telegraf container with it mounted in the expected location:
 
 ```console
-$ docker run -v /path/to/telegraf.conf:/etc/telegraf/telegraf.conf:ro telegraf
+$ docker run -v $PWD/telegraf.conf:/etc/telegraf/telegraf.conf:ro telegraf
 ```
+
+Modify `$PWD` to the directory where you want to store the configuration file.
 
 Read more about the Telegraf configuration [here](https://docs.influxdata.com/telegraf/latest/introduction/configuration/).
 
@@ -51,15 +53,14 @@ Read more about the Telegraf configuration [here](https://docs.influxdata.com/te
 These examples assume you are using a custom configuration file that takes advantage of Docker's built-in service discovery capability. In order to do so, we'll first create a new network:
 
 ```console
-$ docker network create telegraf_nw
+$ docker network create influxdb
 ```
 
 Next, we'll start our InfluxDB container named `influxdb`:
 
 ```console
-$ docker run -d --name influxdb \
-      --net=telegraf_nw \
-      -p 8083:8083 -p 8086:8086 \
+$ docker run -d --name=influxdb \
+      --net=influxdb \
       influxdb
 ```
 
@@ -73,11 +74,10 @@ The `telegraf.conf` configuration can now resolve the `influxdb` container by na
 Finally, we start our Telegraf container and verify functionality:
 
 ```console
-$ docker run -d --name telegraf \
-      --net=telegraf_nw \
-      -v /path/to/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
+$ docker run -d --name=telegraf \
+      --net=influxdb \
+      -v $PWD/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
       telegraf
-...
 $ docker logs -f telegraf
 ```
 
@@ -87,7 +87,7 @@ Start an instance of aerospike:
 
 ```console
 $ docker run -d --name aerospike \
-      --net=telegraf_nw \
+      --net=influxdb \
       -p 3000-3003:3000-3003 \
       aerospike
 ```
@@ -123,9 +123,9 @@ Start an Nginx container utilizing it:
 
 ```console
 $ docker run -d --name=nginx \
-      --net=telegraf_nw \
+      --net=influxdb \
       -p 8090:8090 -p 8080:80 \
-      -v /path/to/nginx_status.conf:/etc/nginx/conf.d/nginx_status.conf:ro \
+      -v $PWD/nginx_status.conf:/etc/nginx/conf.d/nginx_status.conf:ro \
       nginx
 ```
 
@@ -151,10 +151,10 @@ Telegraf has a StatsD plugin, allowing Telegraf to run as a StatsD server that m
 Run Telegraf with the UDP port 8125 exposed:
 
 ```console
-$ docker run -d --name telegraf \
-      --net=telegraf_nw \
+$ docker run -d --name=telegraf \
+      --net=influxdb \
       -p 8125:8125/udp \
-      -v /path/to/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
+      -v $PWD/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
       telegraf
 ```
 


### PR DESCRIPTION
Fixing some small inconsistencies between them so now the documentation
is more uniform and all of the commands work correctly and are formatted
the same.