### PR TITLE
Add info to Ghost about finding Node Version

### DIFF
--- a/ghost/README.md
+++ b/ghost/README.md
@@ -42,6 +42,20 @@ Alternatively you can use a [data container](http://docs.docker.com/userguide/do
 $ docker run --name some-ghost --volumes-from some-ghost-data ghost
 ```
 
+# What is the node version?
+
+This information is a needed when you want to open a ticket over https://github.com/TryGhost/Ghost/issues. The version is going to vary as the node:4-slim tag is updated. To find the version...
+
+Log into the container
+
+```docker exec -it <container-id> bash```
+
+Then run:
+
+```node --version```
+
+The output should looks like: `v4.4.7`
+
 # Supported Docker versions
 
 This image is officially supported on Docker version 1.12.0.

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -42,20 +42,6 @@ Alternatively you can use a [data container](http://docs.docker.com/userguide/do
 $ docker run --name some-ghost --volumes-from some-ghost-data ghost
 ```
 
-# What is the node version?
-
-This information is a needed when you want to open a ticket over https://github.com/TryGhost/Ghost/issues. The version is going to vary as the node:4-slim tag is updated. To find the version...
-
-Log into the container
-
-```docker exec -it <container-id> bash```
-
-Then run:
-
-```node --version```
-
-The output should looks like: `v4.4.7`
-
 # Supported Docker versions
 
 This image is officially supported on Docker version 1.12.0.

--- a/ghost/content.md
+++ b/ghost/content.md
@@ -33,3 +33,12 @@ Alternatively you can use a [data container](http://docs.docker.com/userguide/do
 ```console
 $ docker run --name some-ghost --volumes-from some-ghost-data ghost
 ```
+
+# What is the Node.js version?
+
+When opening a ticket at https://github.com/TryGhost/Ghost/issues it becomes necessary to know the version of Node.js in use:
+
+```console
+$ docker exec <container-id> node --version
+v4.4.7
+```


### PR DESCRIPTION
Closes #663 (carried/squashed commits in e2f651d)

cc @pascalandy

`*/README.md` are generated from `*/content.md` :+1: