### PR TITLE
Add section about Ruby image assumptions

### DIFF
--- a/ruby/content.md
+++ b/ruby/content.md
@@ -54,3 +54,11 @@ $ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/
 ## Encoding
 
 By default, Ruby inherits the locale of the environment in which it is run. For most users running Ruby on their desktop systems, that means it's likely using some variation of `*.UTF-8` (`en_US.UTF-8`, etc). In Docker however, the default locale is `C`, which can have unexpected results. If your application needs to interact with UTF-8, it is recommended that you explicitly adjust the locale of your image/container via `-e LANG=C.UTF-8` or `ENV LANG C.UTF-8`.
+
+## Image assumptions
+
+This image sets several environment variables which change the behavior of Bundler and Gem for running a single application within a container (especially in such a way that the development sources of the application can be bind-mounted inside a container and not have `.bundle` from the host interfere with the proper functionality of the container).
+
+The environment variables we set are canonically listed in the above-linked `Dockerfiles`, but some of them include `GEM_HOME`, `BUNDLE_PATH`, `BUNDLE_BIN`, `BUNDLE_SILENCE_ROOT_WARNING`, and `BUNDLE_APP_CONFIG`.
+
+If these cause issues for your use case (running multiple Ruby applications in a single container, for example), setting them to the empty string *should* be sufficient for undoing their behavior.


### PR DESCRIPTION
Closes https://github.com/docker-library/ruby/issues/129
Closes https://github.com/docker-library/ruby/issues/83
Closes https://github.com/docker-library/ruby/pull/191
Closes https://github.com/docker-library/ruby/issues/188

I've verified that this recommendation works by taking the `Dockerfile` provided in https://github.com/docker-library/ruby/issues/188#issuecomment-368440687 and adding `ENV BUNDLE_BIN=` (to unset `BUNDLE_BIN`):

```dockerfile
FROM ruby:2.4

ENV BUNDLE_BIN=

RUN set -ex;\
    git clone https://github.com/jwt/ruby-jwt.git;\
    cd ruby-jwt;\
    bundle install;\
    cd ..;\
    git clone https://github.com/janlelis/clipboard.git;\
    cd clipboard;\
    bundle install;\
    ls -la /clipboard/Gemfile.lock
```

```console
$ docker build --pull .
Sending build context to Docker daemon  2.048kB
...
Step 2/3 : ENV BUNDLE_BIN=
...
Step 3/3 : RUN set -ex;    git clone https://github.com/jwt/ruby-jwt.git;    cd ruby-jwt;    bundle install;    cd ..;    git clone https://github.com/janlelis/clipboard.git;    cd clipboard;    bundle install;    ls -la /clipboard/Gemfile.lock
...
+ ls -la /clipboard/Gemfile.lock
-rw-r--r-- 1 root root 661 May 11 20:54 /clipboard/Gemfile.lock
Removing intermediate container fbd54d26c43b
 ---> 399ec4e9f562
Successfully built 399ec4e9f562
```