### PR TITLE
Update content.md

### DIFF
--- a/vault/content.md
+++ b/vault/content.md
@@ -59,6 +59,11 @@ Run `vault status` in a second container:
 $ docker run -e VAULT_ADDR='http://<container-ip>:8200' --cap-add=IPC_LOCK vault status
 ```
 
+Store a secret:
+```console
+$ docker run -e VAULT_ADDR='http://<container-ip>:8200' -e VAULT_TOKEN='myroot' --cap-add=IPC_LOCK vault kv put secret/hello foo=world excited=yes
+```
+
 ## Running Vault in Server Mode
 
 ```console

--- a/vault/content.md
+++ b/vault/content.md
@@ -42,7 +42,21 @@ When running in development mode, two additional options can be set via environm
 As an example:
 
 ```console
-$ docker run --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:1234' %%IMAGE%%
+$ docker run --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e VAULT_ADDR='http://127.0.0.1:8200' -p 8200:8200 %%IMAGE%%
+```
+
+You can now access the Vault UI on your host machine in a browser at [`http://localhost:8200`](http://localhost:8200)
+
+### To run commands against this container:
+
+In a second terminal, get the IP address of the container you just started:
+```console
+$ docker inspect <container-id> | grep IPAddress
+```
+
+Run `vault status` in a second container:
+```console
+$ docker run -e VAULT_ADDR='http://<container-ip>:8200' --cap-add=IPC_LOCK vault status
 ```
 
 ## Running Vault in Server Mode


### PR DESCRIPTION
Adds some details to the `README.md` on Docker Hub that may help someone when using the image for the first time.

I had followed the command to run a dev server within a container, however, in order to view the UI on my host machine and to run commands against it from another container, I needed to expose the default `8200` port.

Next, when running `docker run vault status`, I would get:
```
Error checking seal status: Get https://127.0.0.1:8200/v1/sys/seal-status: dial tcp 127.0.0.1:8200: connect: connection refused
```

However, running `docker exec -it <container-id> vault status` would succeed.

It took me ~a minute~ longer than I'd like to admit until I realized the former was being run in a second container, and I needed to pass the `VAULT_ADDR` environment variable, which also needed to include the local IP address of the docker container running the dev server. 

From there, `docker run -e VAULT_ADDR='http://<container-ip>:8200' vault <command>` worked perfectly. _Edit:_ To store a secret, I also needed to pass `VAULT_TOKEN`

