### PR TITLE
Update WebSphere Liberty documentation

### DIFF
--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -132,13 +132,15 @@ To elaborate these capabilities this section assumes the standalone Spring Boot 
 	FROM %%IMAGE%%:kernel as staging
 	COPY --chown=1001:0 hellospringboot.jar /staging/myFatApp.jar
 	COPY --chown=1001:0 server.xml /config/
-	RUN configure.sh && springBootUtility thin \
+	RUN springBootUtility thin \
 	   --sourceAppPath=/staging/myFatApp.jar \
 	   --targetThinAppPath=/staging/myThinApp.jar \
 	   --targetLibCachePath=/staging/lib.index.cache
 	FROM %%IMAGE%%:kernel
+	COPY --chown=1001:0 server.xml /config
 	COPY --from=staging /staging/lib.index.cache /lib.index.cache
 	COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
+	RUN configure.sh
 	```
 
 	For Spring Boot applications packaged with library dependencies that rarely change across continuous application updates, you can use the capabilities mentioned above to to share library caches across containers and to create even more efficient docker layers that leverage the docker build cache.


### PR DESCRIPTION
Correcting the order where `configure.sh` must be called.  Also, we need a server.xml in the sample.