### PR TITLE
Update cirros "github-repo"

### DIFF
--- a/cirros/github-repo
+++ b/cirros/github-repo
@@ -1,1 +1,1 @@
-https://github.com/ewindisch/docker-cirros
+https://github.com/tianon/docker-brew-cirros


### PR DESCRIPTION
This is a follow-up/companion to https://github.com/docker-library/official-images/pull/4611 (dependent on).