### PR TITLE
update links in jetty documentation

### DIFF
--- a/jetty/README.md
+++ b/jetty/README.md
@@ -17,7 +17,7 @@ WARNING:
 # Quick reference
 
 -	**Maintained by**:  
-	[the Docker Community](https://github.com/eclipse/jetty.docker)
+	[the Docker Community](https://github.com/appropriate/docker-jetty)
 
 -	**Where to get help**:  
 	[the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)
@@ -52,7 +52,7 @@ WARNING:
 # Quick reference (cont.)
 
 -	**Where to file issues**:  
-	[https://github.com/eclipse/jetty.docker/issues](https://github.com/eclipse/jetty.docker/issues)
+	[https://github.com/appropriate/docker-jetty/issues](https://github.com/appropriate/docker-jetty/issues)
 
 -	**Supported architectures**: ([more info](https://github.com/docker-library/official-images#architectures-other-than-amd64))  
 	[`amd64`](https://hub.docker.com/r/amd64/jetty/), [`arm64v8`](https://hub.docker.com/r/arm64v8/jetty/)
@@ -186,7 +186,7 @@ This image does not contain the common packages contained in the default tag and
 
 # License
 
-View [license information](http://eclipse.org/jetty/licenses.html) for the software contained in this image.
+View [license information](http://eclipse.org/jetty/licenses.php) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/jetty/README.md
+++ b/jetty/README.md
@@ -17,7 +17,7 @@ WARNING:
 # Quick reference
 
 -	**Maintained by**:  
-	[the Docker Community](https://github.com/appropriate/docker-jetty)
+	[the Docker Community](https://github.com/eclipse/jetty.docker)
 
 -	**Where to get help**:  
 	[the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)
@@ -52,7 +52,7 @@ WARNING:
 # Quick reference (cont.)
 
 -	**Where to file issues**:  
-	[https://github.com/appropriate/docker-jetty/issues](https://github.com/appropriate/docker-jetty/issues)
+	[https://github.com/eclipse/jetty.docker/issues](https://github.com/eclipse/jetty.docker/issues)
 
 -	**Supported architectures**: ([more info](https://github.com/docker-library/official-images#architectures-other-than-amd64))  
 	[`amd64`](https://hub.docker.com/r/amd64/jetty/), [`arm64v8`](https://hub.docker.com/r/arm64v8/jetty/)
@@ -186,7 +186,7 @@ This image does not contain the common packages contained in the default tag and
 
 # License
 
-View [license information](http://eclipse.org/jetty/licenses.php) for the software contained in this image.
+View [license information](http://eclipse.org/jetty/licenses.html) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/jetty/github-repo
+++ b/jetty/github-repo
@@ -1,1 +1,1 @@
-https://github.com/appropriate/docker-jetty
+https://github.com/eclipse/jetty.docker

--- a/jetty/license.md
+++ b/jetty/license.md
@@ -1,1 +1,1 @@
-View [license information](http://eclipse.org/jetty/licenses.php) for the software contained in this image.
+View [license information](http://eclipse.org/jetty/licenses.html) for the software contained in this image.


### PR DESCRIPTION
Update links to new repository location at https://github.com/eclipse/jetty.docker,
also fix link for the licence information. 

See original PR for this at https://github.com/docker-library/official-images/pull/8241