### PR TITLE
[amazonlinux] Add a note regarding Docker Hub's vulnerability scanner

### DIFF
--- a/amazonlinux/content.md
+++ b/amazonlinux/content.md
@@ -6,6 +6,8 @@ The Amazon Linux container image contains a minimal set of packages. To install 
 
 AWS provides two versions of Amazon Linux: [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/) and [Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/).
 
+For information on security updates for Amazon Linux, please refer to [Amazon Linux 2 Security Advisories](https://alas.aws.amazon.com/alas2.html) and [Amazon Linux AMI Security Advisories](https://alas.aws.amazon.com/). Note that Docker Hub's vulnerability scanning for Amazon Linux is currently based on RPM versions, which does not reflect the state of backported patches for vulnerabilities.
+
 %%LOGO%%
 
 ## Where can I run Amazon Linux container images?


### PR DESCRIPTION
We wanted a note to help explain why the vulnerability scanning data doesn't match reality due to backported patches to older version numbers.

(ref https://github.com/aws/amazon-linux-docker-images/issues/8)