### PR TITLE
Notice of removal of latest tag for Oracle Linux.

### DIFF
--- a/oraclelinux/content.md
+++ b/oraclelinux/content.md
@@ -8,6 +8,10 @@ Oracle Linux is an open-source operating system available under the GNU General 
 
 The Oracle Linux images are intended for use in the **FROM** field of a downstream `Dockerfile`. For example, to use the latest optimized Oracle Linux 7 image, specify `FROM %%IMAGE%%:7-slim`.
 
+## Removal of `latest` tag
+
+The `latest` tag was removed from the Oracle Linux official images in June 2020 to reduce confusion. Downstream images using `oraclelinux:latest` or no tag should be updated to `oraclelinux:7` for future builds. Note that Oracle recommends using the `-slim` variants for the smallest possible image size.
+
 ## Official Resources
 
 -	[Learn more about Oracle Linux](https://oracle.com/linux)


### PR DESCRIPTION
Documentation update to address the removal of the `latest` tag for the official Oracle Linux image.

Related: https://github.com/docker-library/official-images/pull/8220

Signed-off-by: Avi Miller <avi.miller@oracle.com>