### PR TITLE
Add Source Mage deprecation notice

### DIFF
--- a/sourcemage/deprecated.md
+++ b/sourcemage/deprecated.md
@@ -1,0 +1,3 @@
+This image is deprecated due to maintainer inactivity (last updated Dec 2016; [docker-library/official-images#2403](https://github.com/docker-library/official-images/pull/2403)).
+
+See [docker-library/docs#1433](https://github.com/docker-library/docs/pull/1433) for discussion around an in-progress upstream update.


### PR DESCRIPTION
Refs https://github.com/vaygr/docker-sourcemage/issues/2 (thanks @lag-linaro :heart:)

cc @vaygr -- if the `sourcemage` Docker official image is still something you'd like to continue maintaining, please speak up :wink:

(This also isn't permanent: as the wording implies, we'd be happy to have continued maintenance of this image if it's going to be more active, but even upstream appears to only be slightly more fresh than our image with 0.62-11 in 2017.)