### PR TITLE
Add note about WiredTiger being the default storage engine.

### DIFF
--- a/mongo/content.md
+++ b/mongo/content.md
@@ -34,7 +34,7 @@ $ docker run -it --link some-mongo:mongo --rm mongo sh -c 'exec mongo "$MONGO_PO
 
 See the [official docs](http://docs.mongodb.org/manual/) for infomation on using and configuring MongoDB for things like replica sets and sharding.
 
-Just add the `--storageEngine` argument if you want to use the WiredTiger storage engine in MongoDB 3.0 and above without making a config file. Be sure to check the [docs](http://docs.mongodb.org/manual/release-notes/3.0-upgrade/#change-storage-engine-to-wiredtiger) on how to upgrade from older versions.
+Just add the `--storageEngine` argument if you want to use the WiredTiger storage engine in MongoDB 3.0 and above without making a config file. WiredTiger is the default storage engine in MongoDB 3.2 and above. Be sure to check the [docs](http://docs.mongodb.org/manual/release-notes/3.0-upgrade/#change-storage-engine-to-wiredtiger) on how to upgrade from older versions.
 
 ```console
 $ docker run --name some-mongo -d mongo --storageEngine wiredTiger


### PR DESCRIPTION
Fixes https://github.com/docker-library/mongo/issues/197.