### PR TITLE
Add Alpine license link

### DIFF
--- a/alpine/license.md
+++ b/alpine/license.md
@@ -1,0 +1,1 @@
+View [license information](https://pkgs.alpinelinux.org) for the software contained in this image.


### PR DESCRIPTION
cc @andyshinn @ncopa -- does this seem like a sane place to link for this?

For context, it will also have https://github.com/docker-library/docs/blob/a857080d495c0a0a69299733a6343ca12b77ba45/.template-helpers/license-common.md appended to the end.

Refs #1046