### PR TITLE
psql command with the --dbname params 

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -142,7 +142,7 @@ For example, to add an additional user and database, add the following to `/dock
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
 	CREATE USER docker;
 	CREATE DATABASE docker;
 	GRANT ALL PRIVILEGES ON DATABASE docker TO docker;


### PR DESCRIPTION
On `How to extend this image` section, using the script with environment variables given below fails.

File: `docker-entrypoint-initdb.d/init-user-db.sh`
```
#!/bin/bash
set -e

psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
	CREATE USER docker;
	CREATE DATABASE docker;
	GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
EOSQL
```

`Environment variables`
```
POSTGRES_USER=testuser
POSTGRES_PASSWORD=testpassword
POSTGRES_DB=mytestdb
```

Error 
```
database "testuser" does not exist
```

The `psql` command is looking for the default database (that is not available). Instead we can pass `--dbname` argument to ask `psql` command to look for newly created database.


File: `docker-entrypoint-initdb.d/init-user-db.sh`
```
#!/bin/bash
set -e

psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
	CREATE USER docker;
	CREATE DATABASE docker;
	GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
EOSQL
```