### PR TITLE
Add a note about blocked Debian PHP packages

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -159,6 +159,18 @@ RUN curl -fsSL 'https://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.
 	&& rm -r /tmp/xcache
 ```
 
+#### "`E: Package 'php-XXX' has no installation candidate"`"
+
+As of [docker-library/php#542](https://github.com/docker-library/php/pull/542), this image blocks the installation of Debian's PHP packages. There is some additional discussion of this change in [docker-library/php#551 (comment)](https://github.com/docker-library/php/issues/551#issuecomment-354849074), but the gist is that installing Debian's PHP packages in this image leads to two conflicting installations of PHP in a single image, which is almost certainly not the intended outcome.
+
+For those broken by this change and looking for a workaround to apply in the meantime while a proper fix is developed, adding the following simple line to your `Dockerfile` should remove the block (**with the strong caveat that this will allow the installation of a second installation of PHP, which is definitely not what you're looking for unless you *really* know what you're doing**):
+
+```dockerfile
+RUN rm /etc/apt/preferences.d/no-debian-php
+```
+
+The *proper* solution to this error is to either use `FROM debian:XXX` and install Debian's PHP packages directly, or to use `docker-php-ext-install`, `pecl`, and/or `phpize` to install the necessary additional extensions and utilities.
+
 ### Changing `DocumentRoot`
 
 Some applications may wish to change the default `DocumentRoot` in Apache (away from `/var/www/html`). The following demonstrates one way to do so using an environment variable (which can then be modified at container runtime as well):


### PR DESCRIPTION
This documents the change in https://github.com/docker-library/php/pull/542 with some of the details discussed in https://github.com/docker-library/php/issues/551#issuecomment-354849074.

Closes https://github.com/docker-library/php/issues/551