### PR TITLE
Add a short blurb about TLS + WordPress + NGINX

### DIFF
--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -40,6 +40,8 @@ $ docker run --name some-%%REPO%% -e WORDPRESS_DB_HOST=10.1.2.3:3306 \
     -e WORDPRESS_DB_USER=... -e WORDPRESS_DB_PASSWORD=... -d %%IMAGE%%
 ```
 
+When running WordPress with TLS behind a reverse proxy such as NGINX which is responsible for doing TLS termination, be sure to set `X-Forwarded-Proto` appropriately (see ["Using a Reverse Proxy" in "Administration Over SSL" in upstream's documentation](https://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy)). No additional environment variables or configuration should be necessary (this image automatically adds the noted `HTTP_X_FORWARDED_PROTO` code to `wp-config.php` if *any* of the above-noted environment variables are specified).
+
 If your database requires SSL, [WordPress ticket #28625](https://core.trac.wordpress.org/ticket/28625) has the relevant details regarding support for that with WordPress upstream. As a workaround, [the "Secure DB Connection" plugin](https://wordpress.org/plugins/secure-db-connection/) can be extracted into the WordPress directory and the appropriate values described in the configuration of that plugin added in `wp-config.php`.
 
 ## Docker Secrets


### PR DESCRIPTION
See https://github.com/docker-library/wordpress/blob/cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9/docker-entrypoint.sh#L147-L151 (where we auto-add the appropriate `HTTP_X_FORWARDED_PROTO` code to `wp-config.php`).

See also https://codex.wordpress.org/Function_Reference/is_ssl#Notes and http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy.

Closes https://github.com/docker-library/wordpress/issues/331