### PR TITLE
Add an additional common boilerplate to the "License" section of all images

### DIFF
--- a/.template-helpers/license-common.md
+++ b/.template-helpers/license-common.md
@@ -1,0 +1,5 @@
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+Some additional license information which was able to be auto-detected might be found in [the `repo-info` repository's `%%REPO%%/` directory](https://github.com/docker-library/repo-info/tree/master/repos/%%REPO%%).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/update.sh
+++ b/update.sh
@@ -44,8 +44,9 @@ for image in "${images[@]}"; do
 		getHelp="$(cat "$repo/get-help.md" 2>/dev/null || cat "$helperDir/get-help.md")"
 
 		license="$(cat "$repo/license.md" 2>/dev/null || true)"
+		licenseCommon="$(cat "$repo/license-common.md" 2>/dev/null || cat "$helperDir/license-common.md")"
 		if [ "$license" ]; then
-			license=$'\n\n''# License'$'\n\n'"$license"
+			license=$'\n\n''# License'$'\n\n'"$license"$'\n\n'"$licenseCommon"
 		fi
 
 		logo=


### PR DESCRIPTION
This is an attempt to address the additional note by @thresheek over in https://github.com/docker-library/docs/issues/1046#issuecomment-340093102. :+1: