### PR TITLE
Document postgres POSTGRES_INITDB_XLOGDIR variable

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -68,6 +68,10 @@ This optional environment variable can be used to define a different name for th
 
 This optional environment variable can be used to send arguments to `postgres initdb`. The value is a space separated string of arguments as `postgres initdb` would expect them. This is useful for adding functionality like data page checksums: `-e POSTGRES_INITDB_ARGS="--data-checksums"`.
 
+### `POSTGRES_INITDB_XLOGDIR`
+
+This optional environment variable can be used to define another location for the Postgres transaction log. By default the transaction log is stored in a subdirectory of the main Postgres data folder (`PGDATA`). Sometimes it can be desireable to store the transaction log in a different directory which may be backed by storage with different performance or reliability characteristics.
+
 ## Arbitrary `--user` Notes
 
 As of [docker-library/postgres#253](https://github.com/docker-library/postgres/pull/253), this image supports running as a (mostly) arbitrary user via `--user` on `docker run`.


### PR DESCRIPTION
docker-library/postgres#224 and docker-library/official-images#2762 added the POSTGRES_INITDB_XLOGDIR variable. This adds documentation for that variable.