### PR TITLE
Add CentOS license link

### DIFF
--- a/centos/license.md
+++ b/centos/license.md
@@ -1,0 +1,1 @@
+View [license information](https://www.centos.org/legal/) for the software contained in this image.


### PR DESCRIPTION
cc @jperrin -- does this seem like a sane place to link for this?

For context, it will also have https://github.com/docker-library/docs/blob/a857080d495c0a0a69299733a6343ca12b77ba45/.template-helpers/license-common.md appended to the end.

Refs #1046