### PR TITLE
Update apk install pattern to use `--no-cache'

### DIFF
--- a/alpine/content.md
+++ b/alpine/content.md
@@ -11,8 +11,8 @@
 Use like you would any other base image:
 
 ```dockerfile
-FROM alpine:3.1
-RUN apk add --update mysql-client && rm -rf /var/cache/apk/*
+FROM alpine:3.3
+RUN apk add --no-cache mysql-client
 ENTRYPOINT ["mysql"]
 ```
 


### PR DESCRIPTION
This way there's no need to delete `/var/cache/apk`, leading to a cleaner Dockerfile.
Supported since alpine 3.3, hence the change from 3.1.

Let me know if there's something else to be done.

Related: https://github.com/gliderlabs/docker-alpine/blob/f93486d/docs/usage.md#disabling-cache