### PR TITLE
Add a pointer to MySQL upstream's "environment variables" docs

### DIFF
--- a/mysql/content.md
+++ b/mysql/content.md
@@ -98,6 +98,8 @@ $ docker run -it --rm %%IMAGE%%:tag --verbose --help
 
 When you start the `%%IMAGE%%` image, you can adjust the configuration of the MySQL instance by passing one or more environment variables on the `docker run` command line. Do note that none of the variables below will have any effect if you start the container with a data directory that already contains a database: any pre-existing database will always be left untouched on container startup.
 
+See also https://dev.mysql.com/doc/refman/5.7/en/environment-variables.html for documentation of environment variables which MySQL itself respects (especially variables like `MYSQL_HOST`, which is known to cause issues when used with this image).
+
 ### `MYSQL_ROOT_PASSWORD`
 
 This variable is mandatory and specifies the password that will be set for the MySQL `root` superuser account. In the above example, it was set to `my-secret-pw`.


### PR DESCRIPTION
Closes docker-library/mysql#184