### PR TITLE
Add "Classic Swarm" deprecation notice

### DIFF
--- a/swarm/deprecated.md
+++ b/swarm/deprecated.md
@@ -1,0 +1,3 @@
+> Classic Swarm has been archived and is no longer actively developed. You may want to use the Swarm mode built into the Docker Engine instead, or another orchestration system.
+
+(https://github.com/docker/classicswarm#readme)


### PR DESCRIPTION
Rendering preview:

---

# **DEPRECATION NOTICE**

> Classic Swarm has been archived and is no longer actively developed. You may want to use the Swarm mode built into the Docker Engine instead, or another orchestration system.

(https://github.com/docker/classicswarm#readme)

# Quick reference

...