### PR TITLE
Mount the /etc/haproxy dir instead of the file

### DIFF
--- a/haproxy/content.md
+++ b/haproxy/content.md
@@ -44,7 +44,7 @@ $ docker run -d --name my-running-haproxy my-haproxy
 ## Directly via bind mount
 
 ```console
-$ docker run -d --name my-running-haproxy -v /path/to/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro haproxy:1.5
+$ docker run -d --name my-running-haproxy -v /path/to/etc/haproxy:/usr/local/etc/haproxy:ro haproxy:1.5
 ```
 
 ### Reloading config

--- a/haproxy/content.md
+++ b/haproxy/content.md
@@ -43,6 +43,8 @@ $ docker run -d --name my-running-haproxy my-haproxy
 
 ## Directly via bind mount
 
+Note that your host's `/path/to/etc/haproxy` folder should be populated with an `haproxy.cfg` configuration file. If this configuration file refers to any other files within that folder then you should ensure that they also exist e.g. template files such as `400.http`, `404.http` and so forth. Quite often `haproxy.cfg` does not require a supporting file though given a minimal configuration.
+
 ```console
 $ docker run -d --name my-running-haproxy -v /path/to/etc/haproxy:/usr/local/etc/haproxy:ro haproxy:1.5
 ```


### PR DESCRIPTION
When mounting a volume for HAProxy's configuration, make the entire haproxy configuration directory available. This way, if the haproxy.cfg file is re-written, HAProxy can pick up the new file.
