### PR TITLE
Adjust long-description trimming to prefer trimming tag listing

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -6,4 +6,4 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 #docker pull $(awk '$1 == "FROM" { print $2 }' Dockerfile)
 docker build -t docker-library-docs .
 test -t 1 && it='-it' || it='-i'
-docker run "$it" --rm -v "$(pwd)":/wtf -w /wtf -e TERM --entrypoint 'bash' docker-library-docs -c './push.pl "$@"' -- "$@"
+exec docker run "$it" --rm -v "$(pwd)":/wtf -w /wtf -e TERM --init --entrypoint ./push.pl docker-library-docs "$@"


### PR DESCRIPTION
Instead of cutting off the end of the image documentation, this change makes the code prefer to trim the entire "Supported tags" list, which for all our images which currently go over the limit brings them down enough to be within.  The note about where to get the full `README.md` file (with the "Supported tags" list intact) still stands, although could maybe do with some better styling and/or wording to make it more obvious (TBD).

I also verified that this change does the right thing in the fallback case by making the `postgres` image description intentionally extra long and verified that it simply trims the description content as before (since taking off the tags doesn't make the description short enough to be under the limit in that case).

Refs https://github.com/docker-library/official-images/issues/6030, https://github.com/docker/hub-feedback/issues/238