### PR TITLE
centos add missing \ in readme

### DIFF
--- a/centos/README.md
+++ b/centos/README.md
@@ -51,7 +51,7 @@ Systemd is now included in both the centos:7 and centos:latest base containers, 
 FROM centos:7
 MAINTAINER "you" <your@email.here>
 ENV container docker
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i ==
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\

--- a/centos/content.md
+++ b/centos/content.md
@@ -34,7 +34,7 @@ Systemd is now included in both the centos:7 and centos:latest base containers, 
 FROM centos:7
 MAINTAINER "you" <your@email.here>
 ENV container docker
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i ==
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\


### PR DESCRIPTION
https://github.com/docker-library/docs/tree/master/centos#dockerfile-for-systemd-base-image there is a `\` missing