### PR TITLE
ghost: fix example to improve UX for first time users

### DIFF
--- a/ghost/content.md
+++ b/ghost/content.md
@@ -19,7 +19,7 @@ $ docker run -d --name some-ghost %%IMAGE%%
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 
 ```console
-$ docker run -d --name some-ghost -p 3001:2368 %%IMAGE%%
+$ docker run -d --name some-ghost -e url=http://localhost:3001 -p 3001:2368 %%IMAGE%%
 ```
 
 Then, access it via `http://localhost:3001` or `http://host-ip:3001` in a browser.


### PR DESCRIPTION
Adding this environment variable fixes wrong port on the links when using custom port and connecting to http://localhost:3001 

User experience for first time users is important.