### PR TITLE
Correct wrong parameter name in Jetty docs

### DIFF
--- a/jetty/content.md
+++ b/jetty/content.md
@@ -47,7 +47,7 @@ $ docker run -d %%IMAGE%% --list-config
 Configuration such as parameters and additional modules may also be passed in via the command line. For example:
 
 ```console
-$ docker run -d %%IMAGE%% --modules=jmx jetty.threadPool.maxThreads=500
+$ docker run -d %%IMAGE%% --module=jmx jetty.threadPool.maxThreads=500
 ```
 
 To update the server configuration in a derived Docker image, the `Dockerfile` may enable additional modules with `RUN` commands like:


### PR DESCRIPTION
To run Jetty with particular modules, use the `--module` option; the
previous doc said `--modules`. The Jetty documentation
https://www.eclipse.org/jetty/documentation/9.3.x/startup.html
references the `--module` option many times, but never `--modules`.