### PR TITLE
Add ibmnode offical-image documentation

### DIFF
--- a/ibmnode/README-short.txt
+++ b/ibmnode/README-short.txt
@@ -1,1 +1,1 @@
-This is the short description for the docker hub, limited to 100 characters in a single line.
+IBM® SDK for Node.js is an extended implementation of the Node.js open source project.

--- a/ibmnode/README-short.txt
+++ b/ibmnode/README-short.txt
@@ -1,0 +1,1 @@
+This is the short description for the docker hub, limited to 100 characters in a single line.

--- a/ibmnode/content.md
+++ b/ibmnode/content.md
@@ -1,10 +1,11 @@
-# What is XYZ?
+# What is IBM SDK for Node.js?
 
-// about what the contained software is
+The IBM® SDK for Node.js is an extended implementation of the Node.js open source project. Node.js is a JavaScript runtime that is built on the V8 JavaScript engine used by Google Chrome. The IBM SDK extends Node.js by adding support for IBM platforms and extra features such as the diagnostic tool Node Application Metrics (also known as appmetrics).
 
-%%LOGO%%
+For more information about the IBM SDK for Node.js, see http://developer.ibm.com/node/sdk. For more information about Node.js, see http://nodejs.org.
 
 # How to use this image
 
-// descriptions and examples of common use cases for the image
-// make use of subsections as necessary
+You can use the images via the docker run command. The following example creates and starts a Docker container that is derived from the ibmnode image, using Version 6 of the IBM SDK for Node.js, then runs a Node.js app in the container:
+
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/app -w /usr/src/app ibmnode node your-daemon-or-script.js

--- a/ibmnode/content.md
+++ b/ibmnode/content.md
@@ -1,6 +1,8 @@
 # What is IBM SDK for Node.js?
 
-The IBM® SDK for Node.js is an extended implementation of the Node.js open source project. Node.js is a JavaScript runtime that is built on the V8 JavaScript engine used by Google Chrome. The IBM SDK extends Node.js by adding support for IBM platforms and extra features such as the diagnostic tool Node Application Metrics (also known as appmetrics).
+The IBM® SDK for Node.js™ provides a stand-alone JavaScript® runtime and server-side JavaScript solution for IBM platforms. It provides a high-performance, highly scalable, event-driven environment with non-blocking I/O that is programmed with the familiar JavaScript programming language.
+
+The IBM SDK for Node.js is based on the Node.js™ open source project. It provides a compatible solution for IBM Power™, Intel® and z Systems™ products that require Node.js functionality and package management. It also packages additional features including the diagnostic tools Node Application Metrics (also known as appmetrics) and node-report.
 
 For more information about the IBM SDK for Node.js, see http://developer.ibm.com/node/sdk. For more information about Node.js, see http://nodejs.org.
 

--- a/ibmnode/content.md
+++ b/ibmnode/content.md
@@ -1,0 +1,10 @@
+# What is XYZ?
+
+// about what the contained software is
+
+%%LOGO%%
+
+# How to use this image
+
+// descriptions and examples of common use cases for the image
+// make use of subsections as necessary

--- a/ibmnode/get-help.md
+++ b/ibmnode/get-help.md
@@ -1,0 +1,1 @@
+[IBM® SDK for Node.js](https://www.ibm.com/developerworks/community/groups/community/node#fullpageWidgetId=Wca143b2f9b91_4fc1_9180_94ad850643e2)

--- a/ibmnode/github-repo
+++ b/ibmnode/github-repo
@@ -1,0 +1,1 @@
+https://github.com/ibmruntimes/ci.docker

--- a/ibmnode/license.md
+++ b/ibmnode/license.md
@@ -1,5 +1,5 @@
 Licenses for the products installed within the images:
 
-- IBM® SDK for Node.js™ Version 8: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PMAA-A3Z8P2&title=IBM® SDK, Java™ Technology Edition Docker Image, Version 8.0&l=en).
--	IBM® SDK for Node.js™ Version 6: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-JWOD-AFSFP8&title=IBM® SDK, Java™ Technology Edition Version 9.0 Early Access&l=en).
--	IBM® SDK for Node.js™ Version 4: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-JWOD-AFSFP8&title=IBM® SDK, Java™ Technology Edition Version 9.0 Early Access&l=en).
+- IBM® SDK for Node.js™ Version 8: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PIVN-ARVHJN).
+-	IBM® SDK for Node.js™ Version 6: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PIVN-AR5EGT).
+-	IBM® SDK for Node.js™ Version 4: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PIVN-AKUEV2).

--- a/ibmnode/license.md
+++ b/ibmnode/license.md
@@ -1,0 +1,1 @@
+View [license information]() for the software contained in this image.

--- a/ibmnode/license.md
+++ b/ibmnode/license.md
@@ -1,1 +1,5 @@
-View [license information]() for the software contained in this image.
+Licenses for the products installed within the images:
+
+- IBM® SDK for Node.js™ Version 8: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PMAA-A3Z8P2&title=IBM® SDK, Java™ Technology Edition Docker Image, Version 8.0&l=en).
+-	IBM® SDK for Node.js™ Version 6: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-JWOD-AFSFP8&title=IBM® SDK, Java™ Technology Edition Version 9.0 Early Access&l=en).
+-	IBM® SDK for Node.js™ Version 4: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-JWOD-AFSFP8&title=IBM® SDK, Java™ Technology Edition Version 9.0 Early Access&l=en).

--- a/ibmnode/maintainer.md
+++ b/ibmnode/maintainer.md
@@ -1,0 +1,1 @@
+[IBM Runtime Technologies](%%GITHUB-REPO%%)


### PR DESCRIPTION
Add ibmnode offical-image documentation

docker-library/official-images PR: https://github.com/docker-library/official-images/pull/3612