### PR TITLE
Add "git-prefetch" script to avoid errors like "fatal: Couldn't find remote ref refs/heads/centos-7armhfp"

### DIFF
--- a/.template-helpers/git-prefetch.sh
+++ b/.template-helpers/git-prefetch.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo="${1:-}"
+if [ -z "$repo" ]; then
+	echo >&2 "usage: $0 repo"
+	echo >&2 "   ie: $0 hylang"
+	exit 1
+fi
+
+# if we haven't set BASHBREW_LIBRARY explicitly (like Jenkins does, for example), don't trust the local library
+if [ -z "${BASHBREW_LIBRARY:-}" ]; then
+	repo="https://github.com/docker-library/official-images/raw/master/library/$repo"
+fi
+
+: "${BASHBREW_CACHE:=$HOME/.cache/bashbrew}"
+export BASHBREW_CACHE
+
+# see "generate-dockerfile-links-partial.tmpl" for where our arch-choosing complexity comes from
+templateHeader='{{- $archSpecific := getenv "ARCH_SPECIFIC_DOCS" -}}'
+templateArchVar='{{- $arch := $archSpecific | ternary arch ($e.HasArchitecture arch | ternary arch ($e.Architectures | first)) -}}'
+
+tags="$(bashbrew list --uniq "$repo" | cut -d: -f2-)"
+tags=( $tags )
+toFetch=()
+for tag in "$tags"; do
+	if ! bashbrew cat --format '
+		'"$templateHeader"'
+		{{- $e := $.TagEntry -}}
+		'"$templateArchVar"'
+		{{- if $e.HasArchitecture $arch -}}
+			{{- $from := $.ArchDockerFrom $arch $e -}}
+		{{- end -}}
+	' "$repo:$tag" &> /dev/null; then
+		toFetch+=( "$repo:$tag" )
+	fi
+done
+
+if [ "${#toFetch[@]}" -eq 0 ]; then
+	exit 0
+fi
+
+bashbrewFetchTemplate='
+	'"$templateHeader"'
+	{{- range $i, $e := $.Entries -}}
+		'"$templateArchVar"'
+		{{- if $e.HasArchitecture $arch -}}
+			{{- join "/" "refs/tags" $arch $.RepoName ($e.Tags | first) -}}
+			{{- ":" -}}
+			{{- "\n" -}}
+		{{- end -}}
+	{{- end -}}
+'
+
+bashbrew cat --format "$bashbrewFetchTemplate" "$repo" \
+	| xargs --no-run-if-empty git -C "$BASHBREW_CACHE/git" fetch --quiet --no-tags https://github.com/docker-library/commit-warehouse.git

--- a/update.sh
+++ b/update.sh
@@ -110,6 +110,9 @@ for image in "${images[@]}"; do
 			deprecated+=$'\n\n'
 		fi
 
+		echo '  GIT PREFETCH => "'"$repo"'"'
+		"$helperDir/git-prefetch.sh" "$repo"
+
 		targetFile="$repo/README.md"
 
 		{


### PR DESCRIPTION
In many cases this will be a no-op, but in cases where we don't have the current version fetched, it'll pre-pull the commits from bad-ideas (so we don't fail further down while generating our tag link list).

See https://doi-janky.infosiftr.net/view/flat/job/docs/job/arm32v7/3447/console for a recent example (failing for a few days now).