### PR TITLE
Updating the EULA URL to point to the new non-versioned location.

### DIFF
--- a/oraclelinux/license.md
+++ b/oraclelinux/license.md
@@ -1,1 +1,1 @@
-View the [Oracle Linux End-User License Agreement](https://oss.oracle.com/ol6/EULA) for the software contained in this image.
+View the [Oracle Linux End-User License Agreement](https://oss.oracle.com/ol/EULA) for the software contained in this image.


### PR DESCRIPTION
Our legal team requested the EULA and its URL be version non-specific, so now it is.

Signed-off-by: Avi Miller <avi.miller@oracle.com>