### PR TITLE
Update Joomla stack/compose example

### DIFF
--- a/joomla/README.md
+++ b/joomla/README.md
@@ -97,9 +97,6 @@ version: '3.1'
 services:
   joomla:
     image: joomla
-    restart: always
-    links:
-      - joomladb:mysql
     ports:
       - 8080:80
     environment:
@@ -108,7 +105,6 @@ services:
 
   joomladb:
     image: mysql:5.6
-    restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
 ```


### PR DESCRIPTION
The Joomla README example of a stack.yml file could use updating to remove legacy/confusing options:

1. Links are no longer needed as of compose v2. Since this example uses v3.1, links should be removed.
2. restart: option is only used for docker-compose, while restart_policy: is only used for stack deploy. Since it's an option setting, I'd recommend removing it from the example to avoid confusion like this question on SO.