### PR TITLE
Update URL to CQL documentation

### DIFF
--- a/cassandra/content.md
+++ b/cassandra/content.md
@@ -72,7 +72,7 @@ $ docker run -it --link some-%%REPO%%:cassandra --rm %%REPO%% cqlsh cassandra
 
 ... where `some-%%REPO%%` is the name of your original Cassandra Server container.
 
-More information about the CQL can be found in the [Cassandra documentation](https://cassandra.apache.org/doc/cql3/CQL.html).
+More information about the CQL can be found in the [Cassandra documentation](https://cassandra.apache.org/doc/latest/cql/index.html).
 
 ## Container shell access and viewing Cassandra logs
 


### PR DESCRIPTION
Current URL (https://cassandra.apache.org/doc/cql3/CQL.html) returns a 404.
URL in this PR (https://cassandra.apache.org/doc/latest/cql/index.html) takes reader to latest version of CQL documentation, currently version 3.