### PR TITLE
Update examples to use PHP 7.2 instead of 7.0

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -15,7 +15,7 @@ For PHP projects run through the command line interface (CLI), you can do the fo
 ### Create a `Dockerfile` in your PHP project
 
 ```dockerfile
-FROM %%IMAGE%%:7.0-cli
+FROM %%IMAGE%%:7.2-cli
 COPY . /usr/src/myapp
 WORKDIR /usr/src/myapp
 CMD [ "php", "./your-script.php" ]
@@ -33,7 +33,7 @@ $ docker run -it --rm --name my-running-app my-php-app
 For many simple, single file projects, you may find it inconvenient to write a complete `Dockerfile`. In such cases, you can run a PHP script by using the PHP Docker image directly:
 
 ```console
-$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:7.0-cli php your-script.php
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:7.2-cli php your-script.php
 ```
 
 Note that all variants of the `php` image contain the PHP cli.
@@ -45,7 +45,7 @@ More commonly, you will probably want to run PHP in conjunction with Apache http
 ### Create a `Dockerfile` in your PHP project
 
 ```dockerfile
-FROM %%IMAGE%%:7.0-apache
+FROM %%IMAGE%%:7.2-apache
 COPY src/ /var/www/html/
 ```
 
@@ -59,7 +59,7 @@ $ docker run -d --name my-running-app my-php-app
 We recommend that you add a custom `php.ini` configuration. `COPY` it into `/usr/local/etc/php` by adding one more line to the Dockerfile above and running the same commands to build and run:
 
 ```dockerfile
-FROM %%IMAGE%%:7.0-apache
+FROM %%IMAGE%%:7.2-apache
 COPY config/php.ini /usr/local/etc/php/
 COPY src/ /var/www/html/
 ```
@@ -71,7 +71,7 @@ Where `src/` is the directory containing all your PHP code and `config/` contain
 If you don't want to include a `Dockerfile` in your project, it is sufficient to do the following:
 
 ```console
-$ docker run -d -p 80:80 --name my-apache-php-app -v "$PWD":/var/www/html %%IMAGE%%:7.0-apache
+$ docker run -d -p 80:80 --name my-apache-php-app -v "$PWD":/var/www/html %%IMAGE%%:7.2-apache
 ```
 
 ### Changing `DocumentRoot`
@@ -96,7 +96,7 @@ We provide the helper scripts `docker-php-ext-configure`, `docker-php-ext-instal
 In order to keep the images smaller, PHP's source is kept in a compressed tar file. To facilitate linking of PHP's source with any extension, we also provide the helper script `docker-php-source` to easily extract the tar or delete the extracted source. Note: if you do use `docker-php-source` to extract the source, be sure to delete it in the same layer of the docker image.
 
 ```Dockerfile
-FROM %%IMAGE%%:7.0-apache
+FROM %%IMAGE%%:7.2-apache
 RUN docker-php-source extract \
 	# do important things \
 	&& docker-php-source delete
@@ -104,16 +104,15 @@ RUN docker-php-source extract \
 
 ### PHP Core Extensions
 
-For example, if you want to have a PHP-FPM image with `iconv`, `mcrypt` and `gd` extensions, you can inherit the base image that you like, and write your own `Dockerfile` like this:
+For example, if you want to have a PHP-FPM image with `iconv` and `gd` extensions, you can inherit the base image that you like, and write your own `Dockerfile` like this:
 
 ```dockerfile
-FROM %%IMAGE%%:7.0-fpm
+FROM %%IMAGE%%:7.2-fpm
 RUN apt-get update && apt-get install -y \
 		libfreetype6-dev \
 		libjpeg62-turbo-dev \
-		libmcrypt-dev \
 		libpng-dev \
-	&& docker-php-ext-install -j$(nproc) iconv mcrypt \
+	&& docker-php-ext-install -j$(nproc) iconv \
 	&& docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
 	&& docker-php-ext-install -j$(nproc) gd
 ```


### PR DESCRIPTION
Since PHP 7.0 is no longer supported (security only), updated the documentation examples to 7.2.

http://php.net/supported-versions.php