### PR TITLE
Update stack.yml

### DIFF
--- a/bonita/stack.yml
+++ b/bonita/stack.yml
@@ -22,7 +22,7 @@ services:
       - TENANT_PASSWORD=secret
       - PLATFORM_LOGIN=pfadmin
       - PLATFORM_PASSWORD=pfsecret
-    restart: always
+    restart: on-failure:2
     depends_on:
       - db
     entrypoint:
@@ -34,6 +34,7 @@ services:
         export PGPASSWORD="$$POSTGRES_ENV_POSTGRES_PASSWORD"
         maxTries=10
         while [ "$$maxTries" -gt 0 ] && ! psql -h "$$DB_HOST" -U 'postgres' -c '\l'; do
+            let maxTries--
             sleep 1
         done
         echo


### PR DESCRIPTION
fix(entrypoint): infinite loop in postgres check

* maxTries was not modified, so in case PostgreSQL is down, we have un infinite loop
* also change settings for restart policy, so that we can observe container stopping