### PR TITLE
Change Docker-in-Docker README perspective

### DIFF
--- a/docker/content.md
+++ b/docker/content.md
@@ -1,16 +1,23 @@
-# What is Docker?
+# What is Docker in Docker?
 
-Docker is an open-source project that automates the deployment of applications inside software containers, by providing an additional layer of abstraction and automation of operating-system-level virtualization on Linux, Mac OS and Windows.
+Although running Docker inside Docker is generally not recommended, there are some legitimate use cases, such as
+developing Docker itself.
+
+_Docker is an open-source project that automates the deployment of applications inside software containers, by providing an additional layer of abstraction and automation of operating-system-level virtualization on Linux, Mac OS and Windows._
 
 > [wikipedia.org/wiki/Docker_(software)](https://en.wikipedia.org/wiki/Docker_%28software%29)
 
 %%LOGO%%
 
+Before running Docker-in-Docker, be sure to read through [Jérôme Petazzoni's excellent blog post on the subject](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/), where he outlines some of the pros and cons of doing so (and some nasty gotchas you might run into).
+
+If you are still convinced that you need Docker-in-Docker and not just access to a container's host Docker server, then read on.
+
 # How to use this image
 
 [![asciicast](https://asciinema.org/a/24707.png)](https://asciinema.org/a/24707)
 
-## start a daemon instance
+## Start a daemon instance
 
 ```console
 $ docker run --privileged --name some-docker -d docker:1.8-dind
@@ -20,9 +27,7 @@ $ docker run --privileged --name some-docker -d docker:1.8-dind
 
 This image includes `EXPOSE 2375` (the Docker port), so standard container linking will make it automatically available to the linked containers (as the following examples illustrate).
 
-Before running Docker-in-Docker, be sure to read through [Jérôme Petazzoni's excellent blog post on the subject](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/), where he outlines some of the pros and cons of doing so (and some nasty gotchas you might run into).
-
-## connect to it from a second container
+## Connect to it from a second container
 
 ```console
 $ docker run --rm --link some-docker:docker docker:1.7 version
@@ -79,7 +84,7 @@ WARNING: bridge-nf-call-ip6tables is disabled
 $ docker run --rm --link some-docker:docker docker:git build https://github.com/docker-library/hello-world.git
 Sending build context to Docker daemon 132.1 kB
 Step 0 : FROM scratch
- ---> 
+ --->
 Step 1 : COPY hello /
  ---> 29bef505052d
 Removing intermediate container f98aab888906
@@ -109,7 +114,7 @@ Server:
  OS/Arch:      linux/amd64
 ```
 
-## custom daemon flags
+## Custom daemon flags
 
 ```console
 $ docker run --privileged --name some-devicemapper-docker -d docker:dind --storage-driver=devicemapper


### PR DESCRIPTION
I'm not even a newcomer to DinD and I found the READEME, coupled
with Jérôme's blog post, confusing.

Firstly, the README doesn't make explicit the oddity of having a
Docker image of Docker - I think that Elephant In The Room
needs to be acknowledged straight away.

Secondly, Jérôme's blog post concludes with a single, unambiguous
solution - simply mount the host's Docker socket inside.
Personally, I feel that strongly imlpies that that is in fact
what DinD has now officially become - a means to create sibling
contianers, rather than child containers. However, that is not
what the DinD image here does and despite the warnigns in the blog
post DinD is actively maintained.

I have attempted to make the README more obvious and explicit for
first time readers. I'd also argue that the blog post could
benefit similarly.

I would also like to see a clarification of the differences
between the vanilla, git and dind flavours.

To give some background - I am currently looking at using the DinD driver for Docker Machine, so that I can run Swarm integration tests on Travis.