### PR TITLE
Fix links to Neo4j documentation

### DIFF
--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -60,7 +60,7 @@ By default, this requires you to login with `neo4j/neo4j` and change the passwor
 
 ## Note on version 2.3
 
-Neo4j 3.0 introduced several major user-facing changes, primarily the new binary Bolt protocol. This is not available in 2.3 and as such, there is no need to expose the `7687` port. Due to changes made to the structure of configuration files, several environment variables used to configure the image has changed as well. Please see the [2.x specific section in the manual](http://neo4j.com/developer/docker-2.x/) for further details.
+Neo4j 3.0 introduced several major user-facing changes, primarily the new binary Bolt protocol. This is not available in 2.3 and as such, there is no need to expose the `7687` port. Due to changes made to the structure of configuration files, several environment variables used to configure the image has changed as well. Please see the [2.x specific section in the manual](http://neo4j.com/developer/docker-23/) for further details.
 
 You can start an instance of Neo4j 2.3 like this:
 
@@ -73,7 +73,7 @@ docker run \
 
 # Documentation
 
-For more examples and complete documentation please go [here for 2.x](http://neo4j.com/developer/docker-2.x/) and [here for 3.x](http://neo4j.com/developer/docker-3.x/).
+For more examples and complete documentation please go [here for 2.x](http://neo4j.com/developer/docker-23/) and [here for 3.x](http://neo4j.com/docs/operations-manual/current/deployment/single-instance/docker/).
 
 # Supported Docker versions
 

--- a/neo4j/content.md
+++ b/neo4j/content.md
@@ -25,7 +25,7 @@ By default, this requires you to login with `neo4j/neo4j` and change the passwor
 
 ## Note on version 2.3
 
-Neo4j 3.0 introduced several major user-facing changes, primarily the new binary Bolt protocol. This is not available in 2.3 and as such, there is no need to expose the `7687` port. Due to changes made to the structure of configuration files, several environment variables used to configure the image has changed as well. Please see the [2.x specific section in the manual](http://neo4j.com/developer/docker-2.x/) for further details.
+Neo4j 3.0 introduced several major user-facing changes, primarily the new binary Bolt protocol. This is not available in 2.3 and as such, there is no need to expose the `7687` port. Due to changes made to the structure of configuration files, several environment variables used to configure the image has changed as well. Please see the [2.x specific section in the manual](http://neo4j.com/developer/docker-23/) for further details.
 
 You can start an instance of Neo4j 2.3 like this:
 
@@ -38,4 +38,4 @@ docker run \
 
 # Documentation
 
-For more examples and complete documentation please go [here for 2.x](http://neo4j.com/developer/docker-2.x/) and [here for 3.x](http://neo4j.com/developer/docker-3.x/).
+For more examples and complete documentation please go [here for 2.x](http://neo4j.com/developer/docker-23/) and [here for 3.x](http://neo4j.com/docs/operations-manual/current/deployment/single-instance/docker/).


### PR DESCRIPTION
Both will be 404 soon (if not already).