### PR TITLE
 Add how to include pre-installed themes/plugins for WordPress

### DIFF
--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -73,8 +73,8 @@ The following Docker Hub features can help with the task of keeping your depende
 
 Mount the volume containing your themes or plugins to the proper directory; and then apply them through the wp-admin webui. Ensure read/write/execute permissions are in place for the user.
 
--       Themes go in a subdirectory in `/var/www/html/wp-content/themes/`
--       Plugins go in a subdirectory in `/var/www/html/wp-content/plugins/`
+-	Themes go in a subdirectory in `/var/www/html/wp-content/themes/`
+-	Plugins go in a subdirectory in `/var/www/html/wp-content/plugins/`
 
 ## Running as an arbitrary user
 

--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -69,6 +69,13 @@ The following Docker Hub features can help with the task of keeping your depende
 -	[Automated Builds](https://docs.docker.com/docker-hub/builds/) let Docker Hub automatically build your Dockerfile each time you push changes to it.
 -	[Repository Links](https://docs.docker.com/docker-hub/builds/#repository-links) can ensure that your image is also rebuilt any time `%%REPO%%` is updated.
 
+## Include pre-installed themes / plugins
+
+Mount the volume containing your themes or plugins to the proper directory; and then apply them through the wp-admin webui. Ensure read/write/execute permissions are in place for the user.
+
+-       Themes go in a subdirectory in `/var/www/html/wp-content/themes/`
+-       Plugins go in a subdirectory in `/var/www/html/wp-content/plugins/`
+
 ## Running as an arbitrary user
 
 See [the "Running as an arbitrary user" section of the `php` image documentation](https://hub.docker.com/_/php/).


### PR DESCRIPTION
Relevant to https://github.com/docker-library/wordpress/issues/344 and https://github.com/docker-library/wordpress/issues/341

As mentioned previously in https://github.com/docker-library/wordpress/issues/246#issuecomment-340557707 and https://github.com/docker-library/wordpress/issues/146; mounting the themes/plugins to `/usr/src/wordpress/wp-content/` was advised, however there are issues notably with themes that cause a `Stylesheet is missing.` even when insuring the directory and it's contents are owned by `www-data` and given 777 permissions. It seems to be related to the `tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -` in the entrypoint

`/var/www/html/wp-content/` doesn't have this problem, it only requires read/write/execute for either the user `www-data` or for "other" 