### PR TITLE
Add a separate explicit message for architectures which are not supported for an image

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.sh
+++ b/.template-helpers/generate-dockerfile-links-partial.sh
@@ -13,6 +13,11 @@ if [ -z "${BASHBREW_LIBRARY:-}" ]; then
 	repo="https://github.com/docker-library/official-images/raw/master/library/$repo"
 fi
 
+if [ -n "$ARCH_SPECIFIC_DOCS" ] && archTags="$(bashbrew cat --format '{{ range .Entries }}{{ if .HasArchitecture arch }}{{ .Tags | first }}{{ "\n" }}{{ end }}{{ end }}' "$repo")" && [ -z "$archTags" ]; then
+	echo "**WARNING:** THIS IMAGE *IS NOT SUPPORTED* ON THE \`$BASHBREW_ARCH\` ARCHITECTURE"
+	exit
+fi
+
 bashbrew cat \
-		-F "$(dirname "$BASH_SOURCE")/$(basename "$BASH_SOURCE" .sh).tmpl" \
-		"$repo"
+	-F "$(dirname "$BASH_SOURCE")/$(basename "$BASH_SOURCE" .sh).tmpl" \
+	"$repo"


### PR DESCRIPTION
This is to handle explicitly the case of images that were supported once but are no longer supported (like "openjdk" on s390x and ppc64le).

Ref https://github.com/docker-library/openjdk/issues/364#issuecomment-541193861 (where this idea was proposed :+1:)

---

# Supported tags and respective `Dockerfile` links

**WARNING:** THIS IMAGE *IS NOT SUPPORTED* ON THE `s390x` ARCHITECTURE

[![s390x/openjdk build status badge](https://img.shields.io/jenkins/s/https/doi-janky.infosiftr.net/job/multiarch/job/s390x/job/openjdk.svg?label=s390x/openjdk%20%20build%20job)](https://doi-janky.infosiftr.net/job/multiarch/job/s390x/job/openjdk/)

# Quick reference

...