### PR TITLE
Add a short blurb linking to the "dind-rootless" PR

### DIFF
--- a/docker/content.md
+++ b/docker/content.md
@@ -188,6 +188,10 @@ $ docker run --privileged --name some-docker -d \
 	%%IMAGE%%:dind --storage-driver overlay2
 ```
 
+## Rootless
+
+For more information about using the experimental "rootless" image variants, see [docker-library/docker#174](https://github.com/docker-library/docker/pull/174).
+
 ## Where to Store Data
 
 Important note: There are several ways to store data used by applications that run in Docker containers. We encourage users of the `%%REPO%%` images to familiarize themselves with the options available, including:


### PR DESCRIPTION
See https://github.com/docker-library/docker/pull/174.

Given that this is an experimental feature, I think it's reasonable to link to the PR itself as documentation (I've marked as "resolved" several distracting discussions there so the discussion and examples are easy to follow).