### PR TITLE
fix(#1406): set Mediawiki MYSQL_RANDOM_ROOT_PASSWORD boolean to a string

### DIFF
--- a/mediawiki/stack.yml
+++ b/mediawiki/stack.yml
@@ -25,4 +25,4 @@ services:
       MYSQL_DATABASE: my_wiki
       MYSQL_USER: wikiuser
       MYSQL_PASSWORD: example
-      MYSQL_RANDOM_ROOT_PASSWORD: yes
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'


### PR DESCRIPTION
https://devops.stackexchange.com/questions/537/why-is-one-not-allowed-to-use-a-boolean-in-a-docker-compose-yml

Fixes #1406