### PR TITLE
Correct instructions  for server-client networking

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -106,7 +106,7 @@ First developed by the software company 10gen (now MongoDB Inc.) in October 2007
 ## Start a `mongo` server instance
 
 ```console
-$ docker run --name some-mongo --network=some-network-d mongo:tag
+$ docker run --name some-mongo --network some-network -d mongo:tag
 ```
 
 ... where `some-mongo` is the name you want to assign to your container, tag` is the tag specifying the MongoDB version you want, and `some-network` is an existing Docker network. See the list above for relevant tags.

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -106,20 +106,22 @@ First developed by the software company 10gen (now MongoDB Inc.) in October 2007
 ## Start a `mongo` server instance
 
 ```console
-$ docker run --name some-mongo -d mongo:tag
+$ docker run --name some-mongo --network=some-network-d mongo:tag
 ```
 
-... where `some-mongo` is the name you want to assign to your container and `tag` is the tag specifying the MongoDB version you want. See the list above for relevant tags.
+... where `some-mongo` is the name you want to assign to your container, tag` is the tag specifying the MongoDB version you want, and `some-network` is an existing Docker network. See the list above for relevant tags.
+
+(Hint: A Docker network can be created with the command `docker network create some-network`)
 
 ## Connect to MongoDB from another Docker container
 
 The MongoDB server in the image listens on the standard MongoDB port, `27017`, so connecting via Docker networks will be the same as connecting to a remote `mongod`. The following example starts another MongoDB container instance and runs the `mongo` command line client against the original MongoDB container from the example above, allowing you to execute MongoDB statements against your database instance:
 
 ```console
-$ docker run -it --network some-network --rm mongo mongo --host some-mongo test
+$ docker run -it --network=some-network --rm mongo mongo --host some-mongo test
 ```
 
-... where `some-mongo` is the name of your original `mongo` container.
+... where `some-mongo` is the name of your original `mongo` container and `some-network` is the same network used by the origonal container.
 
 ## ... via [`docker stack deploy`](https://docs.docker.com/engine/reference/commandline/stack_deploy/) or [`docker-compose`](https://github.com/docker/compose)
 


### PR DESCRIPTION
1. Added `--network` when starting mongo server
2. Fixed `--network` option when starting client
3. Added additional notes about use of Docker network