### PR TITLE
Improvements to owncloud's docker-compose.yml

### DIFF
--- a/owncloud/docker-compose.yml
+++ b/owncloud/docker-compose.yml
@@ -1,14 +1,21 @@
-# access via "http://localhost:8080" (or "http://$(docker-machine ip):8080" if using docker-machine)
-# during initial setup, use "mysql" as the MySQL hostname
+# ownCloud with MariaDB
+#
+# Access via "http://localhost:8080" (or "http://$(docker-machine ip):8080" if using docker-machine)
+#
+# During initial ownCloud setup, select "Storage & database" --> "Configure the database" --> "MySQL/MariaDB"
+# Database user: root
+# Database password: my-database-password
+# Database name: pick any name
+# Database host: replace "localhost" with owncloud_db 
 
 owncloud:
-  image: owncloud
+  image: owncloud:9
   links:
-    - db:mysql
+    - owncloud_db
   ports:
     - 8080:80
 
-db:
+owncloud_db:
   image: mariadb
   environment:
-    MYSQL_ROOT_PASSWORD: example
+    MYSQL_ROOT_PASSWORD: my-database-password


### PR DESCRIPTION
* Given that the ownCloud setup steps are closely dependent on the settings in the `docker-compose.yml` file, it's very helpful to show the links between the two in the top comments. 
* `mysql` was a bit of a misleading name for a link alias, specifying a link alias is unnecessary and might cause confusion. 
* Specify an owncloud image tag, as setup steps for future ownCloud versions might be incompatible with current compose file.