### PR TITLE
Add custom description for slim openjdk to point out headless

### DIFF
--- a/openjdk/variant-slim.md
+++ b/openjdk/variant-slim.md
@@ -1,0 +1,3 @@
+## `%%IMAGE%%:slim`
+
+This image installs the `-headless` package of OpenJDK and so is missing many of the UI-related Java libraries and some common packages contained in the default tag. It only contains the minimal packages needed to run Java. Unless you are working in an environment where *only* the `%%IMAGE%%` image will be deployed and you have space constraints, we highly recommend using the default image of this repository.


### PR DESCRIPTION
Docs for https://github.com/docker-library/official-images/pull/3424 and https://github.com/docker-library/openjdk/pull/143.

```diff
# git --no-pager  diff --no-index ../.template-helpers/variant-slim.md variant-slim.md
diff --git a/../.template-helpers/variant-slim.md b/variant-slim.md
index 8c9dd03a..9b10ed93 100644
--- a/../.template-helpers/variant-slim.md
+++ b/variant-slim.md
@@ -1,3 +1,3 @@
 ## `%%IMAGE%%:slim`
 
-This image does not contain the common packages contained in the default tag and only contains the minimal packages needed to run `%%IMAGE%%`. Unless you are working in an environment where *only* the `%%IMAGE%%` image will be deployed and you have space constraints, we highly recommend using the default image of this repository.
+This image installs the `headless` package of `%%IMAGE%%` and so does not contain the common packages contained in the default tag and only contains the minimal packages needed to run `%%IMAGE%%`. Unless you are working in an environment where *only* the `%%IMAGE%%` image will be deployed and you have space constraints, we highly recommend using the default image of this repository.
```