### PR TITLE
Add CRUX deprecation notice

### DIFF
--- a/crux/deprecated.md
+++ b/crux/deprecated.md
@@ -1,0 +1,3 @@
+This image is deprecated due to maintainer inactivity (last updated Nov 2018; [docker-library/official-images#5073](https://github.com/docker-library/official-images/pull/5073)).
+
+See [docker-library/official-images#7130](https://github.com/docker-library/official-images/pull/7130) for discussion around an in-progress upstream update.


### PR DESCRIPTION
This is per the discussion that occurred in https://github.com/docker-library/official-images/pull/5073 and later in https://github.com/docker-library/official-images/pull/7130 -- it sounds like updating the image is going to be a non-trivial endeavor, so this is an attempt to communicate the image status to users.

Hopefully we can revert this soon! :heart:

FYI @ image/repo maintainers: @prologic @lag-linaro @mcharytoniuk @wawrzek