### PR TITLE
Update cargo install command

### DIFF
--- a/rust/content.md
+++ b/rust/content.md
@@ -18,7 +18,7 @@ FROM %%IMAGE%%:1.31
 WORKDIR /usr/src/myapp
 COPY . .
 
-RUN cargo install --path /usr/src/myapp
+RUN cargo install --path .
 
 CMD ["myapp"]
 ```

--- a/rust/content.md
+++ b/rust/content.md
@@ -13,12 +13,12 @@ Rust is a systems programming language sponsored by Mozilla Research. It is desi
 The most straightforward way to use this image is to use a Rust container as both the build and runtime environment. In your `Dockerfile`, writing something along the lines of the following will compile and run your project:
 
 ```dockerfile
-FROM %%IMAGE%%:1.23.0
+FROM %%IMAGE%%:1.31
 
 WORKDIR /usr/src/myapp
 COPY . .
 
-RUN cargo install
+RUN cargo install --path /usr/src/myapp
 
 CMD ["myapp"]
 ```


### PR DESCRIPTION
Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead.

Also updated image version in the example to the current one.