### PR TITLE
Add a link to "Dockerizing Compiled Software" in the "PHP Core Extensions" section of PHP's docs

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -105,6 +105,8 @@ RUN apt-get update && apt-get install -y \
 
 Remember, you must install dependencies for your extensions manually. If an extension needs custom `configure` arguments, you can use the `docker-php-ext-configure` script like this example. There is no need to run `docker-php-source` manually in this case, since that is handled by the `configure` and `install` scripts.
 
+See ["Dockerizing Compiled Software"](https://tianon.xyz/post/2017/12/26/dockerize-compiled-software.html) for a description of the technique Tianon uses for determining the necessary build-time dependencies for any bit of software (which applies directly to compiling PHP extensions).
+
 #### PECL extensions
 
 Some extensions are not provided with the PHP source, but are instead available through [PECL](https://pecl.php.net/). To install a PECL extension, use `pecl install` to download and compile it, then use `docker-php-ext-enable` to enable it:


### PR DESCRIPTION
This blog post (https://tianon.xyz/post/2017/12/26/dockerize-compiled-software.html) is a slightly longer-form explanation of what I outlined over in https://github.com/docker-library/php/issues/75#issuecomment-353673374. :+1: