### PR TITLE
Deprecate "hipache" due to upstream inactivity

### DIFF
--- a/hipache/deprecated.md
+++ b/hipache/deprecated.md
@@ -1,0 +1,9 @@
+This image is officially deprecated due to upstream inactivity (last updated Feb 2015, [2d36766](https://github.com/hipache/hipache/commit/2d3676638f8b4b1758d70a8dffde1bef88eacf32); last release Apr 2014, [0.3.1](https://github.com/hipache/hipache/releases/tag/0.3.1)).
+
+The following is a list of other HTTP proxies which might be suitable replacements depending on your needs:
+
+-	[`mailgun/vulcand`](https://hub.docker.com/r/mailgun/vulcand/)
+-	[`traefik`](https://hub.docker.com/_/traefik/)
+-	[`nginx`](https://hub.docker.com/_/nginx/)
+-	[`haproxy`](https://hub.docker.com/_/haproxy/)
+-	[`httpd`](https://hub.docker.com/_/httpd/)


### PR DESCRIPTION
cc @dmp42 @samalba -- any objections to deprecating the `hipache` official image?

We don't plan to remove the artifacts (in case folks are still using them), but it does seem prudent to let our users know the status of the project.

If there aren't objections to the deprecation, then I'd appreciate suggestions for improvement on the wording of the deprecation notice, especially whether the "potentially similar solutions" list is even in the right ballpark. :innocent: :heart: