### PR TITLE
README: Add port map -p 8080:80 to a docker run

### DIFF
--- a/httpd/README.md
+++ b/httpd/README.md
@@ -70,8 +70,9 @@ Then, run the commands to build and run the Docker image:
 
 ```console
 $ docker build -t my-apache2 .
-$ docker run -dit --name my-running-app my-apache2
+$ docker run -dit --name my-running-app -p 8080:80 my-apache2
 ```
+Visit http://localhost:8080/ and see It works!
 
 ### Without a `Dockerfile`
 


### PR DESCRIPTION
Adding port map -p 8080:80 to a docker run command
And a link to localhost:8080
To make this readme more newbie friendly