### PR TITLE
Delete deprecated.md

### DIFF
--- a/rethinkdb/deprecated.md
+++ b/rethinkdb/deprecated.md
@@ -1,3 +1,0 @@
-This image is deprecated due to maintainer inactivity (last updated Oct 2017; [docker-library/official-images#3530](https://github.com/docker-library/official-images/pull/3530)).
-
-If a representative of the RethinkDB community would like to step up and continue maintenance, [the contribution guidelines](https://github.com/docker-library/official-images/blob/master/README.md#contributing-to-the-standard-library) are the best place to start.


### PR DESCRIPTION
Since we are publishing a new version, I believe this deprecation warning is not necessary anymore. https://github.com/docker-library/official-images/pull/7060