### PR TITLE
Remove broken imagelayers badges

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -31,22 +31,3 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 {{- end -}}
 
 {{- "\n\n" -}}
-
-[![](
-	{{- "https://badge.imagelayers.io/" -}}
-
-	{{- /* either "repo:latest" or "repo:first-tag" */ -}}
-	{{- printf "%s:%s" .RepoName (.Manifest.GetTag "latest" | ternary "latest" ((.Entries | first).Tags | first)) -}}
-
-	{{- ".svg" -}}
-)](
-	{{- "https://imagelayers.io/?images=" -}}
-
-	{{- /* list all "repo:tag" combinations, comma separated */ -}}
-	{{- range $i, $e := $.Entries -}}
-		{{- if $i -}} , {{- end -}}
-		{{- printf "%s:%s" $.RepoName ($e.Tags | first) -}}
-	{{- end -}}
-)
-
-{{- "\n\n" -}}


### PR DESCRIPTION
It would appear that CenturyLinkLabs has no interest in updating ImageLayers for v2 images, and thus no longer loads our images. :cry: