### PR TITLE
Update Rabbitmq docs

### DIFF
--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -153,6 +153,14 @@ FROM rabbitmq:3.7-management
 RUN rabbitmq-plugins enable --offline rabbitmq_mqtt rabbitmq_federation_management rabbitmq_stomp
 ```
 
+You can also mount a file at `/etc/rabbitmq/enabled_plugins` with contents as an erlang list of atoms ending with a period.
+
+Example `enabled_plugins`
+
+```bash
+[rabbitmq_federation_management,rabbitmq_management,rabbitmq_mqtt,rabbitmq_stomp].
+```
+
 ### Additional Configuration
 
 If additional configuration is required, it is recommended to use the `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable, whose syntax is described [in section 7.8 ("Configuring an Application") of the Erlang OTP Design Principles User's Guide](http://erlang.org/doc/design_principles/applications.html#id81887) (the appropriate value for `-ApplName` is `-rabbit`).

--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -93,7 +93,7 @@ You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser
 A small selection of the possible environment variables are defined in the Dockerfile to be passed through the docker engine (listed below). For the full comprehensive list of possible variables (which are implemented through the rabbitmq.conf) see: https://www.rabbitmq.com/configure.html
 
 For SSL configuration without the management plugin:
-```
+```bash
 RABBITMQ_SSL_CACERTFILE
 RABBITMQ_SSL_CERTFILE
 RABBITMQ_SSL_DEPTH
@@ -103,7 +103,7 @@ RABBITMQ_SSL_VERIFY
 ```
 
 For SSL configuration using the rabbitmq:management plugin:
-```
+```bash
 RABBITMQ_MANAGEMENT_SSL_CACERTFILE
 RABBITMQ_MANAGEMENT_SSL_CERTFILE
 RABBITMQ_MANAGEMENT_SSL_DEPTH

--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -92,22 +92,25 @@ You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser
 
 A small selection of the possible environment variables are defined in the Dockerfile to be passed through the docker engine (listed below). For the full comprehensive list of possible variables (which are implemented through the rabbitmq.conf) see: https://www.rabbitmq.com/configure.html
 
-For SSL configuration without the management plugin:  
-RABBITMQ_SSL_CACERTFILE  
-RABBITMQ_SSL_CERTFILE  
-RABBITMQ_SSL_DEPTH  
-RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT  
-RABBITMQ_SSL_KEYFILE  
-RABBITMQ_SSL_VERIFY  
+For SSL configuration without the management plugin:
+```
+RABBITMQ_SSL_CACERTFILE
+RABBITMQ_SSL_CERTFILE
+RABBITMQ_SSL_DEPTH
+RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT
+RABBITMQ_SSL_KEYFILE
+RABBITMQ_SSL_VERIFY
+```
 
-For SSL configuration using the rabbitmq:management plugin:  
-RABBITMQ_MANAGEMENT_SSL_CACERTFILE  
-RABBITMQ_MANAGEMENT_SSL_CERTFILE  
-RABBITMQ_MANAGEMENT_SSL_DEPTH  
-RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT  
-RABBITMQ_MANAGEMENT_SSL_KEYFILE  
-RABBITMQ_MANAGEMENT_SSL_VERIFY  
-
+For SSL configuration using the rabbitmq:management plugin:
+```
+RABBITMQ_MANAGEMENT_SSL_CACERTFILE
+RABBITMQ_MANAGEMENT_SSL_CERTFILE
+RABBITMQ_MANAGEMENT_SSL_DEPTH
+RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT
+RABBITMQ_MANAGEMENT_SSL_KEYFILE
+RABBITMQ_MANAGEMENT_SSL_VERIFY
+```
 
 ### Setting default user and password
 

--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -93,6 +93,7 @@ You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser
 A small selection of the possible environment variables are defined in the Dockerfile to be passed through the docker engine (listed below). For the full comprehensive list of possible variables (which are implemented through the rabbitmq.conf) see: https://www.rabbitmq.com/configure.html
 
 For SSL configuration without the management plugin:
+
 ```bash
 RABBITMQ_SSL_CACERTFILE
 RABBITMQ_SSL_CERTFILE
@@ -103,6 +104,7 @@ RABBITMQ_SSL_VERIFY
 ```
 
 For SSL configuration using the rabbitmq:management plugin:
+
 ```bash
 RABBITMQ_MANAGEMENT_SSL_CACERTFILE
 RABBITMQ_MANAGEMENT_SSL_CERTFILE

--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -88,6 +88,27 @@ $ docker run -d --hostname my-rabbit --name some-rabbit -p 8080:15672 %%IMAGE%%:
 
 You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser.
 
+### Environment Variables
+
+A small selection of the possible environment variables are defined in the Dockerfile to be passed through the docker engine (listed below). For the full comprehensive list of possible variables (which are implemented through the rabbitmq.conf) see: https://www.rabbitmq.com/configure.html
+
+For SSL configuration without the management plugin:  
+RABBITMQ_SSL_CACERTFILE  
+RABBITMQ_SSL_CERTFILE  
+RABBITMQ_SSL_DEPTH  
+RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT  
+RABBITMQ_SSL_KEYFILE  
+RABBITMQ_SSL_VERIFY  
+
+For SSL configuration using the rabbitmq:management plugin:  
+RABBITMQ_MANAGEMENT_SSL_CACERTFILE  
+RABBITMQ_MANAGEMENT_SSL_CERTFILE  
+RABBITMQ_MANAGEMENT_SSL_DEPTH  
+RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT  
+RABBITMQ_MANAGEMENT_SSL_KEYFILE  
+RABBITMQ_MANAGEMENT_SSL_VERIFY  
+
+
 ### Setting default user and password
 
 If you wish to change the default username and password of `guest` / `guest`, you can do so with the `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` environmental variables:
@@ -117,6 +138,15 @@ For enabling the HiPE compiler on startup use `RABBITMQ_HIPE_COMPILE` set to `1`
 > Set to true to precompile parts of RabbitMQ with HiPE, a just-in-time compiler for Erlang. This will increase server throughput at the cost of increased startup time. You might see 20-50% better performance at the cost of a few minutes delay at startup.
 
 It is therefore important to take that startup delay into consideration when configuring health checks, automated clustering etc.
+
+### Enabling Plugins
+
+Creating a Dockerfile will have them enabled at runtime. To see the full list of plugins present on the image `rabbitmq-plugins list`
+
+```Dockerfile
+FROM rabbitmq:3.7-management
+RUN rabbitmq-plugins enable --offline rabbitmq_mqtt rabbitmq_federation_management rabbitmq_stomp
+```
 
 ### Additional Configuration
 

--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -90,7 +90,7 @@ You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser
 
 ### Environment Variables
 
-A small selection of the possible environment variables are defined in the Dockerfile to be passed through the docker engine (listed below). For the full comprehensive list of possible variables (which are implemented through the rabbitmq.conf) see: https://www.rabbitmq.com/configure.html
+A small selection of the possible environment variables are defined in the Dockerfile to be passed through the docker engine (listed below). For a list of environment variables supported by RabbitMQ itself, see: https://www.rabbitmq.com/configure.html
 
 For SSL configuration without the management plugin:
 
@@ -103,7 +103,7 @@ RABBITMQ_SSL_KEYFILE
 RABBITMQ_SSL_VERIFY
 ```
 
-For SSL configuration using the rabbitmq:management plugin:
+For SSL configuration using the management plugin:
 
 ```bash
 RABBITMQ_MANAGEMENT_SSL_CACERTFILE


### PR DESCRIPTION
Closes https://github.com/docker-library/rabbitmq/issues/138 
Closes https://github.com/docker-library/rabbitmq/issues/264

https://www.rabbitmq.com/relocate.html
Adding this is probably unecessary, users should familiarize themselves with the documentation

Can rabbitmq reload the .conf, or must it be mounted so as to be configured before runtime?