### PR TITLE
clean dockerfile layer in example

### DIFF
--- a/rust/content.md
+++ b/rust/content.md
@@ -39,7 +39,7 @@ COPY . .
 RUN cargo install --path .
 
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y extra-runtime-dependencies
+RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/myapp /usr/local/bin/myapp
 CMD ["myapp"]
 ```


### PR DESCRIPTION
Following the [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) we should encourage people to remove the cache after installing dependencies.