### PR TITLE
Remove unused email alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ This file is an optional override of the default `user-feedback.md` for those re
 
 # Issues and Contributing
 
-If you would like to make a new Official Image, be sure to follow the [guidelines](https://docs.docker.com/docker-hub/official_repos/) and optionally talk to officialrepos@docker.com.
+If you would like to make a new Official Image, be sure to follow the [guidelines](https://docs.docker.com/docker-hub/official_repos/).
 
 Feel free to make a pull request for fixes and improvements to current documentation. For questions or problems on this repo come talk to us via the `#docker-library` IRC channel on [Freenode](https://freenode.net) or open up an issue.


### PR DESCRIPTION
Also removed from the private repo behind docs.docker.com (though not published yet at the time of writing).