### PR TITLE
Correct image name in command

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -47,7 +47,7 @@ $ docker build -t my-haproxy .
 ## Test the configuration file
 
 ```console
-$ docker run -it --rm --name haproxy-syntax-check haproxy:1.5 haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
+$ docker run -it --rm --name haproxy-syntax-check my-haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 ```
 
 ## Run the container


### PR DESCRIPTION
This PR corrects a small typo in the command that runs the config file check. It should be the name of the image ("my-proxy") instead of "haproxy:1.5".

This issue seems to have tripped up a few folks (myself included) and the correction was already pointed out in the comments, but never made it to the docs themselves :)