### PR TITLE
Update WordPress stack to use more environment variables so it's a better example

### DIFF
--- a/wordpress/stack.yml
+++ b/wordpress/stack.yml
@@ -8,10 +8,16 @@ services:
     ports:
       - 8080:80
     environment:
-      WORDPRESS_DB_PASSWORD: example
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: exampleuser
+      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_NAME: exampledb
 
-  mysql:
+  db:
     image: mysql:5.7
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: exampledb
+      MYSQL_USER: exampleuser
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'


### PR DESCRIPTION
Closes https://github.com/docker-library/wordpress/issues/346

The current example works, but only makes sense if you understand the default values the WordPress image applies to these variables, which is obscure and unhelpful, so this updates the example to be very explicit, and to not use the `root` MySQL account anymore (so it's a safer example too).