### PR TITLE
Remove excessive complexity from update.sh

### DIFF
--- a/.template-helpers/user-feedback.md
+++ b/.template-helpers/user-feedback.md
@@ -4,7 +4,7 @@ Documentation for this image is stored in the [`%%REPO%%/` directory](https://gi
 
 ## Issues
 
-If you have any problems with or questions about this image, please contact us %%MAILING-LIST%% through a [GitHub issue](%%GITHUB-REPO%%/issues). If the issue is related to a CVE, please check for [a `cve-tracker` issue on the `official-images` repository first](https://github.com/docker-library/official-images/issues?q=label%3Acve-tracker).
+If you have any problems with or questions about this image, please contact us through a [GitHub issue](%%GITHUB-REPO%%/issues). If the issue is related to a CVE, please check for [a `cve-tracker` issue on the `official-images` repository first](https://github.com/docker-library/official-images/issues?q=label%3Acve-tracker).
 
 You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
 
@@ -12,4 +12,4 @@ You can also reach many of the official image maintainers via the `#docker-libra
 
 You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
 
-Before you start to code, we recommend discussing your plans %%MAILING-LIST%% through a [GitHub issue](%%GITHUB-REPO%%/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
+Before you start to code, we recommend discussing your plans through a [GitHub issue](%%GITHUB-REPO%%/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,16 @@ script:
       echo >&2 "Too long (or too many lines):$failed";
       exit 1;
     fi
+  - failed='';
+    for repo in */; do
+      if [ ! -e "$repo/github-repo" ]; then
+        failed+=" $repo";
+      fi
+    done;
+    if [ "$failed" ]; then
+    echo >&2 "Missing github-repo for:$failed";
+      exit 1;
+    fi
   - if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
       if [ "$(git diff --numstat "$TRAVIS_COMMIT_RANGE" -- '*/README.md')" ]; then
         echo >&2 'Error:'' at least one repo README.md has changed';

--- a/README.md
+++ b/README.md
@@ -12,16 +12,23 @@ All Markdown files here are run through [tianon's fork of `markdownfmt`](https:/
 -	create a `README-short.txt` (required, 100 char max)
 -	create a `content.md` (required)
 -	create a `license.md` (required)
+-	create a `github-repo` (required)
 -	add a `logo.png` (recommended)
--	edit `update.sh` as needed (see below)
--	run `./markdownfmt.sh -l myimage` to verify that the format of your markdown files is compliant with `tianon/markdownfmt`. In case you see any file names, markdownfmt detected some issues, which might result in a failed build during continuous integration.
--	optionally run `./update.sh myimage` to generate `myimage/README.md` for review. **Note:** do not actually commit the `README.md` file; it is automatically generated/committed before being uploaded to DockerHub.
+
+Optionally:
+
+-	run `./update.sh myimage` to generate `myimage/README.md` for your review. **Note:** do not actually commit the `README.md` file; it is automatically generated/committed before being uploaded to Docker Hub.
+-	run `./markdownfmt.sh -l myimage` to verify whether format of your markdown files is compliant to `tianon/markdownfmt`. In case you see any file names, markdownfmt detected some issues, which might result in a failed build during continuous integration. run `./markdownfmt.sh -d myimage` to see a diff of changes required to pass.
+
+# How do I update an image's docs
+
+To update `README.md` for a specific image do not edit `README.md` directly. Please edit `content.md` or another appropriate file within the folder. To see the changes, run `./update.sh myimage` from the repo root, but do not add the `README.md` changes to your pull request. See also `markdownfmt.sh` point [above](#how-do-i-add-a-new-images-docs).
 
 # What are all these files?
 
 ## `update.sh`
 
-This is the main script used to generate the `README.md` files for each image. When a new image is added that is not under the `docker-library` namespace on GitHub, a new entry must be added to the `otherRepos` array in this script. Accepted arguments are which image(s) you want to update and no arguments to update all of them.
+This is the main script used to generate the `README.md` files for each image. The generated file is committed along with the files used to generate it (see below on what customizations are available). Accepted arguments are which image(s) you want to update or no arguments to update all of them.
 
 ## `generate-repo-stub-readme.sh`
 
@@ -80,6 +87,14 @@ This file should contain a link to the license for the main software in the imag
 
 ```markdown
 View [license information](http://golang.org/LICENSE) for the software contained in this image.
+```
+
+## `<image name>/github-repo`
+
+This file should contain the URL to the GitHub repository for the Dockerfiles that become the images. The file should be in a single line ending in a newline with no extraneous whitespace. Only one GitHub repo per image repository is supported. It is used in generating links. Here is an example for `golang`:
+
+```text
+https://github.com/docker-library/golang
 ```
 
 ## `<image name>/user-feedback.md`

--- a/README.md
+++ b/README.md
@@ -101,14 +101,6 @@ https://github.com/docker-library/golang
 
 This file is an optional override of the default `user-feedback.md` for those repositories with different issue and contributing policies.
 
-## `<image name>/mailing-list.md`
-
-This file is snippet that gets inserted into the user feedback section to provide and extra way to get help, like a mailing list. Here is an example from the Postgres image:
-
-```markdown
-on the [mailing list](http://www.postgresql.org/community/lists/subscribe/) or
-```
-
 # Issues and Contributing
 
 If you would like to make a new Official Image, be sure to follow the [guidelines](https://docs.docker.com/docker-hub/official_repos/) and optionally talk to officialrepos@docker.com.

--- a/aerospike/github-repo
+++ b/aerospike/github-repo
@@ -1,0 +1,1 @@
+https://github.com/aerospike/aerospike-server.docker

--- a/aerospike/mailing-list.md
+++ b/aerospike/mailing-list.md
@@ -1,1 +1,0 @@
-on the [Aerospike Forums](https://discuss.aerospike.com) or

--- a/aerospike/user-feedback.md
+++ b/aerospike/user-feedback.md
@@ -1,0 +1,15 @@
+## Documentation
+
+Documentation for this image is stored in the [`%%REPO%%/` directory](https://github.com/docker-library/docs/tree/master/%%REPO%%) of the [`docker-library/docs` GitHub repo](https://github.com/docker-library/docs). Be sure to familiarize yourself with the [repository's `README.md` file](https://github.com/docker-library/docs/blob/master/README.md) before attempting a pull request.
+
+## Issues
+
+If you have any problems with or questions about this image, please contact us on the [Aerospike Forums](https://discuss.aerospike.com) or through a [GitHub issue](%%GITHUB-REPO%%/issues). If the issue is related to a CVE, please check for [a `cve-tracker` issue on the `official-images` repository first](https://github.com/docker-library/official-images/issues?q=label%3Acve-tracker).
+
+You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans on the [Aerospike Forums](https://discuss.aerospike.com) or through a [GitHub issue](%%GITHUB-REPO%%/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.

--- a/alpine/github-repo
+++ b/alpine/github-repo
@@ -1,0 +1,1 @@
+https://github.com/gliderlabs/docker-alpine

--- a/arangodb/github-repo
+++ b/arangodb/github-repo
@@ -1,0 +1,1 @@
+https://github.com/arangodb/arangodb-docker

--- a/backdrop/github-repo
+++ b/backdrop/github-repo
@@ -1,0 +1,1 @@
+https://github.com/backdrop-ops/backdrop-docker

--- a/bonita/github-repo
+++ b/bonita/github-repo
@@ -1,0 +1,1 @@
+https://github.com/Bonitasoft-Community/docker_bonita

--- a/buildpack-deps/github-repo
+++ b/buildpack-deps/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/buildpack-deps

--- a/busybox/github-repo
+++ b/busybox/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/busybox

--- a/cassandra/github-repo
+++ b/cassandra/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/cassandra

--- a/celery/github-repo
+++ b/celery/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/celery

--- a/centos/github-repo
+++ b/centos/github-repo
@@ -1,0 +1,1 @@
+https://github.com/CentOS/sig-cloud-instance-images

--- a/centos/mailing-list.md
+++ b/centos/mailing-list.md
@@ -1,1 +1,0 @@
-by submitting a ticket at [https://bugs.centos.org](https://bugs.centos.org) or

--- a/centos/user-feedback.md
+++ b/centos/user-feedback.md
@@ -1,0 +1,15 @@
+## Documentation
+
+Documentation for this image is stored in the [`%%REPO%%/` directory](https://github.com/docker-library/docs/tree/master/%%REPO%%) of the [`docker-library/docs` GitHub repo](https://github.com/docker-library/docs). Be sure to familiarize yourself with the [repository's `README.md` file](https://github.com/docker-library/docs/blob/master/README.md) before attempting a pull request.
+
+## Issues
+
+If you have any problems with or questions about this image, please contact us by submitting a ticket at [https://bugs.centos.org](https://bugs.centos.org) or through a [GitHub issue](%%GITHUB-REPO%%/issues). If the issue is related to a CVE, please check for [a `cve-tracker` issue on the `official-images` repository first](https://github.com/docker-library/official-images/issues?q=label%3Acve-tracker).
+
+You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans by submitting a ticket at [https://bugs.centos.org](https://bugs.centos.org) or through a [GitHub issue](%%GITHUB-REPO%%/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.

--- a/chronograf/github-repo
+++ b/chronograf/github-repo
@@ -1,0 +1,1 @@
+https://github.com/influxdata/chronograf-docker

--- a/cirros/github-repo
+++ b/cirros/github-repo
@@ -1,0 +1,1 @@
+https://github.com/ewindisch/docker-cirros

--- a/clojure/github-repo
+++ b/clojure/github-repo
@@ -1,0 +1,1 @@
+https://github.com/Quantisan/docker-clojure

--- a/consul/github-repo
+++ b/consul/github-repo
@@ -1,0 +1,1 @@
+https://github.com/hashicorp/docker-consul

--- a/couchbase/github-repo
+++ b/couchbase/github-repo
@@ -1,0 +1,1 @@
+https://github.com/couchbase/docker

--- a/couchdb/github-repo
+++ b/couchdb/github-repo
@@ -1,0 +1,1 @@
+https://github.com/klaemo/docker-couchdb

--- a/crate/github-repo
+++ b/crate/github-repo
@@ -1,0 +1,1 @@
+https://github.com/crate/docker-crate

--- a/crux/github-repo
+++ b/crux/github-repo
@@ -1,0 +1,1 @@
+https://github.com/therealprologic/docker-crux

--- a/debian/github-repo
+++ b/debian/github-repo
@@ -1,0 +1,1 @@
+https://github.com/tianon/docker-brew-debian

--- a/django/github-repo
+++ b/django/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/django

--- a/docker-dev/github-repo
+++ b/docker-dev/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker/docker

--- a/docker/github-repo
+++ b/docker/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/docker

--- a/drupal/github-repo
+++ b/drupal/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/drupal

--- a/elasticsearch/github-repo
+++ b/elasticsearch/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/elasticsearch

--- a/elixir/github-repo
+++ b/elixir/github-repo
@@ -1,0 +1,1 @@
+https://github.com/c0b/docker-elixir

--- a/erlang/github-repo
+++ b/erlang/github-repo
@@ -1,0 +1,1 @@
+https://github.com/c0b/docker-erlang-otp

--- a/fedora/github-repo
+++ b/fedora/github-repo
@@ -1,0 +1,1 @@
+https://github.com/lsm5/docker-brew-fedora

--- a/fedora/mailing-list.md
+++ b/fedora/mailing-list.md
@@ -1,1 +1,0 @@
-by filing a bug on [Fedora's bugzilla page](https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora) (choose `docker` as component and include details about image problems in the description) or

--- a/fedora/user-feedback.md
+++ b/fedora/user-feedback.md
@@ -1,0 +1,15 @@
+## Documentation
+
+Documentation for this image is stored in the [`%%REPO%%/` directory](https://github.com/docker-library/docs/tree/master/%%REPO%%) of the [`docker-library/docs` GitHub repo](https://github.com/docker-library/docs). Be sure to familiarize yourself with the [repository's `README.md` file](https://github.com/docker-library/docs/blob/master/README.md) before attempting a pull request.
+
+## Issues
+
+If you have any problems with or questions about this image, please contact us by filing a bug on [Fedora's bugzilla page](https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora) (choose `docker` as component and include details about image problems in the description) or through a [GitHub issue](%%GITHUB-REPO%%/issues). If the issue is related to a CVE, please check for [a `cve-tracker` issue on the `official-images` repository first](https://github.com/docker-library/official-images/issues?q=label%3Acve-tracker).
+
+You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans by filing a bug on [Fedora's bugzilla page](https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora) (choose `docker` as component and include details about image problems in the description) or through a [GitHub issue](%%GITHUB-REPO%%/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.

--- a/gazebo/github-repo
+++ b/gazebo/github-repo
@@ -1,0 +1,1 @@
+https://github.com/osrf/docker_images

--- a/gcc/github-repo
+++ b/gcc/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/gcc

--- a/ghost/github-repo
+++ b/ghost/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/ghost

--- a/glassfish/github-repo
+++ b/glassfish/github-repo
@@ -1,0 +1,1 @@
+https://github.com/aws/aws-eb-glassfish

--- a/golang/github-repo
+++ b/golang/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/golang

--- a/haproxy/github-repo
+++ b/haproxy/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/haproxy

--- a/haskell/github-repo
+++ b/haskell/github-repo
@@ -1,0 +1,1 @@
+https://github.com/freebroccolo/docker-haskell

--- a/hello-world/github-repo
+++ b/hello-world/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/hello-world

--- a/hipache/github-repo
+++ b/hipache/github-repo
@@ -1,0 +1,1 @@
+https://github.com/dotcloud/hipache

--- a/httpd/github-repo
+++ b/httpd/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/httpd

--- a/hylang/github-repo
+++ b/hylang/github-repo
@@ -1,0 +1,1 @@
+https://github.com/hylang/hy

--- a/influxdb/github-repo
+++ b/influxdb/github-repo
@@ -1,0 +1,1 @@
+https://github.com/influxdata/influxdb-docker

--- a/iojs/github-repo
+++ b/iojs/github-repo
@@ -1,0 +1,1 @@
+https://github.com/nodejs/docker-iojs

--- a/irssi/github-repo
+++ b/irssi/github-repo
@@ -1,0 +1,1 @@
+https://github.com/jfrazelle/irssi

--- a/java/github-repo
+++ b/java/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/java

--- a/jenkins/github-repo
+++ b/jenkins/github-repo
@@ -1,0 +1,1 @@
+https://github.com/cloudbees/jenkins-ci.org-docker

--- a/jetty/github-repo
+++ b/jetty/github-repo
@@ -1,0 +1,1 @@
+https://github.com/appropriate/docker-jetty

--- a/joomla/github-repo
+++ b/joomla/github-repo
@@ -1,0 +1,1 @@
+https://github.com/joomla/docker-joomla

--- a/jruby/github-repo
+++ b/jruby/github-repo
@@ -1,0 +1,1 @@
+https://github.com/cpuguy83/docker-jruby

--- a/julia/github-repo
+++ b/julia/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/julia

--- a/kaazing-gateway/github-repo
+++ b/kaazing-gateway/github-repo
@@ -1,0 +1,1 @@
+https://github.com/kaazing/gateway.docker

--- a/kapacitor/github-repo
+++ b/kapacitor/github-repo
@@ -1,0 +1,1 @@
+https://github.com/influxdata/kapacitor-docker

--- a/kibana/github-repo
+++ b/kibana/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/kibana

--- a/lightstreamer/github-repo
+++ b/lightstreamer/github-repo
@@ -1,0 +1,1 @@
+https://github.com/Lightstreamer/Docker

--- a/logstash/github-repo
+++ b/logstash/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/logstash

--- a/mageia/github-repo
+++ b/mageia/github-repo
@@ -1,0 +1,1 @@
+https://github.com/juanluisbaptiste/docker-brew-mageia

--- a/mariadb/github-repo
+++ b/mariadb/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/mariadb

--- a/maven/github-repo
+++ b/maven/github-repo
@@ -1,0 +1,1 @@
+https://github.com/carlossg/docker-maven

--- a/memcached/github-repo
+++ b/memcached/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/memcached

--- a/mongo-express/github-repo
+++ b/mongo-express/github-repo
@@ -1,0 +1,1 @@
+https://github.com/mongo-express/mongo-express-docker

--- a/mongo/github-repo
+++ b/mongo/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/mongo

--- a/mono/github-repo
+++ b/mono/github-repo
@@ -1,0 +1,1 @@
+https://github.com/mono/docker

--- a/mysql/github-repo
+++ b/mysql/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/mysql

--- a/nats/github-repo
+++ b/nats/github-repo
@@ -1,0 +1,1 @@
+https://github.com/nats-io/nats-docker

--- a/neo4j/github-repo
+++ b/neo4j/github-repo
@@ -1,0 +1,1 @@
+https://github.com/neo4j/docker-neo4j

--- a/neurodebian/github-repo
+++ b/neurodebian/github-repo
@@ -1,0 +1,1 @@
+https://github.com/neurodebian/dockerfiles

--- a/nginx/github-repo
+++ b/nginx/github-repo
@@ -1,0 +1,1 @@
+https://github.com/nginxinc/docker-nginx

--- a/node/github-repo
+++ b/node/github-repo
@@ -1,0 +1,1 @@
+https://github.com/nodejs/docker-node

--- a/notary/github-repo
+++ b/notary/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker/notary-official-images

--- a/nuxeo/github-repo
+++ b/nuxeo/github-repo
@@ -1,0 +1,1 @@
+https://github.com/nuxeo/docker-nuxeo

--- a/odoo/github-repo
+++ b/odoo/github-repo
@@ -1,0 +1,1 @@
+https://github.com/odoo/docker

--- a/opensuse/github-repo
+++ b/opensuse/github-repo
@@ -1,0 +1,1 @@
+https://github.com/openSUSE/docker-containers-build

--- a/oraclelinux/github-repo
+++ b/oraclelinux/github-repo
@@ -1,0 +1,1 @@
+https://github.com/oracle/docker

--- a/orientdb/github-repo
+++ b/orientdb/github-repo
@@ -1,0 +1,1 @@
+https://github.com/orientechnologies/orientdb-docker

--- a/owncloud/github-repo
+++ b/owncloud/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/owncloud

--- a/percona/github-repo
+++ b/percona/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/percona

--- a/perl/github-repo
+++ b/perl/github-repo
@@ -1,0 +1,1 @@
+https://github.com/Perl/docker-perl

--- a/photon/github-repo
+++ b/photon/github-repo
@@ -1,0 +1,1 @@
+https://github.com/frapposelli/photon-docker-image

--- a/php-zendserver/github-repo
+++ b/php-zendserver/github-repo
@@ -1,0 +1,1 @@
+https://github.com/zendtech/php-zendserver-docker

--- a/php/github-repo
+++ b/php/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/php

--- a/piwik/github-repo
+++ b/piwik/github-repo
@@ -1,0 +1,1 @@
+https://github.com/piwik/docker-piwik

--- a/postgres/github-repo
+++ b/postgres/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/postgres

--- a/postgres/mailing-list.md
+++ b/postgres/mailing-list.md
@@ -1,1 +1,0 @@
-on the [mailing list](http://www.postgresql.org/community/lists/subscribe/) or

--- a/postgres/user-feedback.md
+++ b/postgres/user-feedback.md
@@ -1,0 +1,15 @@
+## Documentation
+
+Documentation for this image is stored in the [`%%REPO%%/` directory](https://github.com/docker-library/docs/tree/master/%%REPO%%) of the [`docker-library/docs` GitHub repo](https://github.com/docker-library/docs). Be sure to familiarize yourself with the [repository's `README.md` file](https://github.com/docker-library/docs/blob/master/README.md) before attempting a pull request.
+
+## Issues
+
+If you have any problems with or questions about this image, please contact us on the [mailing list](http://www.postgresql.org/community/lists/subscribe/) or through a [GitHub issue](%%GITHUB-REPO%%/issues). If the issue is related to a CVE, please check for [a `cve-tracker` issue on the `official-images` repository first](https://github.com/docker-library/official-images/issues?q=label%3Acve-tracker).
+
+You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans on the [mailing list](http://www.postgresql.org/community/lists/subscribe/) or through a [GitHub issue](%%GITHUB-REPO%%/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.

--- a/pypy/github-repo
+++ b/pypy/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/pypy

--- a/python/github-repo
+++ b/python/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/python

--- a/r-base/github-repo
+++ b/r-base/github-repo
@@ -1,0 +1,1 @@
+https://github.com/rocker-org/rocker

--- a/rabbitmq/github-repo
+++ b/rabbitmq/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/rabbitmq

--- a/rails/github-repo
+++ b/rails/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/rails

--- a/rakudo-star/github-repo
+++ b/rakudo-star/github-repo
@@ -1,0 +1,1 @@
+https://github.com/perl6/docker

--- a/redis/github-repo
+++ b/redis/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/redis

--- a/redmine/github-repo
+++ b/redmine/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/redmine

--- a/registry/github-repo
+++ b/registry/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker/docker-registry

--- a/rethinkdb/github-repo
+++ b/rethinkdb/github-repo
@@ -1,0 +1,1 @@
+https://github.com/stuartpb/rethinkdb-dockerfiles

--- a/rocket.chat/github-repo
+++ b/rocket.chat/github-repo
@@ -1,0 +1,1 @@
+https://github.com/RocketChat/Docker.Official.Image

--- a/ros/github-repo
+++ b/ros/github-repo
@@ -1,0 +1,1 @@
+https://github.com/osrf/docker_images

--- a/ruby/github-repo
+++ b/ruby/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/ruby

--- a/sentry/github-repo
+++ b/sentry/github-repo
@@ -1,0 +1,1 @@
+https://github.com/getsentry/docker-sentry

--- a/solr/github-repo
+++ b/solr/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-solr/docker-solr

--- a/sonarqube/github-repo
+++ b/sonarqube/github-repo
@@ -1,0 +1,1 @@
+https://github.com/SonarSource/docker-sonarqube

--- a/sourcemage/github-repo
+++ b/sourcemage/github-repo
@@ -1,0 +1,1 @@
+https://github.com/vaygr/docker-sourcemage

--- a/swarm/github-repo
+++ b/swarm/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker/swarm-library-image

--- a/telegraf/github-repo
+++ b/telegraf/github-repo
@@ -1,0 +1,1 @@
+https://github.com/influxdata/telegraf-docker

--- a/thrift/github-repo
+++ b/thrift/github-repo
@@ -1,0 +1,1 @@
+https://github.com/ahawkins/docker-thrift

--- a/tomcat/github-repo
+++ b/tomcat/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/tomcat

--- a/tomee/github-repo
+++ b/tomee/github-repo
@@ -1,0 +1,1 @@
+https://github.com/tomitribe/docker-tomee

--- a/traefik/github-repo
+++ b/traefik/github-repo
@@ -1,0 +1,1 @@
+https://github.com/containous/traefik-library-image

--- a/ubuntu-debootstrap/github-repo
+++ b/ubuntu-debootstrap/github-repo
@@ -1,0 +1,1 @@
+https://github.com/tianon/docker-brew-ubuntu-debootstrap

--- a/ubuntu-upstart/github-repo
+++ b/ubuntu-upstart/github-repo
@@ -1,0 +1,1 @@
+https://github.com/tianon/dockerfiles

--- a/ubuntu/github-repo
+++ b/ubuntu/github-repo
@@ -1,0 +1,1 @@
+https://github.com/tianon/docker-brew-ubuntu-core

--- a/update.sh
+++ b/update.sh
@@ -113,9 +113,6 @@ for repo in "${repos[@]}"; do
 		echo '  USER-FEEDBACK => '"$repo"'/user-feedback.md'
 		replace_field "$repo" 'USER-FEEDBACK' "$userFeedback"
 		
-		echo '  MAILING-LIST => '"$repo"'/mailing-list.md'
-		replace_field "$repo" 'MAILING-LIST' "$mailingList" '\s*'
-		
 		echo '  REPO => "'"$repo"'"'
 		replace_field "$repo" 'REPO' "$repo"
 		

--- a/update.sh
+++ b/update.sh
@@ -20,75 +20,6 @@ replace_field() {
 	sed -ri "s/${extraSed}%%${field}%%${extraSed}/$sed_escaped_value/g" "$repo/README.md"
 }
 
-declare -A otherRepos=(
-	[aerospike]='https://github.com/aerospike/aerospike-server.docker'
-	[alpine]='https://github.com/gliderlabs/docker-alpine'
-	[arangodb]='https://github.com/arangodb/arangodb-docker'
-	[backdrop]='https://github.com/backdrop-ops/backdrop-docker'
-	[bonita]='https://github.com/Bonitasoft-Community/docker_bonita'
-	[centos]='https://github.com/CentOS/sig-cloud-instance-images'
-	[chronograf]='https://github.com/influxdata/chronograf-docker'
-	[cirros]='https://github.com/ewindisch/docker-cirros'
-	[clojure]='https://github.com/Quantisan/docker-clojure'
-	[consul]='https://github.com/hashicorp/docker-consul'
-	[crate]='https://github.com/crate/docker-crate'
-	[crux]='https://github.com/therealprologic/docker-crux'
-	[debian]='https://github.com/tianon/docker-brew-debian'
-	[docker-dev]='https://github.com/docker/docker'
-	[elixir]='https://github.com/c0b/docker-elixir'
-	[erlang]='https://github.com/c0b/docker-erlang-otp'
-	[fedora]='https://github.com/lsm5/docker-brew-fedora'
-	[gazebo]='https://github.com/osrf/docker_images'
-	[glassfish]='https://github.com/aws/aws-eb-glassfish'
-	[haskell]='https://github.com/freebroccolo/docker-haskell'
-	[hipache]='https://github.com/dotcloud/hipache'
-	[hylang]='https://github.com/hylang/hy'
-	[influxdb]='https://github.com/influxdata/influxdb-docker'
-	[iojs]='https://github.com/nodejs/docker-iojs'
-	[irssi]='https://github.com/jfrazelle/irssi'
-	[jenkins]='https://github.com/cloudbees/jenkins-ci.org-docker'
-	[jetty]='https://github.com/appropriate/docker-jetty'
-	[joomla]='https://github.com/joomla/docker-joomla'
-	[jruby]='https://github.com/cpuguy83/docker-jruby'
-	[kaazing-gateway]='https://github.com/kaazing/gateway.docker'
-	[kapacitor]='https://github.com/influxdata/kapacitor-docker'
-	[lightstreamer]='https://github.com/Lightstreamer/Docker'
-	[mageia]='https://github.com/juanluisbaptiste/docker-brew-mageia'
-	[maven]='https://github.com/carlossg/docker-maven'
-	[mongo-express]='https://github.com/mongo-express/mongo-express-docker'
-	[mono]='https://github.com/mono/docker'
-	[neo4j]='https://github.com/neo4j/docker-neo4j'
-	[neurodebian]='https://github.com/neurodebian/dockerfiles'
-	[nginx]='https://github.com/nginxinc/docker-nginx'
-	[node]='https://github.com/nodejs/docker-node'
-	[nuxeo]='https://github.com/nuxeo/docker-nuxeor'
-	[odoo]='https://github.com/odoo/docker'
-	[opensuse]='https://github.com/openSUSE/docker-containers-build'
-	[oraclelinux]='https://github.com/oracle/docker'
-	[orientdb]='https://github.com/orientechnologies/orientdb-docker'
-	[perl]='https://github.com/Perl/docker-perl'
-	[photon]='https://github.com/frapposelli/photon-docker-image'
-	[piwik]='https://github.com/piwik/docker-piwik'
-	[r-base]='https://github.com/rocker-org/rocker'
-	[rakudo]='https://github.com/perl6/docker'
-	[registry]='https://github.com/docker/docker-registry'
-	[rethinkdb]='https://github.com/stuartpb/rethinkdb-dockerfiles'
-	[rocket.chat]='https://github.com/RocketChat/Docker.Official.Image'
-	[ros]='https://github.com/osrf/docker_images'
-	[sentry]='https://github.com/getsentry/docker-sentry'
-	[solr]='https://github.com/docker-solr/solr'
-	[sonarqube]='https://github.com/SonarSource/docker-sonarqube'
-	[sourcemage]='https://github.com/vaygr/docker-sourcemage'
-	[swarm]='https://github.com/docker/swarm-library-image'
-	[telegraf]='https://github.com/influxdata/telegraf-docker'
-	[thrift]='https://github.com/ahawkins/docker-thrift'
-	[traefik]='https://github.com/containous/traefik-library-image'
-	[ubuntu-debootstrap]='https://github.com/tianon/docker-brew-ubuntu-debootstrap'
-	[ubuntu-upstart]='https://github.com/tianon/dockerfiles'
-	[ubuntu]='https://github.com/tianon/docker-brew-ubuntu-core'
-	[websphere-liberty]='https://github.com/WASdev/ci.docker'
-)
-
 dockerLatest="$(curl -fsSL 'https://get.docker.com/latest')"
 
 for repo in "${repos[@]}"; do
@@ -97,10 +28,7 @@ for repo in "${repos[@]}"; do
 	fi
 	
 	if [ -e "$repo/content.md" ]; then
-		gitRepo="${otherRepos[$repo]}"
-		if [ -z "$gitRepo" ]; then
-			gitRepo="https://github.com/docker-library/$repo"
-		fi
+		githubRepo="$(cat "$repo/github-repo")"
 		
 		mailingList="$(cat "$repo/mailing-list.md" 2>/dev/null || true)"
 		if [ "$mailingList" ]; then
@@ -191,8 +119,8 @@ for repo in "${repos[@]}"; do
 		echo '  REPO => "'"$repo"'"'
 		replace_field "$repo" 'REPO' "$repo"
 		
-		echo '  GITHUB-REPO => "'"$gitRepo"'"'
-		replace_field "$repo" 'GITHUB-REPO' "$gitRepo"
+		echo '  GITHUB-REPO => "'"$githubRepo"'"'
+		replace_field "$repo" 'GITHUB-REPO' "$githubRepo"
 		
 		echo
 	else

--- a/websphere-liberty/github-repo
+++ b/websphere-liberty/github-repo
@@ -1,0 +1,1 @@
+https://github.com/WASdev/ci.docker

--- a/wordpress/github-repo
+++ b/wordpress/github-repo
@@ -1,0 +1,1 @@
+https://github.com/docker-library/wordpress


### PR DESCRIPTION
- remove `otherRepos` array from update.sh to be a file within each image folder
  - removes the need to edit update.sh on new images; keeps an image self-contained within its folder
- drop `mailing-list` support since we already have `user-feedback.md`
