### PR TITLE
Remove reference to -sample-config in the telegraf docs

### DIFF
--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -35,7 +35,7 @@ $ docker run --net=container:influxdb telegraf
 First, generate a sample configuration and save it as `telegraf.conf` on the host:
 
 ```console
-$ docker run --rm telegraf -sample-config > telegraf.conf
+$ docker run --rm telegraf telegraf config > telegraf.conf
 ```
 
 Once you've customized `telegraf.conf`, you can run the Telegraf container with it mounted in the expected location:


### PR DESCRIPTION
That command has apparently not existed since 1.0.