### PR TITLE
Update opensuse deprecation now that 42.3 is EOL

### DIFF
--- a/opensuse/deprecated.md
+++ b/opensuse/deprecated.md
@@ -1,7 +1,3 @@
-This image has been deprecated in favor of the [`opensuse/leap`](https://hub.docker.com/r/opensuse/leap) and [`opensuse/tumbleweed`](https://hub.docker.com/r/opensuse/tumbleweed) images provided and maintained by the [openSUSE Project](https://www.opensuse.org/) release team.
-
-`opensuse:42.3` (= `opensuse:latest`) will receive security relevant fixes until the [EOL of Leap 42.3](https://en.opensuse.org/Lifetime#openSUSE_Leap). Newer openSUSE Leap releases such as 15.x are only available at [`opensuse/leap`](https://hub.docker.com/r/opensuse/leap).
-
-The opensuse:tumbleweed image is no longer updated, please use [`opensuse/tumbleweed`](https://hub.docker.com/r/opensuse/tumbleweed) instead. [`opensuse/tumbleweed`](https://hub.docker.com/r/opensuse/tumbleweed) is updated on every snapshot release.
+These images were removed in favor of the [`opensuse/leap`](https://hub.docker.com/r/opensuse/leap) and [`opensuse/tumbleweed`](https://hub.docker.com/r/opensuse/tumbleweed) images provided and maintained by the [openSUSE Project](https://www.opensuse.org/) release team.
 
 An archive for images of unsupported versions can be found at [`opensuse/archive`](https://hub.docker.com/r/opensuse/archive).


### PR DESCRIPTION
I believe this is the final step before removing the remaining tags for https://github.com/docker-library/official-images/issues/5371.

@Vogtinator is this accurate?  Should we update this line instead, or is the catch-all of the text above it and the `opensuse/archive` text at the end sufficient?