### PR TITLE
Update liberty content to reflect new tags

### DIFF
--- a/open-liberty/content.md
+++ b/open-liberty/content.md
@@ -49,7 +49,7 @@ Please note that this pattern will duplicate the docker layers for those artifac
 
 There are multiple tags available in this repository.
 
-The `kernel` image contains just the Liberty kernel and no additional runtime features. This image is the recommended basis for custom built images, so that they can contain only the features required for a  specific application. For example, the following Dockerfile starts with this image, copies in the `server.xml` that lists the features required by the application, and then uses the `configure.sh` script to download those features from the online repository.
+The `kernel` image contains just the Liberty kernel and no additional runtime features. This image is the recommended basis for custom built images, so that they can contain only the features required for a specific application. For example, the following Dockerfile starts with this image, copies in the `server.xml` that lists the features required by the application, and then uses the `configure.sh` script to download those features from the online repository.
 
 ```dockerfile
 FROM %%IMAGE%%:kernel

--- a/open-liberty/content.md
+++ b/open-liberty/content.md
@@ -2,7 +2,8 @@
 
 The images in this repository contain Open Liberty. For more information about Open Liberty, see the [Open Liberty Website](https://openliberty.io/) site.
 
-This repository contains OpenLiberty based on top of OpenJDK 8 with Eclipse OpenJ9 JRE images only. See
+This repository contains OpenLiberty based on top of OpenJDK 8 Eclipse
+OpenJ9 with Ubuntu images only. See
 [here](https://hub.docker.com/r/openliberty/open-liberty) for Open Liberty
 based on Red Hat's Universal Base Image, which includes additional java options.
 
@@ -109,14 +110,15 @@ $ docker run -d -p 80:9080 \
   %%IMAGE%%:full
 ```
 
-# Using Spring Boot with `kernel` images
+# Using Spring Boot with Open Liberty
 
 The `full` images introduce capabilities specific to the support of all Liberty
 features, including Spring Boot applications. This image thus includes the
 `springBootUtility` used to separate Spring Boot applications into thin
 applications and dependency library caches. To get these same capabilities
 without including features you are not using, build instead on top of `kernel` images
-and run configure.sh for your server.xml.
+and run configure.sh for your server.xml, ensuring that it enables either the
+`springBoot-1.5` or `springBoot-2.0` feature.
 
 To elaborate these capabilities this
 section assumes the standalone Spring Boot 2.0.x application

--- a/open-liberty/content.md
+++ b/open-liberty/content.md
@@ -2,7 +2,9 @@
 
 The images in this repository contain Open Liberty. For more information about Open Liberty, see the [Open Liberty Website](https://openliberty.io/) site.
 
-If you're looking for Open Liberty based on Red Hat's Universal Base Image, please see [this repo](https://hub.docker.com/r/openliberty/open-liberty).
+This repository contains OpenLiberty based on top of OpenJDK 8 with Eclipse OpenJ9 JRE images only. See
+[here](https://hub.docker.com/r/openliberty/open-liberty) for Open Liberty
+based on Red Hat's Universal Base Image, which includes additional java options.
 
 # Image User
 
@@ -49,7 +51,12 @@ Please note that this pattern will duplicate the docker layers for those artifac
 
 There are multiple tags available in this repository.
 
-The `kernel` image contains the Liberty kernel and can be used as the basis for custom built images that contain only the features required for a specific application. For example, the following Dockerfile starts with this image, copies in the `server.xml` that lists the features required by the application and then run a built-in script to install the needed features.
+The `kernel` image contains just the Liberty kernel and no additional runtime
+features. This image is the recommended basis for custom built images, so that
+they can contain only the features required for a specific application. For
+example, the following Dockerfile starts with this image, copies in the
+`server.xml` that lists the features required by the application, and then uses
+the `configure.sh` script to download those features from the online repository.
 
 ```dockerfile
 FROM %%IMAGE%%:kernel
@@ -72,7 +79,7 @@ The images are designed to support a number of different usage patterns. The fol
 
 It is a very strong best practice to create an extending Docker image, we called it the `application image`, that encapsulates an application and its configuration. This creates a robust, self-contained and predictable Docker image that can span new containers upon request, without relying on volumes or other external runtime artifacts that may behave different over time.
 
-If you want to build the smallest possible WebSphere Liberty application image you can start with our `kernel` tag, add your artifacts, and run `configure.sh` to grow the set of features to be fit-for-purpose. Please see our [GitHub page](https://github.com/OpenLiberty/ci.docker#building-an-application-image) for more details.
+If you want to build the smallest possible Open Liberty application image you can start with our `kernel` tag, add your artifacts, and run `configure.sh` to grow the set of features to be fit-for-purpose. Please see our [GitHub page](https://github.com/OpenLiberty/ci.docker#building-an-application-image) for more details.
 
 ## Enabling Enterprise functionality
 
@@ -87,7 +94,7 @@ When using `volumes`, an application file can be mounted in the `dropins` direct
 ```console
 $ docker run -d -p 80:9080 -p 443:9443 \
 	    -v /tmp/DefaultServletEngine/dropins/Sample1.war:/config/dropins/Sample1.war \
-	    %%IMAGE%%:webProfile8
+	    %%IMAGE%%:full
 ```
 
 When the server is started, you can browse to http://localhost/Sample1/SimpleServlet on the Docker host.
@@ -99,18 +106,31 @@ For greater flexibility over configuration, it is possible to mount an entire se
 ```console
 $ docker run -d -p 80:9080 \
   -v /tmp/DefaultServletEngine:/config \
-  %%IMAGE%%:webProfile8
+  %%IMAGE%%:full
 ```
 
-# Using `springBoot` images
+# Using Spring Boot with `kernel` images
 
-The `springBoot` images introduce capabilities specific to the support of Spring Boot applications, including the `springBootUtility` used to separate Spring Boot applications into thin applications and dependency library caches. To elaborate these capabilities this section assumes the standalone Spring Boot 2.0.x application `hellospringboot.jar` exists in the `/tmp` directory.
+The `full` images introduce capabilities specific to the support of all Liberty
+features, including Spring Boot applications. This image thus includes the
+`springBootUtility` used to separate Spring Boot applications into thin
+applications and dependency library caches. To get these same capabilities
+without including features you are not using, build instead on top of `kernel` images
+and run configure.sh for your server.xml.
+
+To elaborate these capabilities this
+section assumes the standalone Spring Boot 2.0.x application
+`hellospringboot.jar` exists in the `/tmp` directory.
 
 1.	A Spring Boot application JAR deploys to the `dropins/spring` directory within the default server configuration, not the `dropins` directory. Liberty allows one Spring Boot application per server configuration. You can create a Spring Boot application layer over this image by adding the application JAR to the `dropins/spring` directory. In this example we copied `hellospringboot.jar` from `/tmp` to the same directory containing the following Dockerfile.
 
 	```dockerfile
-	FROM %%IMAGE%%:springBoot2
+	FROM %%IMAGE%%:kernel
+
 	COPY --chown=1001:0 hellospringboot.jar /config/dropins/spring/
+    COPY --chown=1001:0 server.xml /config/
+    
+    RUN configure.sh
 	```
 
 	The custom image can be built and run as follows.
@@ -120,23 +140,25 @@ The `springBoot` images introduce capabilities specific to the support of Spring
 	$ docker run -d -p 8080:9080 app
 	```
 
-2.	The `springBoot` images provide the library cache directory, `lib.index.cache`, which contains an indexed library cache created by the `springBootUtility` command. Use `lib.index.cache` to provide the library cache for a thin application.
+2.	The `full` images provide the library cache directory, `lib.index.cache`, which contains an indexed library cache created by the `springBootUtility` command. Use `lib.index.cache` to provide the library cache for a thin application.
 
-	You can use the `springBootUtility` command to create thin application and library cache layers over a `springBoot` image. The following example uses docker staging to efficiently build an image that deploys a fat Spring Boot application as two layers containing a thin application and a library cache.
+	You can use the `springBootUtility` command to create thin application and library cache layers over a `full` image. The following example uses docker staging to efficiently build an image that deploys a fat Spring Boot application as two layers containing a thin application and a library cache.
 
 	```dockerfile
-	FROM %%IMAGE%%:springBoot2 as staging
+	FROM %%IMAGE%%:kernel as staging
 	COPY --chown=1001:0 hellospringboot.jar /staging/myFatApp.jar
-	RUN springBootUtility thin \
+    COPY --chown=1001:0 server.xml /config/
+	RUN configure.sh && springBootUtility thin \
 	   --sourceAppPath=/staging/myFatApp.jar \
 	   --targetThinAppPath=/staging/myThinApp.jar \
 	   --targetLibCachePath=/staging/lib.index.cache
-	FROM %%IMAGE%%:springBoot2
+	FROM %%IMAGE%%:kernel
 	COPY --from=staging /staging/lib.index.cache /lib.index.cache
 	COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 	```
 
 	For Spring Boot applications packaged with library dependencies that rarely change across continuous application updates, you can use the capabilities mentioned above to to share library caches across containers and to create even more efficient docker layers that leverage the docker build cache.
+
 
 # Providing your own keystore/truststore
 

--- a/open-liberty/content.md
+++ b/open-liberty/content.md
@@ -2,10 +2,7 @@
 
 The images in this repository contain Open Liberty. For more information about Open Liberty, see the [Open Liberty Website](https://openliberty.io/) site.
 
-This repository contains OpenLiberty based on top of OpenJDK 8 Eclipse
-OpenJ9 with Ubuntu images only. See
-[here](https://hub.docker.com/r/openliberty/open-liberty) for Open Liberty
-based on Red Hat's Universal Base Image, which includes additional java options.
+This repository contains OpenLiberty based on top of OpenJDK 8 Eclipse OpenJ9 with Ubuntu images only. See [here](https://hub.docker.com/r/openliberty/open-liberty) for Open Liberty based on Red Hat's Universal Base Image, which includes additional java options.
 
 # Image User
 
@@ -52,12 +49,7 @@ Please note that this pattern will duplicate the docker layers for those artifac
 
 There are multiple tags available in this repository.
 
-The `kernel` image contains just the Liberty kernel and no additional runtime
-features. This image is the recommended basis for custom built images, so that
-they can contain only the features required for a specific application. For
-example, the following Dockerfile starts with this image, copies in the
-`server.xml` that lists the features required by the application, and then uses
-the `configure.sh` script to download those features from the online repository.
+The `kernel` image contains just the Liberty kernel and no additional runtime features. This image is the recommended basis for custom built images, so that they can contain only the features required for a  specific application. For example, the following Dockerfile starts with this image, copies in the `server.xml` that lists the features required by the application, and then uses the `configure.sh` script to download those features from the online repository.
 
 ```dockerfile
 FROM %%IMAGE%%:kernel
@@ -112,17 +104,9 @@ $ docker run -d -p 80:9080 \
 
 # Using Spring Boot with Open Liberty
 
-The `full` images introduce capabilities specific to the support of all Liberty
-features, including Spring Boot applications. This image thus includes the
-`springBootUtility` used to separate Spring Boot applications into thin
-applications and dependency library caches. To get these same capabilities
-without including features you are not using, build instead on top of `kernel` images
-and run configure.sh for your server.xml, ensuring that it enables either the
-`springBoot-1.5` or `springBoot-2.0` feature.
+The `full` images introduce capabilities specific to the support of all Liberty features, including Spring Boot applications. This image thus includes the `springBootUtility` used to separate Spring Boot applications into thin applications and dependency library caches. To get these same capabilities without including features you are not using, build instead on top of `kernel` images and run configure.sh for your server.xml, ensuring that it enables either the `springBoot-1.5` or `springBoot-2.0` feature.
 
-To elaborate these capabilities this
-section assumes the standalone Spring Boot 2.0.x application
-`hellospringboot.jar` exists in the `/tmp` directory.
+To elaborate these capabilities this section assumes the standalone Spring Boot 2.0.x application `hellospringboot.jar` exists in the `/tmp` directory.
 
 1.	A Spring Boot application JAR deploys to the `dropins/spring` directory within the default server configuration, not the `dropins` directory. Liberty allows one Spring Boot application per server configuration. You can create a Spring Boot application layer over this image by adding the application JAR to the `dropins/spring` directory. In this example we copied `hellospringboot.jar` from `/tmp` to the same directory containing the following Dockerfile.
 
@@ -130,9 +114,9 @@ section assumes the standalone Spring Boot 2.0.x application
 	FROM %%IMAGE%%:kernel
 
 	COPY --chown=1001:0 hellospringboot.jar /config/dropins/spring/
-    COPY --chown=1001:0 server.xml /config/
-    
-    RUN configure.sh
+	COPY --chown=1001:0 server.xml /config/
+
+	RUN configure.sh
 	```
 
 	The custom image can be built and run as follows.
@@ -149,7 +133,7 @@ section assumes the standalone Spring Boot 2.0.x application
 	```dockerfile
 	FROM %%IMAGE%%:kernel as staging
 	COPY --chown=1001:0 hellospringboot.jar /staging/myFatApp.jar
-    COPY --chown=1001:0 server.xml /config/
+	COPY --chown=1001:0 server.xml /config/
 	RUN configure.sh && springBootUtility thin \
 	   --sourceAppPath=/staging/myFatApp.jar \
 	   --targetThinAppPath=/staging/myThinApp.jar \
@@ -160,7 +144,6 @@ section assumes the standalone Spring Boot 2.0.x application
 	```
 
 	For Spring Boot applications packaged with library dependencies that rarely change across continuous application updates, you can use the capabilities mentioned above to to share library caches across containers and to create even more efficient docker layers that leverage the docker build cache.
-
 
 # Providing your own keystore/truststore
 

--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -2,7 +2,9 @@
 
 The images in this repository contain WebSphere Liberty application server and the IBM Java Runtime Environment. For more information please see our [official repository](https://github.com/WASdev/ci.docker).
 
-If you're looking for UBI-based images, please see [this repo](https://hub.docker.com/r/ibmcom/websphere-liberty/).
+This repository contains WebSphere Liberty based on top of IBM Java 8 images
+only. See [here](https://hub.docker.com/r/ibmcom/websphere-liberty/) for WebSphere Liberty based on Red Hat's Universal Base
+Image, which includes additional java options.
 
 # Image User
 
@@ -49,7 +51,12 @@ Please note that this pattern will duplicate the docker layers for those artifac
 
 There are multiple tags available in this repository. The image with the tag `beta` contains the contents of the install archive for the latest monthly beta. The other images are all based on the latest generally available fix pack.
 
-The `kernel` image contains just the Liberty kernel and no additional runtime features. This image can be used as the basis for custom built images that contain only the features required for a specific application. For example, the following Dockerfile starts with this image, copies in the `server.xml` that lists the features required by the application, and then uses the `configure.sh` script to download those features from the online repository.
+The `kernel` image contains just the Liberty kernel and no additional runtime
+features. This image is the recommended basis for custom built images, so that
+they can contain only the features required for a specific application. For
+example, the following Dockerfile starts with this image, copies in the
+`server.xml` that lists the features required by the application, and then uses
+the `configure.sh` script to download those features from the online repository.
 
 ```dockerfile
 FROM %%IMAGE%%:kernel
@@ -100,15 +107,28 @@ $ docker run -d -p 80:9080 \
       %%IMAGE%%:webProfile8
 ```
 
-# Using `springBoot` images
+# Using Spring Boot with `kernel` images
 
-The `springBoot` images introduce capabilities specific to the support of Spring Boot applications, including the `springBootUtility` used to separate Spring Boot applications into thin applications and dependency library caches. To elaborate these capabilities this section assumes the standalone Spring Boot 2.0.x application `hellospringboot.jar` exists in the `/tmp` directory.
+The `full` images introduce capabilities specific to the support of all Liberty
+features, including Spring Boot applications. This image thus includes the
+`springBootUtility` used to separate Spring Boot applications into thin
+applications and dependency library caches. To get these same capabilities
+without including features you are not using, build instead on top of `kernel` images
+and run configure.sh for your server.xml.
+
+To elaborate these capabilities this
+section assumes the standalone Spring Boot 2.0.x application
+`hellospringboot.jar` exists in the `/tmp` directory.
 
 1.	A Spring Boot application JAR deploys to the `dropins/spring` directory within the default server configuration, not the `dropins` directory. Liberty allows one Spring Boot application per server configuration. You can create a Spring Boot application layer over this image by adding the application JAR to the `dropins/spring` directory. In this example we copied `hellospringboot.jar` from `/tmp` to the same directory containing the following Dockerfile.
 
 	```dockerfile
-	FROM %%IMAGE%%:springBoot2
+	FROM %%IMAGE%%:kernel
+
 	COPY --chown=1001:0 hellospringboot.jar /config/dropins/spring/
+    COPY --chown=1001:0 server.xml /config/
+    
+    RUN configure.sh
 	```
 
 	The custom image can be built and run as follows.
@@ -118,18 +138,19 @@ The `springBoot` images introduce capabilities specific to the support of Spring
 	$ docker run -d -p 8080:9080 app
 	```
 
-2.	The `springBoot` images provide the library cache directory, `lib.index.cache`, which contains an indexed library cache created by the `springBootUtility` command. Use `lib.index.cache` to provide the library cache for a thin application.
+2.	The `full` images provide the library cache directory, `lib.index.cache`, which contains an indexed library cache created by the `springBootUtility` command. Use `lib.index.cache` to provide the library cache for a thin application.
 
-	You can use the `springBootUtility` command to create thin application and library cache layers over a `springBoot` image. The following example uses docker staging to efficiently build an image that deploys a fat Spring Boot application as two layers containing a thin application and a library cache.
+	You can use the `springBootUtility` command to create thin application and library cache layers over a `full` image. The following example uses docker staging to efficiently build an image that deploys a fat Spring Boot application as two layers containing a thin application and a library cache.
 
 	```dockerfile
-	FROM %%IMAGE%%:springBoot2 as staging
+	FROM %%IMAGE%%:kernel as staging
 	COPY --chown=1001:0 hellospringboot.jar /staging/myFatApp.jar
-	RUN springBootUtility thin \
+    COPY --chown=1001:0 server.xml /config/
+	RUN configure.sh && springBootUtility thin \
 	   --sourceAppPath=/staging/myFatApp.jar \
 	   --targetThinAppPath=/staging/myThinApp.jar \
 	   --targetLibCachePath=/staging/lib.index.cache
-	FROM %%IMAGE%%:springBoot2
+	FROM %%IMAGE%%:kernel
 	COPY --from=staging /staging/lib.index.cache /lib.index.cache
 	COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 	```
@@ -176,10 +197,14 @@ docker run -d -p 80:9080 -p 443:9443 \
 
 # Changing locale
 
-The base Ubuntu image does not include additional language packs. To use an alternative locale, build your own image that installs the required language pack and then sets the `LANG` environment variable. For example, the following Dockerfile starts with the `%%IMAGE%%:webProfile8` image, installs the Portuguese language pack, and sets Brazilian Portuguese as the default locale:
+The base Ubuntu image does not include additional language packs. To use an
+alternative locale, build your own image that installs the required language
+pack and then sets the `LANG` environment variable. For example, the following
+Dockerfile starts with the `%%IMAGE%%:full` image, installs the Portuguese
+language pack, and sets Brazilian Portuguese as the default locale:
 
 ```dockerfile
-FROM %%IMAGE%%:webProfile8
+FROM %%IMAGE%%:full
 RUN apt-get update \
   && apt-get install -y language-pack-pt-base \
   && rm -rf /var/lib/apt/lists/*

--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -104,7 +104,6 @@ $ docker run -d -p 80:9080 \
 
 The `full` images introduce capabilities specific to the support of all Liberty features, including Spring Boot applications. This image thus includes the `springBootUtility` used to separate Spring Boot applications into thin applications and dependency library caches. To get these same capabilities without including features you are not using, build instead on top of `kernel` images and run configure.sh for your server.xml, ensuring that it enables either the `springBoot-1.5` or `springBoot-2.0` feature.
 
-
 To elaborate these capabilities this section assumes the standalone Spring Boot 2.0.x application `hellospringboot.jar` exists in the `/tmp` directory.
 
 1.	A Spring Boot application JAR deploys to the `dropins/spring` directory within the default server configuration, not the `dropins` directory. Liberty allows one Spring Boot application per server configuration. You can create a Spring Boot application layer over this image by adding the application JAR to the `dropins/spring` directory. In this example we copied `hellospringboot.jar` from `/tmp` to the same directory containing the following Dockerfile.

--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -2,9 +2,7 @@
 
 The images in this repository contain WebSphere Liberty application server and the IBM Java Runtime Environment. For more information please see our [official repository](https://github.com/WASdev/ci.docker).
 
-This repository contains WebSphere Liberty based on top of IBM Java 8 with Ubuntu images
-only. See [here](https://hub.docker.com/r/ibmcom/websphere-liberty/) for WebSphere Liberty based on Red Hat's Universal Base
-Image, which includes additional java options.
+This repository contains WebSphere Liberty based on top of IBM Java 8 with Ubuntu images only. See [here](https://hub.docker.com/r/ibmcom/websphere-liberty/) for WebSphere Liberty based on Red Hat's Universal Base Image, which includes additional java options.
 
 # Image User
 
@@ -51,12 +49,7 @@ Please note that this pattern will duplicate the docker layers for those artifac
 
 There are multiple tags available in this repository. The image with the tag `beta` contains the contents of the install archive for the latest monthly beta. The other images are all based on the latest generally available fix pack.
 
-The `kernel` image contains just the Liberty kernel and no additional runtime
-features. This image is the recommended basis for custom built images, so that
-they can contain only the features required for a specific application. For
-example, the following Dockerfile starts with this image, copies in the
-`server.xml` that lists the features required by the application, and then uses
-the `configure.sh` script to download those features from the online repository.
+The `kernel` image contains just the Liberty kernel and no additional runtime features. This image is the recommended basis for custom built images, so that they can contain only the features required for a specific application. For example, the following Dockerfile starts with this image, copies in the `server.xml` that lists the features required by the application, and then uses the `configure.sh` script to download those features from the online repository.
 
 ```dockerfile
 FROM %%IMAGE%%:kernel
@@ -109,18 +102,10 @@ $ docker run -d -p 80:9080 \
 
 # Using Spring Boot with WebSphere Liberty
 
-The `full` images introduce capabilities specific to the support of all Liberty
-features, including Spring Boot applications. This image thus includes the
-`springBootUtility` used to separate Spring Boot applications into thin
-applications and dependency library caches. To get these same capabilities
-without including features you are not using, build instead on top of `kernel` images
-and run configure.sh for your server.xml, ensuring that it enables either the
-`springBoot-1.5` or `springBoot-2.0` feature.
+The `full` images introduce capabilities specific to the support of all Liberty features, including Spring Boot applications. This image thus includes the `springBootUtility` used to separate Spring Boot applications into thin applications and dependency library caches. To get these same capabilities without including features you are not using, build instead on top of `kernel` images and run configure.sh for your server.xml, ensuring that it enables either the `springBoot-1.5` or `springBoot-2.0` feature.
 
 
-To elaborate these capabilities this
-section assumes the standalone Spring Boot 2.0.x application
-`hellospringboot.jar` exists in the `/tmp` directory.
+To elaborate these capabilities this section assumes the standalone Spring Boot 2.0.x application `hellospringboot.jar` exists in the `/tmp` directory.
 
 1.	A Spring Boot application JAR deploys to the `dropins/spring` directory within the default server configuration, not the `dropins` directory. Liberty allows one Spring Boot application per server configuration. You can create a Spring Boot application layer over this image by adding the application JAR to the `dropins/spring` directory. In this example we copied `hellospringboot.jar` from `/tmp` to the same directory containing the following Dockerfile.
 
@@ -128,9 +113,9 @@ section assumes the standalone Spring Boot 2.0.x application
 	FROM %%IMAGE%%:kernel
 
 	COPY --chown=1001:0 hellospringboot.jar /config/dropins/spring/
-    COPY --chown=1001:0 server.xml /config/
-    
-    RUN configure.sh
+	COPY --chown=1001:0 server.xml /config/
+
+	RUN configure.sh
 	```
 
 	The custom image can be built and run as follows.
@@ -147,7 +132,7 @@ section assumes the standalone Spring Boot 2.0.x application
 	```dockerfile
 	FROM %%IMAGE%%:kernel as staging
 	COPY --chown=1001:0 hellospringboot.jar /staging/myFatApp.jar
-    COPY --chown=1001:0 server.xml /config/
+	COPY --chown=1001:0 server.xml /config/
 	RUN configure.sh && springBootUtility thin \
 	   --sourceAppPath=/staging/myFatApp.jar \
 	   --targetThinAppPath=/staging/myThinApp.jar \
@@ -199,11 +184,7 @@ docker run -d -p 80:9080 -p 443:9443 \
 
 # Changing locale
 
-The base Ubuntu image does not include additional language packs. To use an
-alternative locale, build your own image that installs the required language
-pack and then sets the `LANG` environment variable. For example, the following
-Dockerfile starts with the `%%IMAGE%%:full` image, installs the Portuguese
-language pack, and sets Brazilian Portuguese as the default locale:
+The base Ubuntu image does not include additional language packs. To use an alternative locale, build your own image that installs the required language pack and then sets the `LANG` environment variable. For example, the following Dockerfile starts with the `%%IMAGE%%:full` image, installs the Portuguese language pack, and sets Brazilian Portuguese as the default locale:
 
 ```dockerfile
 FROM %%IMAGE%%:full

--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -2,7 +2,7 @@
 
 The images in this repository contain WebSphere Liberty application server and the IBM Java Runtime Environment. For more information please see our [official repository](https://github.com/WASdev/ci.docker).
 
-This repository contains WebSphere Liberty based on top of IBM Java 8 images
+This repository contains WebSphere Liberty based on top of IBM Java 8 with Ubuntu images
 only. See [here](https://hub.docker.com/r/ibmcom/websphere-liberty/) for WebSphere Liberty based on Red Hat's Universal Base
 Image, which includes additional java options.
 
@@ -107,14 +107,16 @@ $ docker run -d -p 80:9080 \
       %%IMAGE%%:webProfile8
 ```
 
-# Using Spring Boot with `kernel` images
+# Using Spring Boot with WebSphere Liberty
 
 The `full` images introduce capabilities specific to the support of all Liberty
 features, including Spring Boot applications. This image thus includes the
 `springBootUtility` used to separate Spring Boot applications into thin
 applications and dependency library caches. To get these same capabilities
 without including features you are not using, build instead on top of `kernel` images
-and run configure.sh for your server.xml.
+and run configure.sh for your server.xml, ensuring that it enables either the
+`springBoot-1.5` or `springBoot-2.0` feature.
+
 
 To elaborate these capabilities this
 section assumes the standalone Spring Boot 2.0.x application


### PR DESCRIPTION
- Updates the content.md files to more accurately reflect recent changes to the tags provided by `websphere-liberty` and `open-liberty`

@arthurdm I tried to update sections related to specific feature images, like `springBoot2` to use the new tags and best practice approach of building on top of `kernel` and running configure.sh. If you want me to change it to just use `full` instead let me know.

RE: [#149](https://github.com/OpenLiberty/ci.docker/issues/149)