### PR TITLE
nginx: add section "Entrypoint quiet logs"

### DIFF
--- a/nginx/content.md
+++ b/nginx/content.md
@@ -136,6 +136,14 @@ web:
   command: [nginx-debug, '-g', 'daemon off;']
 ```
 
+## Entrypoint quiet logs
+
+Since version 1.19.0, a verbose entrypoint was added. It provides information on what's happening during container startup. You can silence this output by setting environment variable `NGINX_ENTRYPOINT_QUIET_LOGS`:
+
+```console
+$ docker run -d -e NGINX_ENTRYPOINT_QUIET_LOGS=1 %%IMAGE%%
+```
+
 ## User and group id
 
 Since 1.17.0, both alpine- and debian-based images variants use the same user and group ids to drop the privileges for worker processes:


### PR DESCRIPTION
**Related issue**:  nginxinc/docker-nginx#421
**Related pull-request**: nginxinc/docker-nginx#424

### :warning: Wait for feature to be released before merging documentation

- [ ] Wait for release 1.20, who should contain it.
- [ ] Test the feature to make sure it's effective in 1.20
