### PR TITLE
Fix incorrect port mapping of 2368 and update to latest docker image version

### DIFF
--- a/ghost/README.md
+++ b/ghost/README.md
@@ -144,7 +144,7 @@ version: '3.1'
 services:
 
   ghost:
-    image: ghost:1-alpine
+    image: ghost
     restart: always
     ports:
       - 2368:2368

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -147,7 +147,7 @@ services:
     image: ghost:1-alpine
     restart: always
     ports:
-      - 8080:2368
+      - 2368:2368
     environment:
       # see https://docs.ghost.org/docs/config#section-running-ghost-with-config-env-variables
       database__client: mysql
@@ -165,7 +165,7 @@ services:
 
 [![Try in PWD](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/docker-library/docs/e24f39cddf21560cf0a24f149059ff23640b0f16/ghost/stack.yml)
 
-Run `docker stack deploy -c stack.yml ghost` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml ghost` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:2368`, `http://localhost:2368`, or `http://host-ip:2368` (as appropriate).
 
 # Image Variants
 


### PR DESCRIPTION
Ghost's port is displayed as `8080` which is incorrect, port `2368` should be the correct port as there are URLs on the page that is redirecting to port `2368`.

Example:
```
http://localhost:2368/author/ghost/
```