### PR TITLE
Add CirrOS license information

### DIFF
--- a/cirros/license.md
+++ b/cirros/license.md
@@ -1,0 +1,3 @@
+View [license information](https://launchpad.net/cirros) for the software contained in this image:
+
+> The code for building CirrOS is available under GPLv2. The binary images that will be distributed contain many different licenses all of which are opensource.


### PR DESCRIPTION
fyi @ewindisch -- this is the best I can find anywhere, even digging through the upstream Git repo :sweat_smile:

For context, it will also have https://github.com/docker-library/docs/blob/a857080d495c0a0a69299733a6343ca12b77ba45/.template-helpers/license-common.md appended to the end.

Refs #1046