### PR TITLE
Add a blurb explicitly pointing out why RabbitMQ doesn't come with a default HEALTHCHECK

### DIFF
--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -177,6 +177,10 @@ Alternatively, it is possible to use the `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` e
 
 Additional configuration keys would be specified as a list. For example, configuring both [`channel_max`](https://www.rabbitmq.com/configure.html#config-items) and [`auth_backends`](https://www.rabbitmq.com/ldap.html#overview) would look something like `-e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-rabbit channel_max 4007 auth_backends [rabbit_auth_backend_ldap,rabbit_auth_backend_internal]"`. Note that some variables such as for `auth_backends` require their value(s) to be enclosed in brackets, and for multiple values explicitly including the comma as a delimiter.
 
+### Health/Liveness/Readiness Checking
+
+See [the "Official Images" FAQ](https://github.com/docker-library/faq#healthcheck) and [the discussion on docker-library/rabbitmq#174 (especially the large comment by Michael Klishin from RabbitMQ upstream)](https://github.com/docker-library/rabbitmq/pull/174#issuecomment-452002696) for a detailed explanation of why this image does not come with a default `HEALTHCHECK` defined, and for suggestions for implementing your own health/liveness/readiness checks.
+
 ## Connecting to the daemon
 
 ```console


### PR DESCRIPTION
Excellent idea (and excellent summary), @michaelklishin. :heart:

Do you think this covers it sufficiently?  (I didn't feel like it would be terribly useful to copy your post verbatim when it includes additional context if I link to it.)

Closes https://github.com/docker-library/rabbitmq/pull/174