### PR TITLE
Add Registry license link

### DIFF
--- a/registry/license.md
+++ b/registry/license.md
@@ -1,0 +1,1 @@
+View [license information](https://github.com/docker/distribution/blob/master/LICENSE) for the software contained in this image.


### PR DESCRIPTION
fyi @stevvooe @dmp42 @RichardScothern @aaronlehmann @dmcgowan -- this seems like the most appropriate place to link for license information on the Registry image :smile:

For context, it will also have https://github.com/docker-library/docs/blob/a857080d495c0a0a69299733a6343ca12b77ba45/.template-helpers/license-common.md appended to the end.

Refs #1046