### PR TITLE
Add more non-root documentation

### DIFF
--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -4,13 +4,15 @@ The images in this repository contain IBM WebSphere Application Server Liberty f
 
 # Image User
 
-This image runs by default with `USER 1001` (non-root), as part of `group 0`. All of the folders accessed by WebSphere Liberty been given the appropriate permission, but if your extending Dockerfile needs permission to another location you can simply temporarily switch into root and provide the needed permissions, example:
+This image runs by default with `USER 1001` (non-root), as part of group `0`. All of the folders accessed by WebSphere Liberty been given the appropriate permission, but if your extending Dockerfile needs permission to another location you can simply temporarily switch into root and provide the needed permissions, example:
 
 ```dockerfile
 USER root
 RUN mkdir -p /myFolder && chown -R 1001:0 /myFolder
 USER 1001
 ```
+
+Also, you have to make sure that the artifacts you are copying into the image (via `COPY`) have the correct permission to be `read` by user `1001` or group `0`.  For example, you can do `chmod 744 server.xml` to ensure your `server.xml` can be read by user `1001`. 
 
 # Tags
 


### PR DESCRIPTION
Adding more documentation to clarify that the artifacts copied into the image must be accessible by the non-root user or by its group.