### PR TITLE
Fix xcache example and add example of using docker-php-ext-* with an absolute path

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -111,7 +111,7 @@ RUN apt-get update && apt-get install -y libmemcached-dev \
 Some extensions are not provided via either Core or PECL; these can be installed too, although the process is less automated:
 
 ```dockerfile
-FROM php:7.0-apache
+FROM php:5.6-apache
 RUN curl -fsSL 'https://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.gz' -o xcache.tar.gz \
 	&& mkdir -p xcache \
 	&& tar -xf xcache.tar.gz -C xcache --strip-components=1 \
@@ -125,6 +125,19 @@ RUN curl -fsSL 'https://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.
 	) \
 	&& rm -r xcache \
 	&& docker-php-ext-enable xcache
+```
+
+The `docker-php-ext-*` scripts *can* accept an arbitrary path, but it must be absolute (to disambiguate from built-in extension names), so the above example could also be written as the following:
+
+```dockerfile
+FROM php:5.6-apache
+RUN curl -fsSL 'https://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.gz' -o xcache.tar.gz \
+	&& mkdir -p /tmp/xcache \
+	&& tar -xf xcache.tar.gz -C /tmp/xcache --strip-components=1 \
+	&& rm xcache.tar.gz \
+	&& docker-php-ext-configure /tmp/xcache --enable-xcache \
+	&& docker-php-ext-install /tmp/xcache \
+	&& rm -r /tmp/xcache
 ```
 
 ### Without a `Dockerfile`


### PR DESCRIPTION
Similar fix to https://github.com/docker-library/docs/pull/767