### PR TITLE
Updating postgres notes/example

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -142,7 +142,7 @@ For example, to add an additional user and database, add the following to `/dock
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -d "$POSTGRES_DB" <<-EOSQL
 	CREATE USER docker;
 	CREATE DATABASE docker;
 	GRANT ALL PRIVILEGES ON DATABASE docker TO docker;


### PR DESCRIPTION
The example init script in this documentation fails when the `$POSTGRES_USER` and `$POSTGRES_DB` values mismatch.  By default, `psql` attempts to set the database in use to the same name as the logging in `$POSTGRES_USER`, so without setting the `-d` flag users will encounter an error similar to: psql: FATAL:  database "root" does not exist when they don't match.  Related to docker-library/postgres#41