### PR TITLE
Deprecate RethinkDB

### DIFF
--- a/rethinkdb/deprecated.md
+++ b/rethinkdb/deprecated.md
@@ -1,0 +1,3 @@
+This image is deprecated due to maintainer inactivity (last updated Oct 2017; [docker-library/official-images#3530](https://github.com/docker-library/official-images/pull/3530)).
+
+If a representative of the RethinkDB community would like to step up and continue maintenance, [the contribution guidelines](https://github.com/docker-library/official-images/blob/master/README.md#contributing-to-the-standard-library) are the best place to start.


### PR DESCRIPTION
This is as discussed in https://github.com/rethinkdb/rethinkdb-dockerfiles/issues/44#issuecomment-503769612 -- I want to be clear that this is intended as a temporary measure, and I do hope to see `rethinkdb` image updates resume in the future! :heart: