### PR TITLE
Add note about stack immediately after the example code

### DIFF
--- a/haskell/content.md
+++ b/haskell/content.md
@@ -36,6 +36,8 @@ RUN stack install pandoc pandoc-citeproc
 ENTRYPOINT ["pandoc"]
 ```
 
+**NOTE**: You might get a "Compiler version mismatched" error in some cases. See [Considerations for Stack](#considerations-for-stack) for details.
+
 Dockerize an application using `cabal`:
 
 ```dockerfile

--- a/haskell/content.md
+++ b/haskell/content.md
@@ -36,7 +36,7 @@ RUN stack install pandoc pandoc-citeproc
 ENTRYPOINT ["pandoc"]
 ```
 
-**NOTE**: You might get a "Compiler version mismatched" error in some cases. See [Considerations for Stack](#considerations-for-stack) for details.
+**NOTE**: You might get a "Compiler version mismatched" error in some cases. See the "Considerations for Stack" section below for details.
 
 Dockerize an application using `cabal`:
 


### PR DESCRIPTION
A Haskell newbie loving Docker got confused by the error.
I think we should guide him/her to the section about the error near from the example code of stack.

(Retry of https://github.com/docker-library/docs/pull/1793)