### PR TITLE
Fix incorrect path for eclipse-mosquitto configuration

### DIFF
--- a/eclipse-mosquitto/content.md
+++ b/eclipse-mosquitto/content.md
@@ -16,9 +16,9 @@ Three directories have been created in the image to be used for configuration, p
 
 ## Configuration
 
-When running the image, the default configuration values are used. To use a custom configuration file, mount a **local** configuration file to `/mosquitto/conf/mosquitto.conf`
+When running the image, the default configuration values are used. To use a custom configuration file, mount a **local** configuration file to `/mosquitto/config/mosquitto.conf`
 
-	docker run -it -p 1883:1883 -p 9001:9001 -v mosquitto.conf:/mosquitto/data/mosquitto.conf eclipse-mosquitto
+	docker run -it -p 1883:1883 -p 9001:9001 -v mosquitto.conf:/mosquitto/config/mosquitto.conf eclipse-mosquitto
 
 Configuration can be changed to:
 
@@ -37,6 +37,6 @@ i.e. add the following to `mosquitto.conf`:
 
 Run a container using the new image:
 
-	docker run -it -p 1883:1883 -p 9001:9001 -v mosquitto.conf:/mosquitto/data/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto
+	docker run -it -p 1883:1883 -p 9001:9001 -v mosquitto.conf:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto
 
 **Note**: if the mosquitto configuration (mosquitto.conf) was modified to use non-default ports, the docker run command will need to be updated to expose the ports that have been configured.


### PR DESCRIPTION
- mosquitto configuration is read from /mosquitto/config/ not /mosquitto/conf
- docker run examples are now showing correct path to configuration

Signed-off-by: David Audet <david.audet@ca.com>