### PR TITLE
[postgres] Update link to point to latest stable (9.5) docs

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -19,7 +19,7 @@ $ docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postg
 This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
 
 > The postgres database is a default database meant for use by users, utilities and third party applications.  
-> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.5/interactive/app-initdb.html)
 
 ## connect to it from an application
 


### PR DESCRIPTION
There does not seem to be any difference in this particular page, but I thought it might make sense to link to the latest stable docs anyway.