### PR TITLE
Convert wordpress example "docker-compose.yml" to version 2

### DIFF
--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -1,11 +1,15 @@
-wordpress:
-  image: wordpress
-  links:
-    - db:mysql
-  ports:
-    - 8080:80
+version: '2'
 
-db:
-  image: mariadb
-  environment:
-    MYSQL_ROOT_PASSWORD: example
+services:
+
+  wordpress:
+    image: wordpress
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_PASSWORD: example
+
+  mysql:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: example


### PR DESCRIPTION
Closes #532

Made possible by https://github.com/docker-library/wordpress/pull/144.