### PR TITLE
Crate: Updated docs to reflect config file changes

### DIFF
--- a/crate/content.md
+++ b/crate/content.md
@@ -69,19 +69,13 @@ Crate stores all important data in */data*. It's advised to mount this directory
 
 ## Use Custom Crate Configuration
 
-Crate is controlled by a single configuration file which has sensible defaults already. If you derive your container from the Crate container, make sure to place your file inside it and let Crate know where to find it:
+Starting with 0.55.0, Crate does no longer support providing custom configuration files. However it is still possible to mount Crate's configuration into `/crate/config/crate.yml`.
 
 ```console
-# docker run -d crate crate -Des.config=</path/to>/crate.yml
+# docker run -d -v <custom/config/path>/crate.yml:/crate/config/crate.yml crate crate
 ```
 
-Other configuration settings may be specified upon startup using the `-D` option prefix. For example, configuring the cluster name by using system properties works like this:
-
-```console
-# docker run -d crate crate -Des.cluster.name=<my-cluster-name>
-```
-
-For further configuration options refer to the [Configuration](https://crate.io/docs/stable/configuration.html) section of our documentation.
+For further configuration options refer to the[Configuration](https://crate.io/docs/stable/configuration.html) section of our documentation.
 
 ## Environment
 


### PR DESCRIPTION
Updated the docs to remove deprecated bits of documentation. ES 2.X disallows having custom configuration paths, and so do we.

Cheers, Claus