### PR TITLE
Add explicit volumes to WordPress stack example

### DIFF
--- a/wordpress/stack.yml
+++ b/wordpress/stack.yml
@@ -12,6 +12,8 @@ services:
       WORDPRESS_DB_USER: exampleuser
       WORDPRESS_DB_PASSWORD: examplepass
       WORDPRESS_DB_NAME: exampledb
+    volumes:
+      - wordpress:/var/www/html
 
   db:
     image: mysql:5.7
@@ -21,3 +23,9 @@ services:
       MYSQL_USER: exampleuser
       MYSQL_PASSWORD: examplepass
       MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:


### PR DESCRIPTION
Closes https://github.com/docker-library/wordpress/issues/404