### PR TITLE
fix(#1406): set Mediawiki MYSQL_RANDOM_ROOT_PASSWORD boolean to a string

### DIFF
--- a/mediawiki/README.md
+++ b/mediawiki/README.md
@@ -129,7 +129,7 @@ services:
       MYSQL_DATABASE: my_wiki
       MYSQL_USER: wikiuser
       MYSQL_PASSWORD: example
-      MYSQL_RANDOM_ROOT_PASSWORD: yes
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
 ```
 
 [![Try in PWD](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/docker-library/docs/9efeec18b6b2ed232cf0fbd3914b6211e16e242c/mediawiki/stack.yml)


### PR DESCRIPTION
https://devops.stackexchange.com/questions/537/why-is-one-not-allowed-to-use-a-boolean-in-a-docker-compose-yml