### PR TITLE
Correct file names in Jetty documentation

### DIFF
--- a/jetty/content.md
+++ b/jetty/content.md
@@ -58,7 +58,7 @@ FROM %%IMAGE%%
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,stats
 ```
 
-Modules may be configured in a `Dockerfile` by editing the properties in the corresponding `/var/lib/jetty/start.d/*.mod` file or the module can be deactivated by removing that file.
+Modules may be configured in a `Dockerfile` by editing the properties in the corresponding `/var/lib/jetty/start.d/*.ini` file or the module can be deactivated by removing that file.
 
 ### JVM Configuration
 


### PR DESCRIPTION
The `start.d` files are called `*.ini` (not `*.mod`, as was stated in
the previous documentation)