### PR TITLE
ZNC: IPv6 was enabled a while ago

### DIFF
--- a/znc/content.md
+++ b/znc/content.md
@@ -24,6 +24,4 @@ The port should match the port you used during `--makeconf`. Note that 6667 is o
 
 If you use any external module, put the .cpp, .py or .pm file to `/znc-data/modules` (you may need to create that directory).
 
-Musl silently doesn't support `AI_ADDRCONFIG` yet, and ZNC doesn't support [Happy Eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs) yet. Together they cause very slow connection. So for now IPv6 is disabled here.
-
 This image contains the latest released version. If you want the bleeding edge (unstable) version, it's at [zncbouncer/znc-git](https://hub.docker.com/r/zncbouncer/znc-git).


### PR DESCRIPTION
https://github.com/znc/znc-docker/issues/19