### PR TITLE
Added information about running nginx in debug mode

### DIFF
--- a/nginx/content.md
+++ b/nginx/content.md
@@ -72,7 +72,8 @@ Out-of-the-box, Nginx doesn't support using environment variables inside most co
 
 Here is an example using docker-compose.yml:
 
-```web:
+```
+web:
   image: nginx
   volumes:
    - ./mysite.template:/etc/nginx/conf.d/mysite.template
@@ -84,7 +85,27 @@ Here is an example using docker-compose.yml:
   command: /bin/bash -c "envsubst < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
 ```
 
-The `mysite.template` file may then contain variable references like this :
+The `mysite.template` file may then contain variable references like this:
 
 `listen       ${NGINX_PORT};
 `
+
+## running nginx in debug mode
+ 
+Images since version 1.9.8 come with `nginx-debug` binary that produces
+complete output when using higher verbosity log levels. It can be used 
+with simple CMD substitution:
+
+```console
+docker run --name my-nginx -v /host/path/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx nginx-debug -g 'daemon off;'
+```
+
+Similar configuration in docker-compose.yml may look like this:
+
+```
+web:
+  image: nginx
+  volumes:
+    - ./nginx.conf:/etc/nginx/nginx.conf:ro
+  command: [nginx-debug, '-g', 'daemon off;']
+```

--- a/nginx/content.md
+++ b/nginx/content.md
@@ -72,7 +72,7 @@ Out-of-the-box, Nginx doesn't support using environment variables inside most co
 
 Here is an example using docker-compose.yml:
 
-```
+```yaml
 web:
   image: nginx
   volumes:
@@ -91,18 +91,16 @@ The `mysite.template` file may then contain variable references like this:
 `
 
 ## running nginx in debug mode
- 
-Images since version 1.9.8 come with `nginx-debug` binary that produces
-complete output when using higher verbosity log levels. It can be used 
-with simple CMD substitution:
+
+Images since version 1.9.8 come with `nginx-debug` binary that produces complete output when using higher verbosity log levels. It can be used with simple CMD substitution:
 
 ```console
-docker run --name my-nginx -v /host/path/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx nginx-debug -g 'daemon off;'
+$ docker run --name my-nginx -v /host/path/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx nginx-debug -g 'daemon off;'
 ```
 
 Similar configuration in docker-compose.yml may look like this:
 
-```
+```yaml
 web:
   image: nginx
   volumes:


### PR DESCRIPTION
Nginx images come with two binaries inside (nginx and nginx-debug), but it hasn't been reflected in image information yet, so this small pull request fixes it.

Discussion started in nginxinc/docker-nginx#55