### PR TITLE
Update content.md

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -164,7 +164,7 @@ There are many ways to set PostgreSQL server configuration. For information on w
 -	Set options directly on the run line. The entrypoint script is made so that any options passed to the docker command will be passed along to the `postgres` server daemon. From the [docs](https://www.postgresql.org/docs/current/static/app-postgres.html) we see that any option available in a `.conf` file can be set via `-c`.
 
 	```console
-	$ docker run -d --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword %%IMAGE%% -c 'shared_buffers=256MB' -c 'max_connections=200'
+	$ docker run -d --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword %%IMAGE%% -c shared_buffers=256MB -c max_connections=200
 	```
 
 ## Locale Customization


### PR DESCRIPTION
The `'` characters around the parameter name and value prevent it to be properly passed and should be skipped.