### PR TITLE
Update license.md

### DIFF
--- a/rethinkdb/license.md
+++ b/rethinkdb/license.md
@@ -1,1 +1,1 @@
-View [license information](http://www.gnu.org/licenses/agpl-3.0.html) for the software contained in this image.
+View [license information](https://raw.githubusercontent.com/rethinkdb/rethinkdb/next/LICENSE) for the software contained in this image.


### PR DESCRIPTION
The license of RethinkDB has been changed several years ago, but the link was not updated here.