### PR TITLE
Add details about trust authentication.

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -50,6 +50,8 @@ The PostgreSQL image uses several environment variables which are easy to miss. 
 
 This environment variable is recommended for you to use the PostgreSQL image. This environment variable sets the superuser password for PostgreSQL. The default superuser is defined by the `POSTGRES_USER` environment variable. In the above example, it is being set to "mysecretpassword".
 
+Note: The PostgreSQL image sets up `trust` authentication locally so you may notice a password is not required when connecting from `localhost` (inside the same container). However, a password will be required if connecting from a different host/container.
+
 ### `POSTGRES_USER`
 
 This optional environment variable is used in conjunction with `POSTGRES_PASSWORD` to set a user and its password. This variable will create the specified user with superuser power and a database with the same name. If it is not specified, then the default user of `postgres` will be used.


### PR DESCRIPTION
The PostgreSQL image sets up trust authentication and may be confusing for folks who are unfamiliar with it. Add a note to explain this.