### PR TITLE
fix running consul for development

### DIFF
--- a/consul/content.md
+++ b/consul/content.md
@@ -38,15 +38,15 @@ The entry point also includes a small utility to look up a client or bind addres
 ## Running Consul for Development
 
 ```console
-$ docker run -d --name=dev-consul %%IMAGE%%
+$ docker run -d --name=dev-consul -e CONSUL_BIND_INTERFACE=eth0 %%IMAGE%%
 ```
 
 This runs a completely in-memory Consul server agent with default bridge networking and no services exposed on the host, which is useful for development but should not be used in production. For example, if that server is running at internal address 172.17.0.2, you can run a three node cluster for development by starting up two more instances and telling them to join the first node.
 
 ```console
-$ docker run -d %%IMAGE%% agent -dev -join=172.17.0.2
+$ docker run -d -e CONSUL_BIND_INTERFACE=eth0 %%IMAGE%% agent -dev -join=172.17.0.2
 ... server 2 starts
-$ docker run -d %%IMAGE%% agent -dev -join=172.17.0.2
+$ docker run -d -e CONSUL_BIND_INTERFACE=eth0 %%IMAGE%% agent -dev -join=172.17.0.2
 ... server 3 starts
 ```
 


### PR DESCRIPTION
At least under ``Docker version 17.07.0-ce-rc4``,  running consul for development does not work
without being explicit about ``CONSUL_BIND_INTERFACE``