### PR TITLE
php: optimize layers order

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -12,9 +12,9 @@ PHP is a server-side scripting language designed for web development, but which 
 
 ```dockerfile
 FROM %%IMAGE%%:7.2-cli
-COPY . /usr/src/myapp
 WORKDIR /usr/src/myapp
 CMD [ "php", "./your-script.php" ]
+COPY . .
 ```
 
 Then, run the commands to build and run the Docker image:


### PR DESCRIPTION
optimize commands order that they can be cached if build context (project source) changes.

it might seem a bit illogical to use commands that don't exist yet, but the result is the same and avoids adding `WORKDIR` and `CMD` layers over and over when rebuilding with layers cache. 