### PR TITLE
Add information on how to run command as root in Dockerfile

### DIFF
--- a/nuxeo/content.md
+++ b/nuxeo/content.md
@@ -117,7 +117,7 @@ Allows to setup [Database creation option](https://doc.nuxeo.com/x/hwQz#Reposito
 
 ### `NUXEO_CUSTOM_PARAM`
 
-Allows to add custom parameters to `nuxeo.conf`. Multiple parameters can be splitted by a `\n`. For instance :
+Allows to add custom parameters to `nuxeo.conf`. Multiple parameters can be splitted by a `\n`. For instance:
 
 	NUXEO_CUSTOM_PARAM="repository.clustering.enabled=false\nrepository.clustering.delay=1000"
 
@@ -132,16 +132,27 @@ FROM nuxeo:7.10
 ADD nuxeo.conf /nuxeo.conf
 ```
 
+If you need a root account to run some installation steps in your `Dockerfile`, then you need to put those steps between two `USER` command as the image is run with the user `1000` (nuxeo). For instance:
+
+```dockerfile
+FROM nuxeo:LTS
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends vim
+USER 1000
+```
+
 ## Launching custom shell scripts
 
 You can add your own shell scripts in a special `/docker-entrypoint-initnuxeo.d` directory. When ending in `.sh`, they will be run on default entrypoint startup.
 
 ## ffmpeg
 
-As it contains some non-free Codecs, we dont't ship a binary version of `ffmpeg` as part of this image. However, you can simply add the compilation in a derived images by adding these lines to your Dockerfile
+As it contains some non-free Codecs, we dont't ship a binary version of `ffmpeg` as part of this image. However, you can simply add the compilation in a derived images by adding these lines to your Dockerfile.
 
 ```dockerfile
 FROM nuxeo:7.10
+
+USER root
 
 RUN echo "deb http://httpredir.debian.org/debian jessie non-free" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y --no-install-recommends libfaac-dev git
@@ -160,6 +171,8 @@ RUN ./prepare-packages.sh \
  && cd /tmp \
  && rm -Rf ffmpeg-nuxeo \
  && rm -rf /var/lib/apt/lists/*
+
+USER 1000
 ```
 
 ## Using Oracle JVM


### PR DESCRIPTION
As Nuxeo image now runs with user `nuxeo`, then it's not possible anymore to run root commands without explicit switching.