### PR TITLE
GET to create db is deprecated, replace with POST

### DIFF
--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -160,7 +160,7 @@ To use the administrator interface, both the HTTP API and the administrator inte
 Creating a DB named mydb:
 
 ```console
-$ curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
+$ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
 ```
 
 Inserting into the DB:


### PR DESCRIPTION
on the HTTP API section, the GET method of the API call to create a db is deprecated.
Doing so will generate a JSON warning response saying it is deprecated.