### PR TITLE
Use architecture-specific fields in link generation for now

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -5,29 +5,34 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 */ -}}
 
 {{- define "dockerfilePath" -}}
-	{{- if ne .Directory "." -}}
-		{{- .Directory -}}
+	{{- $dir := .ArchDirectory arch -}}
+	{{- if ne $dir "." -}}
+		{{- $dir -}}
 		/
 	{{- end -}}
 	Dockerfile
 {{- end -}}
 
 {{- range $i, $e := $.Entries -}}
-	{{- /* force bashbrew to "fetch" the GitCommit so that it is fully resolved */ -}}
-	{{- $from := $.DockerFrom $e -}}
+	{{- if $e.HasArchitecture arch -}}
+		{{- /* force bashbrew to "fetch" the GitCommit so that it is fully resolved */ -}}
+		{{- $from := $.DockerFrom $e -}}
 
-	{{- $repoUrlBase := $e.GitRepo | replace "git://" "https://" | trimSuffixes ".git" -}}
-	{{- $isGitHub := hasPrefix "https://github.com/" $repoUrlBase -}}
+		{{- $gitRepo := $e.ArchGitRepo arch -}}
+		{{- $repoUrlBase := $gitRepo | replace "git://" "https://" | trimSuffixes ".git" -}}
+		{{- $isGitHub := hasPrefix "https://github.com/" $repoUrlBase -}}
 
-	{{- if $i -}}
-		{{- "\n" -}}
+		{{- if $i -}}
+			{{- "\n" -}}
+		{{- end -}}
+
+		- {{- "\t" -}}
+		{{- if $isGitHub -}} [ {{- end -}}
+		` {{- $e.Tags | join "`, `" -}} ` (* {{- template "dockerfilePath" $e -}} *)
+		{{- $gitCommit := $e.ArchGitCommit arch -}}
+		{{- if $isGitHub -}} ]( {{- $repoUrlBase -}} /blob/ {{- $gitCommit -}} / {{- template "dockerfilePath" $e -}} ) {{- end -}}
+		{{- /* TODO decide what to do (if anything) about non-GitHub repos with respect to URL */ -}}
 	{{- end -}}
-
-	- {{- "\t" -}}
-	{{- if $isGitHub -}} [ {{- end -}}
-	` {{- $e.Tags | join "`, `" -}} ` (* {{- template "dockerfilePath" $e -}} *)
-	{{- if $isGitHub -}} ]( {{- $repoUrlBase -}} /blob/ {{- $e.GitCommit -}} / {{- template "dockerfilePath" $e -}} ) {{- end -}}
-	{{- /* TODO decide what to do (if anything) about non-GitHub repos with respect to URL */ -}}
 {{- end -}}
 
 {{- "\n\n" -}}


### PR DESCRIPTION
(Displaying architecture information in a clean, simple way per-tag is still definitely a big WIP/unknown.)