### PR TITLE
Add (and later strip) a nice warning at the top of README.md about it being auto-generated

### DIFF
--- a/.template-helpers/template.md
+++ b/.template-helpers/template.md
@@ -1,3 +1,19 @@
+<!--
+
+********************************************************************************
+
+WARNING:
+
+    DO NOT EDIT "%%REPO%%/README.md"
+
+    IT IS AUTO-GENERATED
+
+    (from the other files in "%%REPO%%/" combined with a set of templates)
+
+********************************************************************************
+
+-->
+
 # Supported tags and respective `Dockerfile` links
 
 %%TAGS%%

--- a/push.pl
+++ b/push.pl
@@ -60,6 +60,9 @@ sub prompt_for_edit {
 	my $proposedText = slurp $proposedFile or warn 'missing ' . $proposedFile;
 	$proposedText = trim(decode('UTF-8', $proposedText));
 	
+	# remove our warning about generated files (Hub doesn't support HTML comments in Markdown)
+	$proposedText =~ s% ^ <!-- .*? --> \s* %%sx;
+	
 	if ($lengthLimit > 0 && length($proposedText) > $lengthLimit) {
 		# TODO https://github.com/docker/hub-beta-feedback/issues/238
 		my $fullUrl = "$githubBase/$proposedFile";


### PR DESCRIPTION
```console
...
no change to debian; skipping
$ git status
On branch master
Your branch is up-to-date with 'docker-library/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   .template-helpers/template.md
	modified:   debian/README.md
	modified:   push.pl

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff debian/
diff --git a/debian/README.md b/debian/README.md
index bfe6a76..cfc27ce 100644
--- a/debian/README.md
+++ b/debian/README.md
@@ -1,3 +1,9 @@
+<!--
+
+       WARNING: DO NOT EDIT "debian/README.md"; IT IS AUTO-GENERATED (from the other files in "debian/" combined with a set of templates).
+
+-->
+
 # Supported tags and respective `Dockerfile` links
 
 -      [`8.7`, `8`, `jessie`, `latest` (*jessie/Dockerfile*)](https://github.com/tianon/docker-brew-debian/blob/a3d2e76fdd618d1ca1b145c0a2268e828d547ea2/jessie/Dockerfile)
```