### PR TITLE
Odoo: force postgres version in docker command line

### DIFF
--- a/odoo/content.md
+++ b/odoo/content.md
@@ -13,7 +13,7 @@ This image requires a running PostgreSQL server.
 ## Start a PostgreSQL server
 
 ```console
-$ docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo --name db postgres
+$ docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo --name db postgres:9.4
 ```
 
 ## Start an Odoo instance


### PR DESCRIPTION
The odoo docker image is based on debian:jessie, which only has
postgresql-client-9.4, while the official postgres docker
has 9.5 server. This causes a version mismatch and errors when using the
postgres command-line tools, such as `pg_dump`.

Thanks!

Fixes odoo/odoo#12275
Fixes odoo/docker#49
Fixes odoo/docker#54
Fixes odoo/docker#59