### PR TITLE
Add docs for installing additional commands in telegraf image

### DIFF
--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -210,23 +210,25 @@ Refer to the docker [plugin documentation](https://github.com/influxdata/telegra
 
 ### Install Additional Packages
 
-Some plugins require additional packages to be installed.  For example, the `ntpq` plugin requires `ntpq` command.  It is recommended to create a custom derivative image to install any needed commands.
+Some plugins require additional packages to be installed.  For example, the `ntpq` plugin requires `ntpq` command. It is recommended to create a custom derivative image to install any needed commands.
 
 As an example this Dockerfile add the `mtr-tiny` image to the stock image and save it as `telegraf-mtr.docker`:
+
 ```dockerfile
 FROM telegraf:1.12.3
 
-RUN DEBIAN_FRONTEND=noninteractive \
-	apt-get update && apt-get install -y --no-install-recommends mtr-tiny && \
+RUN apt-get update && apt-get install -y --no-install-recommends mtr-tiny && \
 	rm -rf /var/lib/apt/lists/*
 ```
 
 Build the derivative image:
+
 ```console
 $ docker build -t telegraf-mtr:1.12.3 - < telegraf-mtr.docker
 ```
 
 Create a `telegraf.conf` configuration file:
+
 ```toml
 [[inputs.exec]]
   interval = "60s"
@@ -243,6 +245,7 @@ Create a `telegraf.conf` configuration file:
 ```
 
 Run your derivative image:
+
 ```console
 $ docker run --name telegraf --rm -v $PWD/telegraf.conf:/etc/telegraf/telegraf.conf telegraf-mtr:1.12.3
 ```

--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -210,7 +210,7 @@ Refer to the docker [plugin documentation](https://github.com/influxdata/telegra
 
 ### Install Additional Packages
 
-Some plugins require additional packages to be installed.  For example, the `ntpq` plugin requires `ntpq` command. It is recommended to create a custom derivative image to install any needed commands.
+Some plugins require additional packages to be installed. For example, the `ntpq` plugin requires `ntpq` command. It is recommended to create a custom derivative image to install any needed commands.
 
 As an example this Dockerfile add the `mtr-tiny` image to the stock image and save it as `telegraf-mtr.docker`:
 


### PR DESCRIPTION
Adds a basic example of how to extend the official image with new packages and use them with Telegraf.