### PR TITLE
Update docs to filter arch-specific content a bit better (variants, supported tags)

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -4,8 +4,11 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 
 */ -}}
 
+{{- $archSpecific := getenv "ARCH_SPECIFIC_DOCS" -}}
+
 {{- range $i, $e := $.Entries -}}
-	{{- $arch := ternary (ternary arch ($e.Architectures | first) ($e.HasArchitecture arch)) arch (eq arch "amd64") -}}
+	{{- $arch := $archSpecific | ternary arch ($e.HasArchitecture arch | ternary arch ($e.Architectures | first)) -}}
+
 	{{- if $e.HasArchitecture $arch -}}
 		{{- /* force bashbrew to "fetch" the GitCommit so that it is fully resolved */ -}}
 		{{- $from := $.ArchDockerFrom $arch $e -}}

--- a/.template-helpers/variant.sh
+++ b/.template-helpers/variant.sh
@@ -17,7 +17,18 @@ if [ -z "${BASHBREW_LIBRARY:-}" ]; then
 fi
 
 IFS=$'\n'
-tags=( $(bashbrew cat -f '{{ range .Entries }}{{ join "\n" .Tags }}{{ "\n" }}{{ end }}' "$repo") )
+tags=( $(bashbrew cat -f '
+	{{- $archSpecific := getenv "ARCH_SPECIFIC_DOCS" -}}
+
+	{{- range .Entries -}}
+		{{- $arch := $archSpecific | ternary arch (.HasArchitecture arch | ternary arch (.Architectures | first)) -}}
+
+		{{- if .HasArchitecture $arch -}}
+			{{- join "\n" .Tags -}}
+			{{- "\n" -}}
+		{{- end -}}
+	{{- end -}}
+' "$repo") )
 unset IFS
 
 text=

--- a/update.sh
+++ b/update.sh
@@ -25,6 +25,13 @@ for image in "${images[@]}"; do
 	namespace="${image%$repo}"
 	namespace="${namespace%/}"
 
+	# this is used by subscripts to determine whether we're pushing /_/xxx or /r/ARCH/xxx
+	# (especialy for "supported tags")
+	export ARCH_SPECIFIC_DOCS=
+	if [ -n "$namespace" ] && [ -n "${BASHBREW_ARCH:-}" ]; then
+		export ARCH_SPECIFIC_DOCS=1
+	fi
+
 	if [ -x "$repo/update.sh" ]; then
 		( set -x; "$repo/update.sh" "$image" )
 	fi


### PR DESCRIPTION
This uses the combination of us pushing to a namespace + `BASHBREW_ARCH` being set to determine whether we're pushing to an arch-specific page and should thus appropriately filter all content to the current architecture.

Special thanks to https://github.com/docker-library/official-images/pull/3189 and https://github.com/docker-library/go-dockerlibrary/pull/15 for making this easier to implement.