### PR TITLE
caddy: Updating docs for builder image changes

### DIFF
--- a/caddy/get-help.md
+++ b/caddy/get-help.md
@@ -1,0 +1,1 @@
+[the Caddy Community Forums](https://caddy.community)


### PR DESCRIPTION
Changes relevant to https://github.com/docker-library/official-images/pull/8735

Many thanks to @francislavoie for writing this 😉

Signed-off-by: Dave Henderson <dhenderson@gmail.com>