### PR TITLE
Update README.md

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -57,7 +57,7 @@ $ docker run -d --name my-running-haproxy my-haproxy
 ## Directly via bind mount
 
 ```console
-$ docker run -d --name my-running-haproxy -v /path/to/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro haproxy:1.5
+$ docker run -d --name my-running-haproxy -v /path/to/etc/haproxy:/usr/local/etc/haproxy:ro haproxy:1.5
 ```
 
 ### Reloading config


### PR DESCRIPTION
When mounting a volume for HAProxy's configuration, make the entire haproxy configuration directory available. This way, if the `haproxy.cfg` file is re-written, HAProxy can pick up the new file.