### PR TITLE
Adjust "POSTGRES_INITDB_XLOGDIR" to "POSTGRES_INITDB_WALDIR" (with an added note for 9.x)

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -72,9 +72,11 @@ This optional environment variable can be used to define a different name for th
 
 This optional environment variable can be used to send arguments to `postgres initdb`. The value is a space separated string of arguments as `postgres initdb` would expect them. This is useful for adding functionality like data page checksums: `-e POSTGRES_INITDB_ARGS="--data-checksums"`.
 
-### `POSTGRES_INITDB_XLOGDIR`
+### `POSTGRES_INITDB_WALDIR`
 
 This optional environment variable can be used to define another location for the Postgres transaction log. By default the transaction log is stored in a subdirectory of the main Postgres data folder (`PGDATA`). Sometimes it can be desireable to store the transaction log in a different directory which may be backed by storage with different performance or reliability characteristics.
+
+**Note:** on PostgreSQL 9.x, this variable is `POSTGRES_INITDB_XLOGDIR` (reflecting [the changed name of the `--xlogdir` flag to `--waldir` in PostgreSQL 10+](https://wiki.postgresql.org/wiki/New_in_postgres_10#Renaming_of_.22xlog.22_to_.22wal.22_Globally_.28and_location.2Flsn.29)).
 
 ## Docker Secrets
 


### PR DESCRIPTION
See https://github.com/docker-library/postgres/pull/374 and https://github.com/docker-library/postgres/issues/372.