### PR TITLE
hello.asm -> hello.c

### DIFF
--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -41,7 +41,7 @@ hello-world  latest  c54a2cc56cbb  1.848 kB
 
 # How is this image created?
 
-This image is a prime example of using the [`scratch`](https://registry.hub.docker.com/_/scratch/) image effectively. See [`hello.asm`](https://github.com/docker-library/hello-world/blob/master/hello.asm) in https://github.com/docker-library/hello-world for the source code of the `hello` binary included in this image.
+This image is a prime example of using the [`scratch`](https://registry.hub.docker.com/_/scratch/) image effectively. See [`hello.asm`](https://github.com/docker-library/hello-world/blob/master/hello.c) in https://github.com/docker-library/hello-world for the source code of the `hello` binary included in this image.
 
 # Supported Docker versions
 

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -41,7 +41,7 @@ hello-world  latest  c54a2cc56cbb  1.848 kB
 
 # How is this image created?
 
-This image is a prime example of using the [`scratch`](https://registry.hub.docker.com/_/scratch/) image effectively. See [`hello.asm`](https://github.com/docker-library/hello-world/blob/master/hello.c) in https://github.com/docker-library/hello-world for the source code of the `hello` binary included in this image.
+This image is a prime example of using the [`scratch`](https://registry.hub.docker.com/_/scratch/) image effectively. See [`hello.c`](https://github.com/docker-library/hello-world/blob/master/hello.c) in https://github.com/docker-library/hello-world for the source code of the `hello` binary included in this image.
 
 # Supported Docker versions
 


### PR DESCRIPTION
Just put small adjustment found when reading docker docs
(current version of repo contains hello.c file, not hello.asm as it was changed to C)