### PR TITLE
Add <version> to all variant sections so that they won't be confused as actual tags

### DIFF
--- a/.template-helpers/variant-alpine.md
+++ b/.template-helpers/variant-alpine.md
@@ -1,4 +1,4 @@
-## `%%IMAGE%%:alpine`
+## `%%IMAGE%%:<version>-alpine`
 
 This image is based on the popular [Alpine Linux project](http://alpinelinux.org), available in [the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
 

--- a/.template-helpers/variant-onbuild.md
+++ b/.template-helpers/variant-onbuild.md
@@ -1,4 +1,4 @@
-## `%%IMAGE%%:onbuild`
+## `%%IMAGE%%:<version>-onbuild`
 
 The `ONBUILD` image variants are deprecated, and their usage is discouraged. For more details, see [docker-library/official-images#2076](https://github.com/docker-library/official-images/issues/2076).
 

--- a/.template-helpers/variant-slim.md
+++ b/.template-helpers/variant-slim.md
@@ -1,3 +1,3 @@
-## `%%IMAGE%%:slim`
+## `%%IMAGE%%:<version>-slim`
 
 This image does not contain the common packages contained in the default tag and only contains the minimal packages needed to run `%%IMAGE%%`. Unless you are working in an environment where *only* the `%%IMAGE%%` image will be deployed and you have space constraints, we highly recommend using the default image of this repository.

--- a/.template-helpers/variant-windowsservercore.md
+++ b/.template-helpers/variant-windowsservercore.md
@@ -1,4 +1,4 @@
-## `%%IMAGE%%:windowsservercore`
+## `%%IMAGE%%:<version>-windowsservercore`
 
 This image is based on [Windows Server Core (`microsoft/windowsservercore`)](https://hub.docker.com/r/microsoft/windowsservercore/). As such, it only works in places which that image does, such as Windows 10 Professional/Enterprise (Anniversary Edition) or Windows Server 2016.
 

--- a/openjdk/variant-slim.md
+++ b/openjdk/variant-slim.md
@@ -1,3 +1,3 @@
-## `%%IMAGE%%:slim`
+## `%%IMAGE%%:<version>-slim`
 
 This image installs the `-headless` package of OpenJDK and so is missing many of the UI-related Java libraries and some common packages contained in the default tag. It only contains the minimal packages needed to run Java. Unless you are working in an environment where *only* the `%%IMAGE%%` image will be deployed and you have space constraints, we highly recommend using the default image of this repository.

--- a/python/variant-onbuild.md
+++ b/python/variant-onbuild.md
@@ -1,9 +1,0 @@
-## `%%IMAGE%%:onbuild`
-
-The `ONBUILD` image variants are deprecated, and their usage is discouraged. For more details, see [docker-library/official-images#2076](https://github.com/docker-library/official-images/issues/2076).
-
-This image feeds your `requirements.txt` file automatically to `pip` in order to make building derivative images easier. For most use cases, creating a `Dockerfile` in the base of your project directory with the line `FROM %%IMAGE%%:onbuild` will be enough to create a stand-alone image for your project.
-
-While the `onbuild` variant is really useful for "getting off the ground running" (zero to Dockerized in a short period of time), it's not recommended for long-term usage within a project due to the lack of control over *when* the `ONBUILD` triggers fire (see also [`docker/docker#5714`](https://github.com/docker/docker/issues/5714), [`docker/docker#8240`](https://github.com/docker/docker/issues/8240), [`docker/docker#11917`](https://github.com/docker/docker/issues/11917)).
-
-Once you've got a handle on how your project functions within Docker, you'll probably want to adjust your `Dockerfile` to inherit from a non-`onbuild` variant and copy the commands from the `onbuild` variant `Dockerfile` (moving the `ONBUILD` lines to the end and removing the `ONBUILD` keywords) into your own file so that you have tighter control over them and more transparency for yourself and others looking at your `Dockerfile` as to what it does. This also makes it easier to add additional requirements as time goes on (such as installing more packages before performing the previously-`ONBUILD` steps).

--- a/znc/variant-slim.md
+++ b/znc/variant-slim.md
@@ -1,3 +1,3 @@
-## `%%REPO%%:slim`
+## `%%REPO%%:<version>-slim`
 
 This image is smaller, but it doesn't support external modules. If you need any external C++, Perl or Python module, use `latest` instead of `slim`.


### PR DESCRIPTION
Also remove custom `onbuild` file for python since `onbuild` was removed in https://github.com/docker-library/python/pull/314.

Fixes https://github.com/docker-library/openjdk/issues/232