### PR TITLE
Update for 8u191 changes

### DIFF
--- a/openjdk/content.md
+++ b/openjdk/content.md
@@ -41,23 +41,19 @@ This will add your current directory as a volume to the container, set the worki
 
 ## Make JVM respect CPU and RAM limits
 
-On startup JVM tries to detect the number of available CPU cores and the amount of RAM to adjust its internal parameters (like the number of garbage collector threads to spawn) accordingly. When container is run with limited CPU/RAM, standard system API, used by JVM for probing, will return host-wide values. This can cause excessive CPU usage and memory allocation errors with older versions of JVM.
+On startup the JVM tries to detect the number of available CPU cores and RAM to adjust its internal parameters (like the number of garbage collector threads to spawn) accordingly. When the container is ran with limited CPU/RAM then the standard system API used by the JVM for probing it will return host-wide values. This can cause excessive CPU usage and memory allocation errors with older versions of the JVM.
 
-Inside Linux containers, OpenJDK versions 8 and later can correctly detect container-limited number of CPU cores and available RAM. In OpenJDK 11 this is turned on by default. In versions 8, 9, and 10 you have to enable the detection of container-limited amount of RAM using the following options:
+Inside Linux containers, OpenJDK versions 8 and later can correctly detect the container-limited number of CPU cores and available RAM. For all currently supported OpenJDK versions this is turned on by default.
 
-```console
-$ java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap ...
-```
-
-Inside Windows Server (non-Hyper-V) containers, limit for number of available CPU cores does not work (is ignored by Host Compute Service). To set such limit manually, JVM can be started the following way:
+Inside Windows Server (non-Hyper-V) containers, the limit for the number of available CPU cores doesn't work (it's ignored by Host Compute Service). To set the limit manually the JVM can be started as:
 
 ```console
 $ start /b /wait /affinity 0x3 path/to/java.exe ...
 ```
 
-In this example CPU affinity hex mask `0x3` will limit JVM to 2 CPU cores.
+In this example CPU affinity hex mask `0x3` will limit the JVM to 2 CPU cores.
 
-RAM limit is supported by Windows Server containers, but currently JVM cannot detect it. To prevent excessive memory allocations, `-XX:MaxRAM=...` option must be specified with the value that is not bigger than a containers RAM limit.
+RAM limit is supported by Windows Server containers, but currently the JVM cannot detect it. To prevent excessive memory allocations, `-XX:MaxRAM=...` option must be specified with the value that is not bigger than the containers RAM limit.
 
 ## Environment variables with periods in their names
 


### PR DESCRIPTION
Closes https://github.com/docker-library/openjdk/issues/392
>As of JDK 8 v191 the settings discussed are obsolete, and the container detection is on by default https://www.oracle.com/technetwork/java/javase/8u191-relnotes-5032181.html#JDK-8146115

Also added some `the`'s and other miscellaneous  syntax changes