### PR TITLE
Add deprecation notice to Thrift image

### DIFF
--- a/thrift/deprecated.md
+++ b/thrift/deprecated.md
@@ -1,0 +1,3 @@
+This image is deprecated due to inactivity (last updated Feb 2019; [docker-library/official-images#5411](https://github.com/docker-library/official-images/pull/5411)).
+
+There is a useful discussion in [ahawkins/docker-thrift#12](https://github.com/ahawkins/docker-thrift/issues/12) about the future of this image.


### PR DESCRIPTION
To be clear, this is not intended to discourage -- the goal of this change is to communicate clearly to users that this image has not seen a substantive update since https://github.com/docker-library/official-images/pull/5411.

Hopefully this will change in the future, especially with the discussions occurring in https://github.com/ahawkins/docker-thrift/issues/12 (ideally directly involved with/approved by upstream :pray::heart:), at which point we'll remove this notice!