### PR TITLE
[Gazebo] Updating docs about curl

### DIFF
--- a/gazebo/content.md
+++ b/gazebo/content.md
@@ -11,7 +11,7 @@ Robot simulation is an essential tool in every roboticist's toolbox. A well-desi
 ## Create a `Dockerfile` in your Gazebo project
 
 ```dockerfile
-FROM gazebo:gzserver5
+FROM gazebo:gzserver8
 # place here your application's setup specifics
 CMD [ "gzserver", "my-gazebo-app-args" ]
 ```
@@ -69,6 +69,7 @@ $ docker run -d -v="/tmp/.gazebo/:/root/.gazebo/" --name=gazebo gazebo
 
 ```console
 $ docker exec -it gazebo bash
+$ apt-get update && apt-get install -y curl
 $ curl -o double_pendulum.sdf http://models.gazebosim.org/double_pendulum_with_base/model-1_4.sdf
 $ gz model --model-name double_pendulum --spawn-file double_pendulum.sdf
 ```


### PR DESCRIPTION
Curl may not be installed by default in newer ubuntu images, so for the tutorial, gazebo8 image is missing curl: https://github.com/osrf/docker_images/issues/46
Also updating token Dockerfile