### PR TITLE
Fix Traefik spelling

### DIFF
--- a/traefik/README-short.txt
+++ b/traefik/README-short.txt
@@ -1,1 +1,1 @@
-Træfɪk, a modern reverse proxy
+Traefik, The Cloud Native Edge Router

--- a/traefik/content.md
+++ b/traefik/content.md
@@ -1,10 +1,10 @@
 %%LOGO%%
 
-[Træfɪk](https://github.com/containous/traefik) is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.
+[Traefik](https://github.com/containous/traefik) is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.
 
-Træfik integrates with your existing infrastructure components ([Docker](https://www.docker.com/), [Swarm mode](https://docs.docker.com/engine/swarm/), [Kubernetes](https://kubernetes.io), [Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Rancher](https://rancher.com), [Amazon ECS](https://aws.amazon.com/ecs), ...) and configures itself automatically and dynamically.
+Traefik integrates with your existing infrastructure components ([Docker](https://www.docker.com/), [Swarm mode](https://docs.docker.com/engine/swarm/), [Kubernetes](https://kubernetes.io), [Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Rancher](https://rancher.com), [Amazon ECS](https://aws.amazon.com/ecs), ...) and configures itself automatically and dynamically.
 
-Telling Træfik where your orchestrator is could be the *only* configuration step you need to do.
+Telling Traefik where your orchestrator is could be the *only* configuration step you need to do.
 
 # Example usage
 
@@ -23,7 +23,7 @@ domain = "docker.local"
 watch = true
 ```
 
-Start Træfɪk:
+Start Traefik:
 
 ```bash
 docker run -d -p 8080:8080 -p 80:80 \
@@ -38,7 +38,7 @@ Start a backend server, named `test`:
 docker run -d --name test emilevauge/whoami
 ```
 
-And finally, you can access to your `whoami` server throught Træfɪk, on the domain name `{containerName}.{configuredDomain}`:
+And finally, you can access to your `whoami` server throught Traefik, on the domain name `{containerName}.{configuredDomain}`:
 
 ```bash
 curl --header 'Host: test.docker.local' 'http://localhost:80/'
@@ -67,4 +67,4 @@ The web UI [http://localhost:8080](http://localhost:8080) will give you an overv
 
 You can find the complete documentation at [https://docs.traefik.io](https://docs.traefik.io).
 
-A collection of contributions around Træfik can be found at [https://awesome.traefik.io](https://awesome.traefik.io).
+A collection of contributions around Traefik can be found at [https://awesome.traefik.io](https://awesome.traefik.io).

--- a/traefik/maintainer.md
+++ b/traefik/maintainer.md
@@ -1,1 +1,1 @@
-[the Træfik Project](%%GITHUB-REPO%%)
+[the Traefik Project](%%GITHUB-REPO%%)


### PR DESCRIPTION
Hey!
Here is a small PR that fixes the Traefik spelling (replaces the old deprecated `Træfɪk` by the simpler `Traefik`).
Cheers