### PR TITLE
Remove "Supported Docker versions" quick reference bit

### DIFF
--- a/.template-helpers/template.md
+++ b/.template-helpers/template.md
@@ -27,7 +27,4 @@
 -	**Source of this description**:  
 	[docs repo's `%%REPO%%/` directory](https://github.com/docker-library/docs/tree/master/%%REPO%%) ([history](https://github.com/docker-library/docs/commits/master/%%REPO%%))
 
--	**Supported Docker versions**:  
-	[the latest release](https://github.com/docker/docker-ce/releases/latest) (down to 1.6 on a best-effort basis)
-
 %%CONTENT%%%%VARIANT%%%%LICENSE%%


### PR DESCRIPTION
This really hasn't been horribly relevant for a long time (it was more relevant back when Docker was more frequently making breaking changes to things like image format and those have all been very calm for years now).