### PR TITLE
Update registry repo github url

### DIFF
--- a/registry/github-repo
+++ b/registry/github-repo
@@ -1,1 +1,1 @@
-https://github.com/docker/docker-registry
+https://github.com/docker/distribution-library-image


### PR DESCRIPTION
This is still pointing to the old `docker/registry` repo.

@RichardScothern, is `docker/distribution-library-image` the correct repo for users to file issues that they have with the registry image or would `https://github.com/docker/distribution` be better?