### PR TITLE
Add a link to our FAQ entry about Shared Tags when we have them

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -8,7 +8,10 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 
 {{- $sharedTagGroups := .Manifest.GetSharedTagGroups -}}
 {{- if (len $sharedTagGroups) -}}
-	{{- "## Simple Tags\n\n" -}}
+	(See ["What's the difference between 'Shared' and 'Simple' tags?" in the FAQ](https://github.com/docker-library/faq#whats-the-difference-between-shared-and-simple-tags).)
+	{{- "\n\n" -}}
+	## Simple Tags
+	{{- "\n\n" -}}
 {{- end -}}
 
 {{- range $i, $e := ($archSpecific | ternary (archFilter arch $.Entries) $.Entries) -}}


### PR DESCRIPTION
> # Supported tags and respective `Dockerfile` links
>
> ## Simple Tags
>
> ...
>
> ## Shared Tags
>
> ...
>
> (See also ["What's the difference between 'Shared' and 'Simple' tags?" in the FAQ](https://github.com/docker-library/faq#whats-the-difference-between-shared-and-simple-tags).)

Refs https://github.com/docker-library/official-images/issues/6282, https://github.com/docker-library/docs/issues/1572#issuecomment-531366628