### PR TITLE
Add OpenJDK + Eclipse OpenJ9 images from AdoptOpenJDK.

### DIFF
--- a/adoptopenjdk-openj9/README-short.txt
+++ b/adoptopenjdk-openj9/README-short.txt
@@ -1,0 +1,2 @@
+Official Docker Images for Eclipse OpenJ9 binaries built by AdoptOpenJDK. 
+

--- a/adoptopenjdk-openj9/README-short.txt
+++ b/adoptopenjdk-openj9/README-short.txt
@@ -1,2 +1,2 @@
-Official Docker Images for Eclipse OpenJ9 binaries built by AdoptOpenJDK. 
+Official Docker Images for OpenJDK + Eclipse OpenJ9 binaries built by AdoptOpenJDK. 
 

--- a/adoptopenjdk-openj9/README-short.txt
+++ b/adoptopenjdk-openj9/README-short.txt
@@ -1,2 +1,1 @@
-Official Docker Images for OpenJDK + Eclipse OpenJ9 binaries built by AdoptOpenJDK. 
-
+Official Images for OpenJDK + Eclipse OpenJ9 binaries built by AdoptOpenJDK. 

--- a/adoptopenjdk-openj9/content.md
+++ b/adoptopenjdk-openj9/content.md
@@ -14,7 +14,6 @@ AdoptOpenJDK is a community of Java user group members, Java developers and vend
 
 There are two types of Docker images here: the Java Development Kit (JDK), and a small footprint version of the JDK (slim). These images can be used as the basis for custom built images for running your applications.
 
-
 ##### Multi-Arch Image
 
 Docker Images for the following architectures are now available:

--- a/adoptopenjdk-openj9/content.md
+++ b/adoptopenjdk-openj9/content.md
@@ -1,0 +1,52 @@
+### Overview
+
+The images in this repository contain OpenJDK binaries that are built with Eclipse OpenJ9.
+
+Eclipse OpenJ9 is a high performance, scalable, Java™ virtual machine (JVM) implementation that has a proven track record of running Java applications in production environments. Contributed to the Eclipse project by IBM, the OpenJ9 JVM underpins the IBM SDK, Java Technology Edition product that is a core component of many IBM Enterprise software products. Continued development of OpenJ9 at the Eclipse foundation ensures wider collaboration, fresh innovation, and the opportunity to influence the development of OpenJ9 for the next generation of Java applications. OpenJDK binaries that include Eclipse OpenJ9 are available through [AdoptOpenJDK](https://adoptopenjdk.net/).
+
+Java and all Java-based trademarks and logos are trademarks or registered trademarks of Oracle and/or its affiliates.
+
+### What is AdoptOpenJDK ?
+
+AdoptOpenJDK is a community of Java user group members, Java developers and vendors who are advocates of OpenJDK, the open source project which forms the basis of the Java programming language and platform. AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully open source set of build scripts and infrastructure. AdoptOpenJDK builds and tests binaries for different source code streams based upon OpenJDK. Our binaries undergo extensive testing, and the Releases have passed all the available OpenJDK test suites and our additional tests (donated by the community), ensuring the best quality binary available.
+
+### Images
+
+There are two types of Docker images here: the Software Developers Kit (SDK), and a small footprint version of the SDK (slim). These images can be used as the basis for custom built images for running your applications.
+
+
+##### Multi-Arch Image
+
+Docker Images for the following architectures are now available:
+
+-	x86\_64, ppc64le, s390x
+
+### How to use this Image
+
+To run a pre-built jar file with the JRE image, use the following commands:
+
+```dockerfile
+FROM %%IMAGE%%:8-sdk
+RUN mkdir /opt/app
+COPY japp.jar /opt/app
+CMD ["java", "-jar", "/opt/app/japp.jar"]
+```
+
+You can build and run the Docker Image as shown in the following example:
+
+```console
+docker build -t japp .
+docker run -it --rm japp
+```
+
+If you want to place the jar file on the host file system instead of inside the container, you can mount the host path onto the container by using the following commands:
+
+```dockerfile
+FROM %%IMAGE%%:sdk
+CMD ["java", "-jar", "/opt/app/japp.jar"]
+```
+
+```console
+docker build -t japp .
+docker run -it -v /path/on/host/system/jars:/opt/app japp
+```

--- a/adoptopenjdk-openj9/content.md
+++ b/adoptopenjdk-openj9/content.md
@@ -12,7 +12,7 @@ AdoptOpenJDK is a community of Java user group members, Java developers and vend
 
 ### Images
 
-There are two types of Docker images here: the Software Developers Kit (SDK), and a small footprint version of the SDK (slim). These images can be used as the basis for custom built images for running your applications.
+There are two types of Docker images here: the Java Development Kit (JDK), and a small footprint version of the JDK (slim). These images can be used as the basis for custom built images for running your applications.
 
 
 ##### Multi-Arch Image
@@ -26,7 +26,7 @@ Docker Images for the following architectures are now available:
 To run a pre-built jar file with the JRE image, use the following commands:
 
 ```dockerfile
-FROM %%IMAGE%%:8-sdk
+FROM %%IMAGE%%:8-jdk
 RUN mkdir /opt/app
 COPY japp.jar /opt/app
 CMD ["java", "-jar", "/opt/app/japp.jar"]
@@ -42,7 +42,7 @@ docker run -it --rm japp
 If you want to place the jar file on the host file system instead of inside the container, you can mount the host path onto the container by using the following commands:
 
 ```dockerfile
-FROM %%IMAGE%%:sdk
+FROM %%IMAGE%%:jdk
 CMD ["java", "-jar", "/opt/app/japp.jar"]
 ```
 

--- a/adoptopenjdk-openj9/get-help.md
+++ b/adoptopenjdk-openj9/get-help.md
@@ -1,0 +1,2 @@
+- 	[Eclipse OpenJ9 Slack](https://www.eclipse.org/openj9/oj9_joinslack.html); [Eclipse OpenJ9 Mailing List](https://dev.eclipse.org/mailman/listinfo/openj9-dev)
+-   [AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html); [AdoptOpenJDK Mailing List](https://mail.openjdk.java.net/mailman/listinfo/adoption-discuss)

--- a/adoptopenjdk-openj9/get-help.md
+++ b/adoptopenjdk-openj9/get-help.md
@@ -1,2 +1,2 @@
 - 	[Eclipse OpenJ9 Slack](https://www.eclipse.org/openj9/oj9_joinslack.html); [Eclipse OpenJ9 Mailing List](https://dev.eclipse.org/mailman/listinfo/openj9-dev)
--   [AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html); [AdoptOpenJDK Mailing List](https://mail.openjdk.java.net/mailman/listinfo/adoption-discuss)
+-	[AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html); [AdoptOpenJDK Mailing List](https://mail.openjdk.java.net/mailman/listinfo/adoption-discuss)

--- a/adoptopenjdk-openj9/get-help.md
+++ b/adoptopenjdk-openj9/get-help.md
@@ -1,2 +1,2 @@
-- 	[Eclipse OpenJ9 Slack](https://www.eclipse.org/openj9/oj9_joinslack.html); [Eclipse OpenJ9 Mailing List](https://dev.eclipse.org/mailman/listinfo/openj9-dev)
+-	[Eclipse OpenJ9 Slack](https://www.eclipse.org/openj9/oj9_joinslack.html); [Eclipse OpenJ9 Mailing List](https://dev.eclipse.org/mailman/listinfo/openj9-dev)
 -	[AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html); [AdoptOpenJDK Mailing List](https://mail.openjdk.java.net/mailman/listinfo/adoption-discuss)

--- a/adoptopenjdk-openj9/github-repo
+++ b/adoptopenjdk-openj9/github-repo
@@ -1,0 +1,1 @@
+https://github.com/AdoptOpenJDK/openjdk-docker

--- a/adoptopenjdk-openj9/issues.md
+++ b/adoptopenjdk-openj9/issues.md
@@ -1,0 +1,1 @@
+[GitHub](%%GITHUB-REPO%%/issues); The [adoptopenjdk support](https://adoptopenjdk.net/support.html) page has more information on quality, roadmap and support levels for AdoptOpenJDK builds;

--- a/adoptopenjdk-openj9/license.md
+++ b/adoptopenjdk-openj9/license.md
@@ -1,0 +1,5 @@
+The Dockerfiles and associated scripts are licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+Licenses for the products installed within the images:
+
+-	Eclipse OpenJ9 + OpenJDK: The combined works license is [GNU GPL v2 with Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html).

--- a/adoptopenjdk-openj9/maintainer.md
+++ b/adoptopenjdk-openj9/maintainer.md
@@ -1,0 +1,1 @@
+[AdoptOpenJDK](%%GITHUB-REPO%%)


### PR DESCRIPTION
Adding docs for [official images PR 5433](https://github.com/docker-library/official-images/pull/5433).