### PR TITLE
Deprecate our "ownCloud" image

### DIFF
--- a/owncloud/deprecated.md
+++ b/owncloud/deprecated.md
@@ -1,0 +1,1 @@
+This image has been deprecated in favor of the [official `owncloud/server` image](https://hub.docker.com/r/owncloud/server/) provided, maintained, and supported by [ownCloud upstream](https://owncloud.org/download/#owncloud-server-docker). The images found here will receive no further updates after 2018-12-31 (Dec 31, 2018). Please adjust your usage accordingly.


### PR DESCRIPTION
Upstream maintains their own image (https://owncloud.org/download/#owncloud-server-docker / https://github.com/owncloud-docker/server / https://hub.docker.com/r/owncloud/server/), and it's officially supported and recommended directly by them (so there's really no sense in us duplicating that effort without their involvement).