### PR TITLE
Add "Docker Hub" callout to Registry image Quick Reference

### DIFF
--- a/registry/get-help.md
+++ b/registry/get-help.md
@@ -1,0 +1,3 @@
+[the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)
+
+-	**Need a free, secure hosted registry?** Try [Docker Hub](https://www.docker.com/pricing).


### PR DESCRIPTION
Per conversation with @j0hnst0n :+1:

Example rendering:

# Quick reference

-	**Maintained by**:  
	[Docker, Inc.](https://github.com/docker/distribution-library-image)

-	**Where to get help**:  
	[the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)

-	**Need a free, secure hosted registry?** Try [Docker Hub](https://www.docker.com/pricing).

# Supported tags and respective `Dockerfile` links

...