### PR TITLE
[flink] update docs to reflect new repository location

### DIFF
--- a/flink/content.md
+++ b/flink/content.md
@@ -1,83 +1,9 @@
 # What is Apache Flink?
 
-Apache Flink is an open source stream processing framework with powerful stream- and batch-processing capabilities.
-
-Learn more about Flink at [https://flink.apache.org/](https://flink.apache.org/)
-
-> [wikipedia.org/wiki/Apache_Flink](https://en.wikipedia.org/wiki/Apache_Flink)
+[Apache Flink](https://flink.apache.org/) is an open source stream processing framework with powerful stream- and batch-processing capabilities.
 
 %%LOGO%%
 
-# Flink Docker image tags
+# How to use Apache Flink with Docker?
 
-Starting with Flink 1.5, images without "hadoop" in the tag are the "Hadoop-free" variant of Flink. If you require Hadoop support (such as its HDFS filesystem implementation), you should reference an image whose tag includes the Hadoop version you need.
-
-# How to use this Docker image
-
-## Running a JobManager or a TaskManager
-
-You can run a JobManager (master).
-
-```console
-$ docker run --name flink_jobmanager -d -t %%IMAGE%% jobmanager
-```
-
-You can also run a TaskManager (worker). Notice that workers need to register with the JobManager directly or via ZooKeeper so the master starts to send them tasks to execute.
-
-```console
-$ docker run --name flink_taskmanager -d -t %%IMAGE%% taskmanager
-```
-
-## Running a cluster using Docker Compose
-
-With Docker Compose you can create a Flink cluster:
-
-```yml
-version: "2.1"
-services:
-  jobmanager:
-    image: ${FLINK_DOCKER_IMAGE_NAME:-flink}
-    expose:
-      - "6123"
-    ports:
-      - "8081:8081"
-    command: jobmanager
-    environment:
-      - JOB_MANAGER_RPC_ADDRESS=jobmanager
-
-  taskmanager:
-    image: ${FLINK_DOCKER_IMAGE_NAME:-flink}
-    expose:
-      - "6121"
-      - "6122"
-    depends_on:
-      - jobmanager
-    command: taskmanager
-    links:
-      - "jobmanager:jobmanager"
-    environment:
-      - JOB_MANAGER_RPC_ADDRESS=jobmanager
-```
-
-and just run `docker-compose up`.
-
-Scale the cluster up or down to *N* TaskManagers:
-
-```console
-docker-compose scale taskmanager=<N>
-```
-
-## Configuration
-
-These are the default ports used by the Flink image:
-
--	The Web Client is on port `8081`
--	JobManager RPC port `6123`
--	TaskManagers RPC port `6122`
--	TaskManagers Data port `6121`
-
-# About this repository
-
-This repository is available on [github.com/docker-flink/docker-flink](https://github.com/docker-flink/docker-flink), and the official build is on the [Docker Hub](https://hub.docker.com/_/flink/).
-
-This repository is maintained by members of the Apache Flink community.
+Please refer to the official [Apache Flink documentation](https://ci.apache.org/projects/flink/flink-docs-master/) about [how to use Apache Flink with Docker](https://ci.apache.org/projects/flink/flink-docs-master/ops/deployment/docker.html).

--- a/flink/get-help.md
+++ b/flink/get-help.md
@@ -1,1 +1,1 @@
-[Community & Project Info](https://flink.apache.org/community.html)
+[Official Apache Flink Mailing lists](https://flink.apache.org/community.html#mailing-lists) and [StackOverflow (tag `apache-flink`)](https://stackoverflow.com/questions/tagged/apache-flink)

--- a/flink/github-repo
+++ b/flink/github-repo
@@ -1,1 +1,1 @@
-https://github.com/docker-flink/docker-flink
+https://github.com/apache/flink-docker

--- a/flink/issues.md
+++ b/flink/issues.md
@@ -1,0 +1,1 @@
+https://issues.apache.org/jira/browse/FLINK

--- a/flink/license.md
+++ b/flink/license.md
@@ -2,4 +2,4 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 
 	      https://www.apache.org/licenses/LICENSE-2.0
 
-Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of The Apache Software Foundation.
+Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of [The Apache Software Foundation](https://apache.org/).

--- a/flink/maintainer.md
+++ b/flink/maintainer.md
@@ -1,1 +1,1 @@
-[members of the Apache Flink community](%%GITHUB-REPO%%)
+[Apache Flink](https://flink.apache.org/community.html#people)


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/FLINK-17811

The Hub page of Flink was pretty outdated. This change simplifies the page by mostly linking to the (extensive) documentation on how to use Flink with Docker (which the community is actively maintaining).