### PR TITLE
Modify xargs and cp command to remove error -> cp: missing file operand

### DIFF
--- a/ros/content.md
+++ b/ros/content.md
@@ -66,9 +66,9 @@ RUN vcs import ./ < ../overlay.repos
 WORKDIR /opt
 RUN mkdir -p /tmp/opt && \
     find ./ -name "package.xml" | \
-      xargs cp --parents -t /tmp/opt && \
+      xargs -I '{}' cp '{}' --parents -t /tmp/opt && \
     find ./ -name "COLCON_IGNORE" | \
-      xargs cp --parents -t /tmp/opt || true
+      xargs -I '{}' cp '{}' --parents -t /tmp/opt || true
 
 # multi-stage for building
 FROM $FROM_IMAGE AS builder


### PR DESCRIPTION
When find returns nothing it caused an error in the cp command saying it is missing file operand. I modified the Dockerfile example to remove that error.