### PR TITLE
Add port option in the example without a Dockerfile

### DIFF
--- a/httpd/content.md
+++ b/httpd/content.md
@@ -29,8 +29,9 @@ $ docker run -dit --name my-running-app my-apache2
 If you don't want to include a `Dockerfile` in your project, it is sufficient to do the following:
 
 ```console
-$ docker run -dit --name my-apache-app -p 80:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
+$ docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
 ```
+Please be aware that exposing a port may require root priviliges on your host, depanding your configuration.
 
 ### Configuration
 

--- a/httpd/content.md
+++ b/httpd/content.md
@@ -32,8 +32,6 @@ If you don't want to include a `Dockerfile` in your project, it is sufficient to
 $ docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
 ```
 
-Please be aware that exposing a port may require root priviliges on your host, depanding your configuration.
-
 ### Configuration
 
 To customize the configuration of the httpd server, just `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`.

--- a/httpd/content.md
+++ b/httpd/content.md
@@ -31,6 +31,7 @@ If you don't want to include a `Dockerfile` in your project, it is sufficient to
 ```console
 $ docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
 ```
+
 Please be aware that exposing a port may require root priviliges on your host, depanding your configuration.
 
 ### Configuration

--- a/httpd/content.md
+++ b/httpd/content.md
@@ -29,7 +29,7 @@ $ docker run -dit --name my-running-app my-apache2
 If you don't want to include a `Dockerfile` in your project, it is sufficient to do the following:
 
 ```console
-$ docker run -dit --name my-apache-app -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
+$ docker run -dit --name my-apache-app -p 80:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
 ```
 
 ### Configuration


### PR DESCRIPTION
Add '-p 80:80' to the example without a Dockerfile.
This expose the port 80 so that users can conect to the server through a web client.