### PR TITLE
Add some notes about volumes in Drupal, especially updating "docker-compose.yml"

### DIFF
--- a/drupal/docker-compose.yml
+++ b/drupal/docker-compose.yml
@@ -1,6 +1,7 @@
 # Drupal with PostgreSQL
 #
-# Access via "http://localhost:8080" (or "http://$(docker-machine ip):8080" if using docker-machine)
+# Access via "http://localhost:8080"
+#   (or "http://$(docker-machine ip):8080" if using docker-machine)
 #
 # During initial Drupal setup,
 # Database type: PostgreSQL
@@ -17,6 +18,14 @@ services:
     image: drupal:8.2-apache
     ports:
       - 8080:80
+    volumes:
+      - /var/www/html/modules
+      - /var/www/html/profiles
+      - /var/www/html/themes
+      # this takes advantage of the feature in Docker that a new anonymous
+      # volume (which is what we're creating here) will be initialized with the
+      # existing content of the image at the same location
+      - /var/www/html/sites
     restart: always
 
   postgres:


### PR DESCRIPTION
I tested this by using `docker-compose up -d`, going through Drupal's web-based setup process to get Drupal fully configured and operational, then used `docker-compose up -d --force-recreate` to force both containers to be re-created (which works very hard to keep the volumes), and verified that my site was still configured and working properly.

Closes https://github.com/docker-library/drupal/issues/3