### PR TITLE
Convert "wordpress" to use "docker stack deploy" as an initial "stack" foray

### DIFF
--- a/.template-helpers/stack.md
+++ b/.template-helpers/stack.md
@@ -1,0 +1,7 @@
+... via [`docker stack deploy`](https://docs.docker.com/engine/reference/commandline/stack_deploy/) or [`docker-compose`](https://github.com/docker/compose)
+
+Example `stack.yml` for `%%REPO%%`:
+
+%%STACK-YML%%
+
+[![Try in PWD](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com?stack=%%STACK-URL%%)

--- a/update.sh
+++ b/update.sh
@@ -59,6 +59,17 @@ for image in "${images[@]}"; do
 			fi
 		fi
 
+		stack=
+		stackYml=
+		stackUrl=
+		if [ -f "$repo/stack.yml" ]; then
+			stack="$(cat "$repo/stack.md" 2>/dev/null || cat "$helperDir/stack.md")"
+			stackYml=$'```yaml\n'"$(cat "$repo/stack.yml")"$'\n```'
+			stackCommit="$(git log -1 --format='format:%H' -- "$repo/stack.yml" 2>/dev/null || true)"
+			[ "$stackCommit" ] || stackCommit='master'
+			stackUrl="https://raw.githubusercontent.com/docker-library/docs/$stackCommit/$repo/stack.yml"
+		fi
+
 		compose=
 		composeYml=
 		if [ -f "$repo/docker-compose.yml" ]; then
@@ -97,9 +108,15 @@ for image in "${images[@]}"; do
 		echo "  LOGO => $logo"
 		replace_field "$targetFile" 'LOGO' "$logo" '\s*'
 
+		echo '  STACK => '"$repo"'/stack.md'
+		replace_field "$targetFile" 'STACK' "$stack"
+		echo '  STACK-YML => '"$repo"'/docker-stack.yml'
+		replace_field "$targetFile" 'STACK-YML' "$stackYml"
+		echo '  STACK-URL => '"$repo"'/docker-stack.yml'
+		replace_field "$targetFile" 'STACK-URL' "$stackUrl"
+
 		echo '  COMPOSE => '"$repo"'/compose.md'
 		replace_field "$targetFile" 'COMPOSE' "$compose"
-
 		echo '  COMPOSE-YML => '"$repo"'/docker-compose.yml'
 		replace_field "$targetFile" 'COMPOSE-YML' "$composeYml"
 

--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -38,9 +38,9 @@ $ docker run --name some-%%REPO%% -e WORDPRESS_DB_HOST=10.1.2.3:3306 \
     -e WORDPRESS_DB_USER=... -e WORDPRESS_DB_PASSWORD=... -d %%REPO%%
 ```
 
-## %%COMPOSE%%
+## %%STACK%%
 
-Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080` or `http://host-ip:8080` (as appropriate).
 
 ## Adding additional libraries / extensions
 

--- a/wordpress/stack.yml
+++ b/wordpress/stack.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.1'
 
 services:
 
@@ -10,6 +10,6 @@ services:
       WORDPRESS_DB_PASSWORD: example
 
   mysql:
-    image: mariadb
+    image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: example


### PR DESCRIPTION
Closes #912

Here's an example of what this generates: (and that "Try in PWD" link should actually work!)

## ... via [`docker stack deploy`](https://docs.docker.com/engine/reference/commandline/stack_deploy/) or [`docker-compose`](https://github.com/docker/compose)

Example `stack.yml` for `wordpress`:

```yaml
version: '3.1'

services:

  wordpress:
    image: wordpress
    ports:
      - 8080:80
    environment:
      WORDPRESS_DB_PASSWORD: example

  mysql:
    image: mysql:5.7
    environment:
      MYSQL_ROOT_PASSWORD: example
```

[![Try in PWD](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/docker-library/docs/0cb43ce8ad1da073bbc30c6245cdffb433ba51ba/wordpress/stack.yml)

Run `docker stack deploy -c stack.yml wordpress` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080` or `http://host-ip:8080` (as appropriate).