### PR TITLE
Update Classic Swarm "short description"

### DIFF
--- a/swarm/README-short.txt
+++ b/swarm/README-short.txt
@@ -1,1 +1,1 @@
-Swarm: a Docker-native clustering system.
+Classic Swarm is no longer actively developed; use Swarm mode built into the Docker Engine instead


### PR DESCRIPTION
This is a follow-up to #1738 to make it clear in image listings and `docker search` that this image is deprecated.

I took the deprecation notice and wordsmithed it down to 100 characters so it would fit. :sweat_smile:

(Happy for suggestions if there are better/more preferred ways to adjust the deprecation notice down to 100 characters. :+1: :heart:)

cc @thajeztah @justincormack