### PR TITLE
Add a note to mongo about "/data/configdb" (and --configsvr)

### DIFF
--- a/mongo/content.md
+++ b/mongo/content.md
@@ -95,6 +95,8 @@ The Docker documentation is a good starting point for understanding the differen
 
 The `-v /my/own/datadir:/data/db` part of the command mounts the `/my/own/datadir` directory from the underlying host system as `/data/db` inside the container, where MongoDB by default will write its data files.
 
+This image also defines a volume for `/data/configdb` [for use with `--configsvr` (see docs.mongodb.com for more details)](https://docs.mongodb.com/v3.4/reference/program/mongod/#cmdoption-configsvr).
+
 Note that users on host systems with SELinux enabled may see issues with this. The current workaround is to assign the relevant SELinux policy type to the new data directory so that the container will be allowed to access it:
 
 ```console


### PR DESCRIPTION
Closes docker-library/mongo#198