### PR TITLE
change docs to use --node not --name for starting consul

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -86,7 +86,7 @@ The entry point also includes a small utility to look up a client or bind addres
 ## Running Consul for Development
 
 ```console
-$ docker run -d --name=dev-consul -e CONSUL_BIND_INTERFACE=eth0 consul
+$ docker run -d --node=dev-consul -e CONSUL_BIND_INTERFACE=eth0 consul
 ```
 
 This runs a completely in-memory Consul server agent with default bridge networking and no services exposed on the host, which is useful for development but should not be used in production. For example, if that server is running at internal address 172.17.0.2, you can run a three node cluster for development by starting up two more instances and telling them to join the first node.


### PR DESCRIPTION
I needed to use --node to start consul.  