### PR TITLE
Add an example of installing "redis" and "xdebug" from PECL (PHP 7.1 compatible)

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -100,6 +100,13 @@ Remember, you must install dependencies for your extensions manually. If an exte
 Some extensions are not provided with the PHP source, but are instead available through [PECL](https://pecl.php.net/). To install a PECL extension, use `pecl install` to download and compile it, then use `docker-php-ext-enable` to enable it:
 
 ```dockerfile
+FROM php:7.1-fpm
+RUN pecl install redis-3.1.0 \
+	&& pecl install xdebug-2.5.0 \
+	&& docker-php-ext-enable redis xdebug
+```
+
+```dockerfile
 FROM php:5.6-fpm
 RUN apt-get update && apt-get install -y libmemcached-dev zlib1g-dev \
 	&& pecl install memcached-2.2.0 \


### PR DESCRIPTION
See https://github.com/docker-library/docs/issues/764#issuecomment-266828154