### PR TITLE
Add note about stack immediately after the example code

### DIFF
--- a/haskell/README.md
+++ b/haskell/README.md
@@ -86,6 +86,8 @@ RUN stack install pandoc pandoc-citeproc
 ENTRYPOINT ["pandoc"]
 ```
 
+**NOTE**: You might get a "Compiler version mismatched" error in some cases. See [Considerations for Stack](#considerations-for-stack) for details.
+
 Dockerize an application using `cabal`:
 
 ```dockerfile


### PR DESCRIPTION
A Haskell newbie loving Docker got confused by the error.
I think we should guide him/her to the section about the error near from the example code of stack.