### PR TITLE
Update README.md to show automatic daemon exit

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -99,6 +99,7 @@ The two easiest ways to get around this:
 	The files belonging to this database system will be owned by user "postgres".
 	...
 	( once it's finished initializing successfully and is waiting for connections, stop it )
+	( if you need the process to exit automatically, append `--help` to the command to avoid the daemon restarting )
 	$ docker run -it --rm -v pgdata:/var/lib/postgresql/data bash chown -R 1000:1000 /var/lib/postgresql/data
 	$ docker run -it --rm --user 1000:1000 -v pgdata:/var/lib/postgresql/data postgres
 	LOG:  database system was shut down at 2017-01-20 00:03:23 UTC


### PR DESCRIPTION
The `docker-entrypoint.sh` script always starts the postgresql daemon regardless. I wanted to script  the process of creating a local user as described, so rather than having to hit CTRL+C you can force an exit by passing the `--help` argument so this it self exist on completion.
I remember in passing seeing people asking this question in somewhere else so hopefuly this README update will help in the future.