### PR TITLE
Add SharedTags information to "Supported tags" listing

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -6,6 +6,42 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 
 {{- $archSpecific := getenv "ARCH_SPECIFIC_DOCS" -}}
 
+{{- $sharedTagGroups := .Manifest.GetSharedTagGroups -}}
+{{- if (len $sharedTagGroups) -}}
+	{{- "## Shared Tags\n\n" -}}
+
+	{{- range $sharedTagGroups -}}
+		{{- "-\t`" -}}
+		{{ .SharedTags | join "`, `" }}
+		{{- "`:\n" -}}
+		{{- range $i, $e := .Entries -}}
+			{{- $arch := $archSpecific | ternary arch ($e.HasArchitecture arch | ternary arch ($e.Architectures | first)) -}}
+
+			{{- if $e.HasArchitecture $arch -}}
+				{{- /* force bashbrew to "fetch" the GitCommit so that it is fully resolved */ -}}
+				{{- $from := $.ArchDockerFrom $arch $e -}}
+
+				{{- $gitRepo := $e.ArchGitRepo $arch -}}
+				{{- $repoUrlBase := $gitRepo | replace "git://" "https://" | trimSuffixes ".git" -}}
+				{{- $isGitHub := hasPrefix "https://github.com/" $repoUrlBase -}}
+
+				{{- "\t-\t" -}}
+				{{- if $isGitHub -}} [ {{- end -}}
+				{{- $dir := .ArchDirectory $arch -}}
+				{{- $dockerfilePath := ternary "Dockerfile" (join "/" $dir "Dockerfile") (eq $dir ".") -}}
+				` {{- $e.Tags | first -}} ` (* {{- $dockerfilePath -}} *)
+				{{- $gitCommit := $e.ArchGitCommit $arch -}}
+				{{- if $isGitHub -}} ]( {{- $repoUrlBase -}} /blob/ {{- $gitCommit -}} / {{- $dockerfilePath -}} ) {{- end -}}
+				{{- /* TODO decide what to do (if anything) about non-GitHub repos with respect to URL */ -}}
+
+				{{- "\n" -}}
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
+
+	{{- "\n## Simple Tags\n\n" -}}
+{{- end -}}
+
 {{- range $i, $e := $.Entries -}}
 	{{- $arch := $archSpecific | ternary arch ($e.HasArchitecture arch | ternary arch ($e.Architectures | first)) -}}
 


### PR DESCRIPTION
This is based on what we spitballed over in https://github.com/docker-library/go-dockerlibrary/pull/2#issuecomment-277853597 and created an actual `bashbrew cat` format for in https://github.com/docker-library/official-images/issues/2289#issuecomment-279048796. :+1: