### PR TITLE
Update repositories to point to corretto-docker instead of corretto-8-docker

### DIFF
--- a/amazoncorretto/github-repo
+++ b/amazoncorretto/github-repo
@@ -1,1 +1,1 @@
-https://github.com/corretto/corretto-8-docker
+https://github.com/corretto/corretto-docker


### PR DESCRIPTION
We have migrated from separate repositories for Corretto8 docker images and Corretto11 Docker images to a single repository that contains Dockerfiles for both Corretto8 and Corretto11. Updating the Github issue link and Github repository link to reflect the same. 