### PR TITLE
telegraf: remove deprecated port forwarding

### DIFF
--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -21,7 +21,7 @@ The default configuration requires a running InfluxDB instance as an output plug
 Minimal example to start an InfluxDB container:
 
 ```console
-$ docker run -d --name influxdb -p 8083:8083 -p 8086:8086 influxdb
+$ docker run -d --name influxdb -p 8086:8086 influxdb
 ```
 
 Starting Telegraf using the default config, which connects to InfluxDB at `http://localhost:8086/`:


### PR DESCRIPTION
8083 was the port for the deprecated admin UI which has since then been replaced with Chronograf.

See https://docs.influxdata.com/influxdb/v1.4/tools/web_admin/ and https://docs.influxdata.com/chronograf/v1.4/guides/transition-web-admin-interface/ for more information