### PR TITLE
Notary is moving home

### DIFF
--- a/notary/content.md
+++ b/notary/content.md
@@ -40,7 +40,7 @@ The components you *must* provide are the certificates and keys, and the links f
 
 If you require a different configuration, you should wrap this image with your own Dockerfile.
 
-For more details on how to configure your Notary server, please read the [docs](https://github.com/docker/notary/blob/master/docs/reference/server-config.md).
+For more details on how to configure your Notary server, please read the [docs](https://github.com/theupdateframework/notary/blob/master/docs/reference/server-config.md).
 
 # Notary Signer
 
@@ -71,10 +71,10 @@ The components you *must* provide are the certificates and keys, and the link fo
 
 If you require a different configuration, you should wrap this image with your own Dockerfile.
 
-For more details on how to configure your Notary signer, please read the [docs](https://github.com/docker/notary/blob/master/docs/reference/signer-config.md).
+For more details on how to configure your Notary signer, please read the [docs](https://github.com/theupdateframework/notary/blob/master/docs/reference/signer-config.md).
 
 ## Database Migrations
 
-Notary server and signer both use the [migrate tool](https://github.com/mattes/migrate) to manage database updates. The migration files can be found [here](https://github.com/docker/notary/tree/master/migrations/) and are an ordered list of plain SQL files. The migrate tool manages schema versions to ensure that migrations start and end at the correct point.
+Notary server and signer both use the [migrate tool](https://github.com/mattes/migrate) to manage database updates. The migration files can be found [here](https://github.com/theupdateframework/notary/tree/master/migrations/) and are an ordered list of plain SQL files. The migrate tool manages schema versions to ensure that migrations start and end at the correct point.
 
 We strongly recommend you create separate databases and users with restricted permissions such that the server cannot access the signer's database and vice versa.

--- a/notary/license.md
+++ b/notary/license.md
@@ -1,1 +1,1 @@
-View [license information](https://github.com/docker/notary/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/theupdateframework/notary/blob/master/LICENSE) for the software contained in this image.


### PR DESCRIPTION
Notary has been accepted in to CNCF and will be moving to `GitHub.com/theupdateframework/notary`. This PR updates the links to point at the new location. I'll circle back here once the move is done to confirm this should be merged, I'm just getting everything staged at this point.

I plan to make the move in the next 48 hours. Most likely some time on Oct 26th. I'm just giving our main known downstreams a chance to respond to the notifications I've sent out.

N.B. the location of the notary official image repo will not be moving in the immediate future, only the location of the primary notary repo.