### PR TITLE
Fix rethinkdb/rethinkdb-dockerfiles#31

### DIFF
--- a/rethinkdb/github-repo
+++ b/rethinkdb/github-repo
@@ -1,1 +1,1 @@
-https://github.com/stuartpb/rethinkdb-dockerfiles
+https://github.com/rethinkdb/rethinkdb-dockerfiles


### PR DESCRIPTION
The move to the official RethinkDB organization wasn't previously reflected in the docs.