### PR TITLE
Fix broken link to Docker documentation (--device)

### DIFF
--- a/ros/content.md
+++ b/ros/content.md
@@ -54,7 +54,7 @@ $ docker run -v "/home/ubuntu/.ros/:/root/.ros/" %%IMAGE%%
 
 ### Devices
 
-Some application may require device access for acquiring images from connected cameras, control input from human interface device, or GPUS for hardware acceleration. This can be done using the [`--device`](https://docs.docker.com/reference/run/) run argument to mount the device inside the container, providing processes inside hardware access.
+Some application may require device access for acquiring images from connected cameras, control input from human interface device, or GPUS for hardware acceleration. This can be done using the [`--device`](https://docs.docker.com/engine/reference/commandline/run/#add-host-device-to-container---device) run argument to mount the device inside the container, providing processes inside hardware access.
 
 ### Networks
 


### PR DESCRIPTION
The link to the official Docker documentation of the `docker run` command was broken. Also, I took the liberty to update it so that it points specifically to the section about the `--device` option.