### PR TITLE
Add deprecation notice about HiPE for RabbitMQ image

### DIFF
--- a/rabbitmq/content.md
+++ b/rabbitmq/content.md
@@ -142,7 +142,9 @@ If you wish to change the default vhost, you can do so with the `RABBITMQ_DEFAUL
 $ docker run -d --hostname my-rabbit --name some-rabbit -e RABBITMQ_DEFAULT_VHOST=my_vhost %%IMAGE%%:3-management
 ```
 
-### Enabling HiPE
+### Enabling HiPE (deprecated)
+
+**Note**: HiPE is disabled since version 3.7.15 of rabbimq images (https://github.com/docker-library/rabbitmq/pull/340)
 
 See the [RabbitMQ "Configuration"](http://www.rabbitmq.com/configure.html#config-items) for more information about various configuration options.
 


### PR DESCRIPTION
HiPE is disabled in latest RabbitMQ image.
More information: https://github.com/docker-library/rabbitmq/issues/342