### PR TITLE
Update openjdk docs

### DIFF
--- a/openjdk/variant-oracle.md
+++ b/openjdk/variant-oracle.md
@@ -1,0 +1,5 @@
+## `%%IMAGE%%:<version>` (from 12 onwards), `%%IMAGE%%:<version>-oracle` and `%%IMAGE%%:<version>-oraclelinux7`
+
+Starting with `openjdk:12` the default image as well as the `-oracle` and `-oraclelinux7` variants are based on the official [Oracle Linux 7 image](https://hub.docker.com/_/oraclelinux) which is provided under the GPLv2 as per the [Oracle Linux End User Agreement (EULA)](https://oss.oracle.com/ol7/EULA).
+
+The OpenJDK binaries in the default image as well as the `-oracle` and `-oraclelinux7` variants are built by Oracle and are sourced from the [OpenJDK community](https://openjdk.java.net/). These binaries are licensed under the [GPLv2 with the Classpath Exception](https://openjdk.java.net/legal/gplv2+ce.html).

--- a/openjdk/variant-slim.md
+++ b/openjdk/variant-slim.md
@@ -1,3 +1,0 @@
-## `%%IMAGE%%:<version>-slim`
-
-This image installs the `-headless` package of OpenJDK and so is missing many of the UI-related Java libraries and some common packages contained in the default tag. It only contains the minimal packages needed to run Java. Unless you are working in an environment where *only* the `%%IMAGE%%` image will be deployed and you have space constraints, we highly recommend using the default image of this repository.


### PR DESCRIPTION
Following a discussion with @tianon, we thought it would be a good idea to improve the OpenJDK image documentation to make it very clear the official image is still available under the GPLv2+CE license. 