### PR TITLE
Remove mention of APACHE_RUN_USER/APACHE_RUN_GROUP which are not a general solution

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -133,11 +133,10 @@ RUN curl -fsSL 'https://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.
 
 ## Running as an arbitrary user
 
-For running the Apache variants as an arbitrary user, there are several choices:
+For running the Apache variants as an arbitrary user, there are a couple choices:
 
--	If your kernel [is version 4.11 or newer](https://github.com/moby/moby/issues/8460#issuecomment-312459310), you can add `--sysctl net.ipv4.ip_unprivileged_port_start=0` and then `--user` should work as it does for FPM.
+-	If your kernel [is version 4.11 or newer](https://github.com/moby/moby/issues/8460#issuecomment-312459310), you can add `--sysctl net.ipv4.ip_unprivileged_port_start=0` (which [will be the default in a future version of Docker](https://github.com/moby/moby/pull/41030)) and then `--user` should work as it does for FPM.
 -	If you adjust the Apache configuration to use an "unprivileged" port (greater than 1024 by default), then `--user` should work as it does for FPM regardless of kernel version.
--	Otherwise, setting `APACHE_RUN_USER` and/or `APACHE_RUN_GROUP` should have the desired effect (for example, `-e APACHE_RUN_USER=daemon` or `-e APACHE_RUN_USER=#1000` -- see [the Apache `User` directive documentation for details on the expected syntax](https://httpd.apache.org/docs/2.4/mod/mod_unixd.html#user)).
 
 For running the FPM variants as an arbitrary user, the `--user` flag to `docker run` should be used (which can accept both a username/group in the container's `/etc/passwd` file like `--user daemon` or a specific UID/GID like `--user 1000:1000`).
 


### PR DESCRIPTION
Closes https://github.com/docker-library/php/issues/1053

It turns out that these have *never* worked for running as an arbitrary user, and the failure mode is that Apache just happily runs as root instead...  So we should ditch reference to them (instead of noting their caveats) because `--user` is a generally safer and more reliable solution (especially when combined with `--security-opt no-new-privileges`).