### PR TITLE
Restricting access only to localhost for non-encrypted access to nextcloud containers

### DIFF
--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -168,7 +168,7 @@ services:
   app:
     image: %%IMAGE%%
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     links:
       - db
     volumes:
@@ -217,7 +217,7 @@ services:
   web:
     image: nginx
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     links:
       - app
     volumes:


### PR DESCRIPTION
In the docker-compose examples, the httpd containers (be it apache or nginx) are publicly available on port 8080. In the text it is already mentioned that an appropriate reverse proxy should be used in front of it.
My modifications restrict the ips the containers listen to only localhost. So as long as the reverse proxy is on the same machine, this is perfectly secure without worrying about an additional firewall layer to protect direct access to 8080 from the internet.