### PR TITLE
Update Rust examples version to 1.23.0 and fix a typo

### DIFF
--- a/rust/content.md
+++ b/rust/content.md
@@ -32,7 +32,7 @@ $ docker run -it --rm --name my-running-app my-rust-app
 
 ## Compile your app inside the Docker container
 
-There may be occasions where it is not appropriate to run your app inside a container. To compiler, but not run your app inside the Docker instance, you can write something like:
+There may be occasions where it is not appropriate to run your app inside a container. To compile, but not run your app inside the Docker instance, you can write something like:
 
 ```console
 $ docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.19.0 cargo build --release

--- a/rust/content.md
+++ b/rust/content.md
@@ -13,7 +13,7 @@ Rust is a systems programming language sponsored by Mozilla Research. It is desi
 The most straightforward way to use this image is to use a Rust container as both the build and runtime environment. In your `Dockerfile`, writing something along the lines of the following will compile and run your project:
 
 ```dockerfile
-FROM %%IMAGE%%:1.19.0
+FROM %%IMAGE%%:1.23.0
 
 WORKDIR /usr/src/myapp
 COPY . .
@@ -35,7 +35,7 @@ $ docker run -it --rm --name my-running-app my-rust-app
 There may be occasions where it is not appropriate to run your app inside a container. To compile, but not run your app inside the Docker instance, you can write something like:
 
 ```console
-$ docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.19.0 cargo build --release
+$ docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.23.0 cargo build --release
 ```
 
 This will add your current directory, as a volume, to the container, set the working directory to the volume, and run the command `cargo build --release`. This tells Cargo, Rust's build system, to compile the crate in `myapp` and output the executable to `target/release/myapp`.


### PR DESCRIPTION
This is a small tweak to update the example version of Rust used in the docs (which is getting quite old) and fix a small typo.