### PR TITLE
Update nextcloud content.md with mariadb command

### DIFF
--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -155,6 +155,7 @@ volumes:
 services:
   db:
     image: mariadb
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql
@@ -195,6 +196,7 @@ volumes:
 services:
   db:
     image: mariadb
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql


### PR DESCRIPTION
MariaDB should be setup with the right transaction isolation level and binlog format.

More information is available in the [nextcloud server documentation](https://docs.nextcloud.com/server/14/admin_manual/configuration_database/linux_database_configuration.html#configuring-a-mysql-or-mariadb-database).

Also see [Pull Request 581](https://github.com/nextcloud/docker/pull/581) of the nextcloud docker image.