### PR TITLE
Deprecate the "iojs" image

### DIFF
--- a/iojs/deprecated.md
+++ b/iojs/deprecated.md
@@ -1,0 +1,7 @@
+This image is officially deprecated in favor of [the `node` image](https://hub.docker.com/_/node/). Please adjust your usage accordingly!
+
+See [iojs.org](https://iojs.org/) for more information, specifically the following note:
+
+> ### **io.js has merged with the Node.js project again.**
+>
+> There won't be any further io.js releases. All of the features in io.js are available in Node.js v4 and above.


### PR DESCRIPTION
Since Node.js 4+, io.js has been merged back with the Node.js project, but our documentation has yet to reflect that fact. :+1:

cc @hmalphettes @retrohacker @Starefossen @pesho @chorrell (tagging a few contributors to both `library/iojs` and `library/node` both FYI and for review :heart:)