### PR TITLE
Provide instructions to obtain the default upstream httpd.conf

### DIFF
--- a/httpd/content.md
+++ b/httpd/content.md
@@ -36,7 +36,13 @@ $ docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/h
 
 ### Configuration
 
-To customize the configuration of the httpd server, just `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`.
+To customize the configuration of the httpd server, first obtain the upstream default configuration from the container:
+
+```console
+$ docker run %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
+```
+
+You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`.
 
 ```dockerfile
 FROM %%IMAGE%%:2.4

--- a/httpd/content.md
+++ b/httpd/content.md
@@ -42,7 +42,7 @@ To customize the configuration of the httpd server, first obtain the upstream de
 $ docker run --rm %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
 ```
 
-You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`.
+You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`:
 
 ```dockerfile
 FROM %%IMAGE%%:2.4

--- a/httpd/content.md
+++ b/httpd/content.md
@@ -39,7 +39,7 @@ $ docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/h
 To customize the configuration of the httpd server, first obtain the upstream default configuration from the container:
 
 ```console
-$ docker run %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
+$ docker run --rm %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
 ```
 
 You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`.


### PR DESCRIPTION
This PR closes docker-library/docs#1615, providing instructions to `cat` the
default upstream configuration from the container and, with redirection, store
a local copy for customization.

The resulting `my-httpd.conf` can then be used in the Dockerfile per the
existing instructions.