### PR TITLE
Added the "-it" options to some docs examples for jenkins

### DIFF
--- a/jenkins/content.md
+++ b/jenkins/content.md
@@ -11,13 +11,13 @@ For weekly releases check out [`jenkinsci/jenkins`](https://hub.docker.com/r/jen
 # How to use this image
 
 ```console
-docker run -p 8080:8080 -p 50000:50000 jenkins
+docker run -it -p 8080:8080 -p 50000:50000 jenkins
 ```
 
 This will store the workspace in /var/jenkins_home. All Jenkins data lives in there - including plugins and configuration. You will probably want to make that a persistent volume (recommended):
 
 ```console
-docker run -p 8080:8080 -p 50000:50000 -v /your/home:/var/jenkins_home jenkins
+docker run -it -p 8080:8080 -p 50000:50000 -v /your/home:/var/jenkins_home jenkins
 ```
 
 This will store the jenkins data in `/your/home` on the host. Ensure that `/your/home` is accessible by the jenkins user in container (jenkins user - uid 1000) or use `-u some_other_user` parameter with `docker run`.
@@ -25,7 +25,7 @@ This will store the jenkins data in `/your/home` on the host. Ensure that `/your
 You can also use a volume container:
 
 ```console
-docker run --name myjenkins -p 8080:8080 -p 50000:50000 -v /var/jenkins_home jenkins
+docker run -it --name myjenkins -p 8080:8080 -p 50000:50000 -v /var/jenkins_home jenkins
 ```
 
 Then myjenkins container has the volume (please do read about docker volume handling to find out more).


### PR DESCRIPTION
When I use the **"docker run ..."** command I always add the **"-it"** options. I found them particular useful because I'll be able to use **ctrl+p+q** to detach and **"docker attach ..."** to reattach. So, I think that user will find this tip useful and will avoid the use of **ctrl+c** that causes the stop of the entire container.