### PR TITLE
nginx: ensure best practice when using envsubst

### DIFF
--- a/nginx/content.md
+++ b/nginx/content.md
@@ -82,7 +82,7 @@ web:
   environment:
    - NGINX_HOST=foobar.com
    - NGINX_PORT=80
-  command: /bin/bash -c "envsubst < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+  command: /bin/bash -c "envsubst '$NGINX_HOST $NGINX_PORT' < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
 ```
 
 The `mysite.template` file may then contain variable references like this:


### PR DESCRIPTION
Background: `envsubst` replaces all references that look like references
to variables including those that do not have a corresponding environment
variable - it just replaces those with an empty string. Since it's very
common for nginx.conf to have references like $uri or $host, which are
not definately not to be replaced by environment variables, there is a
need to limit the scope of `envsubsts` by specifying each variable name.

https://stackoverflow.com/questions/46473266/nginx-on-kubernetes-docker-doing-infinite-redirect-when-generating-conf

Also, using `exec nginx` is better, since we can avoid an extra shell
being run and can also make sure that nginx receives the signals
correctly.