### PR TITLE
Add OpenJDK + HotSpot and OpenJDK + Eclipse OpenJ9 images from AdoptOpenJDK.

### DIFF
--- a/adoptopenjdk/README-short.txt
+++ b/adoptopenjdk/README-short.txt
@@ -1,0 +1,1 @@
+Official Images for OpenJDK + HotSpot and OpenJDK + Eclipse OpenJ9 binaries built by AdoptOpenJDK. 

--- a/adoptopenjdk/README-short.txt
+++ b/adoptopenjdk/README-short.txt
@@ -1,1 +1,1 @@
-Official Images for OpenJDK + HotSpot and OpenJDK + Eclipse OpenJ9 binaries built by AdoptOpenJDK. 
+Official Images for OpenJDK + HotSpot and OpenJDK + Eclipse OpenJ9 binaries built by AdoptOpenJDK.

--- a/adoptopenjdk/content.md
+++ b/adoptopenjdk/content.md
@@ -14,33 +14,32 @@ Eclipse OpenJ9 is a high performance, scalable, Java virtual machine (JVM) imple
 
 ### Images
 
-There are three types of Docker images here: the Java Development Kit (JDK), the Java Runtime Environment (JRE) and a small footprint version of the JDK (slim). These images can be used as the basis for custom built images for running your applications.
-
-##### Alpine Linux
-
-Consider using [Alpine Linux](http://alpinelinux.org/) if you are concerned about the size of the overall image. Alpine Linux is a stripped down version of Linux that is based on [musl libc](http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc) and Busybox, resulting in a [Docker image](https://hub.docker.com/_/alpine/) size of approximately 5 MB. Due to its extremely small size and reduced number of installed packages, it has a much smaller attack surface which improves security. The OpenJDK binaries built by AdoptOpenJDK currently have a dependency on gnu glibc, the sources can be found [here](https://github.com/sgerrand/docker-glibc-builder/releases/). Installing this library adds an extra 8 MB to the image size.
+There are two types of Docker images here: the Java Development Kit (JDK) and the Java Runtime Environment (JRE). These images can be used as the basis for custom built images for running your applications.
 
 ##### Multi-Arch Image
 
 Docker Images for the following architectures are now available:
 
--	x86\_64, ppc64le, s390x
+-	HotSpot
+	-	amd64, arm32v7, arm64v8, ppc64le, s390x
+-	Eclipse OpenJ9
+	-	amd64, ppc64le, s390x
 
 ### How to use this Image
 
-To run a pre-built jar file with the latest OpenJDK 8 with HotSpot JRE image, use the following Dockerfile:
+To run a pre-built jar file with the latest OpenJDK 11 with HotSpot JRE image, use the following Dockerfile:
 
 ```dockerfile
-FROM %%IMAGE%%:hotspot-8-jre
+FROM %%IMAGE%%:11-jre-hotspot
 RUN mkdir /opt/app
 COPY japp.jar /opt/app
 CMD ["java", "-jar", "/opt/app/japp.jar"]
 ```
 
-To do the same with the latest OpenJDK 8 with Eclipse OpenJ9 JRE image, use the following Dockerfile:
+To do the same with the latest OpenJDK 11 with Eclipse OpenJ9 JRE image, use the following Dockerfile:
 
 ```dockerfile
-FROM %%IMAGE%%:openj9-8-jre
+FROM %%IMAGE%%:11-jre-openj9
 RUN mkdir /opt/app
 COPY japp.jar /opt/app
 CMD ["java", "-jar", "/opt/app/japp.jar"]
@@ -56,7 +55,7 @@ docker run -it --rm japp
 If you want to place the jar file on the host file system instead of inside the container, you can mount the host path onto the container by using the following commands:
 
 ```dockerfile
-FROM %%IMAGE%%:jre-12.33_openj9-0.13.0-alpine
+FROM %%IMAGE%%:12.0.1_12-jdk-openj9-0.14.1
 CMD ["java", "-jar", "/opt/app/japp.jar"]
 ```
 

--- a/adoptopenjdk/content.md
+++ b/adoptopenjdk/content.md
@@ -1,0 +1,66 @@
+### Overview
+
+The images in this repository contain OpenJDK binaries that are built by AdoptOpenJDK and contain both HotSpot and Eclipse OpenJ9 JVMs.
+
+### What is AdoptOpenJDK ?
+
+[AdoptOpenJDK](https://adoptopenjdk.net/) is a community of Java™ user group members, Java developers and vendors who are advocates of OpenJDK, the open source project which forms the basis of the Java programming language and platform. AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully open source set of build scripts and infrastructure. AdoptOpenJDK builds and tests binaries for different source code streams based upon OpenJDK. Our binaries undergo extensive testing, and the Releases have passed all the available OpenJDK test suites and our additional tests (donated by the community), ensuring the best quality binary available.
+
+Java and all Java-based trademarks and logos are trademarks or registered trademarks of Oracle and/or its affiliates.
+
+### What is Eclipse OpenJ9 ?
+
+Eclipse OpenJ9 is a high performance, scalable, Java virtual machine (JVM) implementation that has a proven track record of running Java applications in production environments. Contributed to the Eclipse project by IBM, the OpenJ9 JVM underpins the IBM SDK, Java Technology Edition product that is a core component of many IBM Enterprise software products. Continued development of OpenJ9 at the Eclipse foundation ensures wider collaboration, fresh innovation, and the opportunity to influence the development of OpenJ9 for the next generation of Java applications. OpenJDK binaries that include Eclipse OpenJ9 are available through AdoptOpenJDK.
+
+### Images
+
+There are three types of Docker images here: the Java Development Kit (JDK), the Java Runtime Environment (JRE) and a small footprint version of the JDK (slim). These images can be used as the basis for custom built images for running your applications.
+
+##### Alpine Linux
+
+Consider using [Alpine Linux](http://alpinelinux.org/) if you are concerned about the size of the overall image. Alpine Linux is a stripped down version of Linux that is based on [musl libc](http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc) and Busybox, resulting in a [Docker image](https://hub.docker.com/_/alpine/) size of approximately 5 MB. Due to its extremely small size and reduced number of installed packages, it has a much smaller attack surface which improves security. The OpenJDK binaries built by AdoptOpenJDK currently have a dependency on gnu glibc, the sources can be found [here](https://github.com/sgerrand/docker-glibc-builder/releases/). Installing this library adds an extra 8 MB to the image size.
+
+##### Multi-Arch Image
+
+Docker Images for the following architectures are now available:
+
+-	x86\_64, ppc64le, s390x
+
+### How to use this Image
+
+To run a pre-built jar file with the latest OpenJDK 8 with HotSpot JRE image, use the following Dockerfile:
+
+```dockerfile
+FROM %%IMAGE%%:hotspot-8-jre
+RUN mkdir /opt/app
+COPY japp.jar /opt/app
+CMD ["java", "-jar", "/opt/app/japp.jar"]
+```
+
+To do the same with the latest OpenJDK 8 with Eclipse OpenJ9 JRE image, use the following Dockerfile:
+
+```dockerfile
+FROM %%IMAGE%%:openj9-8-jre
+RUN mkdir /opt/app
+COPY japp.jar /opt/app
+CMD ["java", "-jar", "/opt/app/japp.jar"]
+```
+
+You can build and run the Docker Image as shown in the following example:
+
+```console
+docker build -t japp .
+docker run -it --rm japp
+```
+
+If you want to place the jar file on the host file system instead of inside the container, you can mount the host path onto the container by using the following commands:
+
+```dockerfile
+FROM %%IMAGE%%:jre-12.33_openj9-0.13.0-alpine
+CMD ["java", "-jar", "/opt/app/japp.jar"]
+```
+
+```console
+docker build -t japp .
+docker run -it -v /path/on/host/system/jars:/opt/app japp
+```

--- a/adoptopenjdk/get-help.md
+++ b/adoptopenjdk/get-help.md
@@ -1,0 +1,2 @@
+-	[AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html); [AdoptOpenJDK Mailing List](https://mail.openjdk.java.net/mailman/listinfo/adoption-discuss)
+-	[Eclipse OpenJ9 Slack](https://www.eclipse.org/openj9/oj9_joinslack.html); [Eclipse OpenJ9 Mailing List](https://dev.eclipse.org/mailman/listinfo/openj9-dev)

--- a/adoptopenjdk/github-repo
+++ b/adoptopenjdk/github-repo
@@ -1,0 +1,1 @@
+https://github.com/AdoptOpenJDK/openjdk-docker

--- a/adoptopenjdk/issues.md
+++ b/adoptopenjdk/issues.md
@@ -1,0 +1,1 @@
+[GitHub](%%GITHUB-REPO%%/issues); The [adoptopenjdk support](https://adoptopenjdk.net/support.html) page has more information on quality, roadmap and support levels for AdoptOpenJDK builds;

--- a/adoptopenjdk/license.md
+++ b/adoptopenjdk/license.md
@@ -3,4 +3,4 @@ The Dockerfiles and associated scripts are licensed under the [Apache License, V
 Licenses for the products installed within the images:
 
 -	Eclipse OpenJ9 + OpenJDK: The combined works license is [GNU GPL v2 with Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html).
--   OpenJDK: The project license is GNU GPL v2 with Classpath Exception.
+-	OpenJDK: The project license is GNU GPL v2 with Classpath Exception.

--- a/adoptopenjdk/license.md
+++ b/adoptopenjdk/license.md
@@ -1,0 +1,6 @@
+The Dockerfiles and associated scripts are licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+Licenses for the products installed within the images:
+
+-	Eclipse OpenJ9 + OpenJDK: The combined works license is [GNU GPL v2 with Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html).
+-   OpenJDK: The project license is GNU GPL v2 with Classpath Exception.

--- a/adoptopenjdk/maintainer.md
+++ b/adoptopenjdk/maintainer.md
@@ -1,0 +1,1 @@
+[AdoptOpenJDK](%%GITHUB-REPO%%)


### PR DESCRIPTION
Adding docs for official images [PR 5710](https://github.com/docker-library/official-images/pull/5710).