### PR TITLE
Add missing environment variable for Redis host password

### DIFF
--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -144,6 +144,7 @@ If you want to use Redis you have to create a separate [Redis](https://hub.docke
 
 -	`REDIS_HOST` (not set by default) Name of Redis container
 -	`REDIS_HOST_PORT` (default: *6379*) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
+-	`REDIS_HOST_PASSWORD` (not set by default) Password for Redis which itself does not work unless one is specified.
 
 The use of Redis is recommended to prevent file locking problems. See the examples for further instructions.
 


### PR DESCRIPTION
REDIS_HOST_PASSWORD was added in https://github.com/nextcloud/docker/pull/856 and is missing from the Docker Hub readme.