### PR TITLE
Update deprecation notice

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -16,7 +16,7 @@ WARNING:
 
 # **DEPRECATED**
 
-This image is officially deprecated in favor of [the `elasticsearch` image provided by elastic.co](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) which is available to pull via `docker.elastic.co/elasticsearch/elasticsearch:[version]` like `5.2.1`. This image will receive no further updates after 2017-06-20 (June 20, 2017). Please adjust your usage accordingly.
+This image is officially deprecated in favor of [the `elasticsearch` image provided by elastic.co](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) which is available to pull via `docker.elastic.co/elasticsearch/elasticsearch:[version]` like `5.4.1`. This image will receive no further updates, starting with version `5.6.0`. Please adjust your usage accordingly.
 
 Elastic provides open-source support for Elasticsearch via the [elastic/elasticsearch GitHub repository](https://github.com/elastic/elasticsearch) and the Docker image via the [elastic/elasticsearch-docker GitHub repository](https://github.com/elastic/elasticsearch-docker), as well as community support via its [forums](https://discuss.elastic.co/c/elasticsearch).
 

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -16,7 +16,7 @@ WARNING:
 
 # **DEPRECATED**
 
-This image is officially deprecated in favor of [the `kibana` image provided by elastic.co](https://www.elastic.co/guide/en/kibana/current/_pulling_the_image.html) which is available to pull via `docker.elastic.co/kibana/kibana:[version]` like `5.2.1`. This image will receive no further updates after 2017-06-20 (June 20, 2017). Please adjust your usage accordingly.
+This image is officially deprecated in favor of [the `kibana` image provided by elastic.co](https://www.elastic.co/guide/en/kibana/current/_pulling_the_image.html) which is available to pull via `docker.elastic.co/kibana/kibana:[version]` like `5.4.1`. This image will receive no further updates, starting with version `5.6.0`. Please adjust your usage accordingly.
 
 Elastic provides open-source support for Kibana via the [elastic/kibana GitHub repository](https://github.com/elastic/kibana) and the Docker image via the [elastic/kibana-docker GitHub repository](https://github.com/elastic/kibana-docker), as well as community support via its [forums](https://discuss.elastic.co/c/kibana).
 

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -16,7 +16,7 @@ WARNING:
 
 # **DEPRECATED**
 
-This image is officially deprecated in favor of [the `logstash` image provided by elastic.co](https://www.elastic.co/guide/en/logstash/current/docker.html) which is available to pull via `docker.elastic.co/logstash/logstash:[version]` like `5.2.1`. This image will receive no further updates after 2017-06-20 (June 20, 2017). Please adjust your usage accordingly.
+This image is officially deprecated in favor of [the `logstash` image provided by elastic.co](https://www.elastic.co/guide/en/logstash/current/docker.html) which is available to pull via `docker.elastic.co/logstash/logstash:[version]` like `5.4.1`. This image will receive no further updates, starting with version `5.6.0`. Please adjust your usage accordingly.
 
 Elastic provides open-source support for Logstash via the [elastic/logstash GitHub repository](https://github.com/elastic/logstash) and the Docker image via the [elastic/logstash-docker GitHub repository](https://github.com/elastic/logstash-docker), as well as community support via its [forums](https://discuss.elastic.co/c/logstash).
 


### PR DESCRIPTION
Version 5.5 of the Elastic stack, including Elasticsearch, Kibana and Logstash has been delayed.

Update documentation clarifying that images will keep receiving updates until version 5.6.0.

cc @yosifkit who, so kindly, worked on the related https://github.com/docker-library/docs/pull/842
