### PR TITLE
Zookeeper - Fix link to Dynamic Reconfiguration

### DIFF
--- a/zookeeper/content.md
+++ b/zookeeper/content.md
@@ -94,7 +94,7 @@ The id must be unique within the ensemble and should have a value between 1 and 
 
 This variable allows you to specify a list of machines of the Zookeeper ensemble. Each entry has the form of `server.id=host:port:port`. Entries are separated with space. Do note that this variable will not have any effect if you start the container with a `/conf` directory that already contains the `zoo.cfg` file.
 
-In 3.5, the syntax of this has changed. Servers should be specified as such: `server.id=<address1>:<port1>:<port2>[:role];[<client port address>:]<client port>` [Zookeeper Dynamic Reconfiguration](http://zookeeper.apache.org/doc/trunk/zookeeperReconfig.html)
+In 3.5, the syntax of this has changed. Servers should be specified as such: `server.id=<address1>:<port1>:<port2>[:role];[<client port address>:]<client port>` [Zookeeper Dynamic Reconfiguration](http://zookeeper.apache.org/doc/r3.5.3-beta/zookeeperReconfig.html)
 
 ## Where to store data
 


### PR DESCRIPTION
Hi,

The link for the Dynamic Reconfiguration is not working, I updated it with the latest version available for 3.5.

I didn't push the README because it has another modification when I run `update.sh`:
```diff

 -      **Supported architectures**: ([more info](https://github.com/docker-library/official-images#architectures-other-than-amd64))
-       [`amd64`](https://hub.docker.com/r/amd64/zookeeper/), [`arm32v6`](https://hub.docker.com/r/arm32v6/zookeeper/), [`arm64v8`](https://hub.docker.com/r/arm64v8/zookeeper/), [`i386`](https://hub.docker.com/r/i386/zookeeper/), [`ppc64le`](https://hub.docker.com/r/ppc64le/zookeeper/), [`s390x`](https://hub.docker.com/r/s390x/zookeeper/)
+       `amd64`, `arm32v6`, `arm64v8`, `i386`, `ppc64le`, `s390x`
```
