### PR TITLE
Remove "Dockerfile path" from tags listing

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -30,7 +30,7 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 	{{- $dir := .ArchDirectory $arch -}}
 	{{- $dockerfile := .ArchFile $arch -}}
 	{{- $dockerfilePath := eq $dir "." | ternary $dockerfile (join "/" $dir $dockerfile) -}}
-	` {{- $e.Tags | join "`, `" -}} ` (* {{- $dockerfilePath -}} *)
+	` {{- $e.Tags | join "`, `" -}} `
 	{{- $gitCommit := $e.ArchGitCommit $arch -}}
 	{{- if $isGitHub -}} ]( {{- $repoUrlBase -}} /blob/ {{- $gitCommit -}} / {{- $dockerfilePath -}} ) {{- end -}}
 	{{- /* TODO decide what to do (if anything) about non-GitHub repos with respect to URL */ -}}
@@ -63,7 +63,7 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 				{{- $dir := .ArchDirectory $arch -}}
 				{{- $dockerfile := .ArchFile $arch -}}
 				{{- $dockerfilePath := eq $dir "." | ternary $dockerfile (join "/" $dir $dockerfile) -}}
-				` {{- $e.Tags | first -}} ` (* {{- $dockerfilePath -}} *)
+				` {{- $e.Tags | first -}} `
 				{{- $gitCommit := $e.ArchGitCommit $arch -}}
 				{{- if $isGitHub -}} ]( {{- $repoUrlBase -}} /blob/ {{- $gitCommit -}} / {{- $dockerfilePath -}} ) {{- end -}}
 				{{- /* TODO decide what to do (if anything) about non-GitHub repos with respect to URL */ -}}


### PR DESCRIPTION
For context, this was added initially because the previous rendering of Markdown on the Hub was such that code in a link would render without underline and barely noticeable blue color (and no hover behavior either besides the normal cursor change), so it wasn't clear it was even a link without additional non-code text. Now that that has been corrected/adjusted, I think it's totally reasonable to remove those (since they're included in the link already).

For reference/comparison, this takes the `open-liberty` readme from ~39k characters down to ~33k characters.

See https://github.com/docker-library/official-images/issues/6030 for discussion.