### PR TITLE
Add example on how to make an onbuild image for Perl

### DIFF
--- a/perl/content.md
+++ b/perl/content.md
@@ -34,7 +34,7 @@ $ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/
 
 ## Creating a reusable `perl:onbuild` image for Perl projects
 
-Suppose you have a project that uses [Carton](https://metacpan.org/pod/Carton) to manage Perl dependencies. You can write a `Dockerfile` that makes use of the [ONBUILD](https://docs.docker.com/engine/reference/builder/#onbuild) instruction like this:
+Suppose you have a project that uses [Carton](https://metacpan.org/pod/Carton) to manage Perl dependencies. You can create a `perl:onbuild` image that makes use of the [ONBUILD](https://docs.docker.com/engine/reference/builder/#onbuild) instruction in its `Dockerfile`, like this:
 
 ```dockerfile
 FROM perl:5.26
@@ -49,4 +49,4 @@ ONBUILD RUN carton install
 ONBUILD COPY . /usr/src/app
 ```
 
-Building this as a `perl:onbuild` image can let you reduce your project's `Dockerfile` into a single line of `FROM perl:onbuild`, which may be enough to build a stand-alone image for your project.
+Then, in your project, you can now reduce your project's `Dockerfile` into a single line of `FROM perl:onbuild`, which may be enough to build a stand-alone image.

--- a/perl/content.md
+++ b/perl/content.md
@@ -31,3 +31,23 @@ For many simple, single file projects, you may find it inconvenient to write a c
 ```console
 $ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp perl:5.20 perl your-daemon-or-script.pl
 ```
+
+## Creating a reusable `perl:onbuild` image for Perl projects
+
+Suppose you have a project that uses [Carton](https://metacpan.org/pod/Carton) to manage Perl dependencies. You can write a `Dockerfile` that makes use of the [ONBUILD](https://docs.docker.com/engine/reference/builder/#onbuild) instruction like this:
+
+```dockerfile
+FROM perl:5.26
+
+RUN cpanm Carton \
+    && mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY cpanfile* /usr/src/myapp
+ONBUILD RUN carton install
+
+ONBUILD COPY . /usr/src/app
+```
+
+Building this as a `perl:onbuild` image can let you reduce your project's `Dockerfile` into a single line of `FROM perl:onbuild`, which may be enough to build a stand-alone image for your project.
+

--- a/perl/content.md
+++ b/perl/content.md
@@ -32,7 +32,7 @@ For many simple, single file projects, you may find it inconvenient to write a c
 $ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp perl:5.20 perl your-daemon-or-script.pl
 ```
 
-## Creating a reusable `perl:onbuild` image for Perl projects
+## Example: Creating a reusable Carton image for Perl projects
 
 Suppose you have a project that uses [Carton](https://metacpan.org/pod/Carton) to manage Perl dependencies. You can create a `perl:carton` image that makes use of the [ONBUILD](https://docs.docker.com/engine/reference/builder/#onbuild) instruction in its `Dockerfile`, like this:
 
@@ -50,3 +50,8 @@ ONBUILD COPY . /usr/src/app
 ```
 
 Then, in your Carton project, you can now reduce your project's `Dockerfile` into a single line of `FROM perl:carton`, which may be enough to build a stand-alone image.
+
+Having a single `perl:carton` base image is useful especially if you have multiple Carton-based projects in development, to avoid "boilerplate" coding of installing Carton and/or copying the project source files into the derived image. Keep in mind, though, about certain things to consider when using the Perl image in this way:
+
+-	This kind of base image will hide the useful bits (such as the`COPY`/`RUN` above) in the image, separating it from more specific Dockerfiles using the base image. This might lead to confusion when creating further derived images, so be aware of how [ONBUILD triggers](https://docs.docker.com/engine/reference/builder/#onbuild) work and plan appropriately.
+-	There is the cost of maintaining an extra base image build, so if you're working on a single Carton project and/or plan to publish it, then it may be more preferable to derive directly from a versioned `perl` image instead.

--- a/perl/content.md
+++ b/perl/content.md
@@ -34,7 +34,7 @@ $ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/
 
 ## Creating a reusable `perl:onbuild` image for Perl projects
 
-Suppose you have a project that uses [Carton](https://metacpan.org/pod/Carton) to manage Perl dependencies. You can create a `perl:onbuild` image that makes use of the [ONBUILD](https://docs.docker.com/engine/reference/builder/#onbuild) instruction in its `Dockerfile`, like this:
+Suppose you have a project that uses [Carton](https://metacpan.org/pod/Carton) to manage Perl dependencies. You can create a `perl:carton` image that makes use of the [ONBUILD](https://docs.docker.com/engine/reference/builder/#onbuild) instruction in its `Dockerfile`, like this:
 
 ```dockerfile
 FROM perl:5.26
@@ -49,4 +49,4 @@ ONBUILD RUN carton install
 ONBUILD COPY . /usr/src/app
 ```
 
-Then, in your project, you can now reduce your project's `Dockerfile` into a single line of `FROM perl:onbuild`, which may be enough to build a stand-alone image.
+Then, in your Carton project, you can now reduce your project's `Dockerfile` into a single line of `FROM perl:carton`, which may be enough to build a stand-alone image.

--- a/perl/content.md
+++ b/perl/content.md
@@ -50,4 +50,3 @@ ONBUILD COPY . /usr/src/app
 ```
 
 Building this as a `perl:onbuild` image can let you reduce your project's `Dockerfile` into a single line of `FROM perl:onbuild`, which may be enough to build a stand-alone image for your project.
-


### PR DESCRIPTION
Instead of providing an `onbuild` variant, show to the user how it is
created instead, by example.

See Perl/docker-perl#13 and
docker-library/official-images#2076