### PR TITLE
Added POSTGRES_PASSWORD to fix example code

### DIFF
--- a/kong/content.md
+++ b/kong/content.md
@@ -33,6 +33,7 @@ $ docker run -d --name kong-database \
                 -p 5432:5432 \
                 -e "POSTGRES_USER=kong" \
                 -e "POSTGRES_DB=kong" \
+                -e "POSTGRES_PASSWORD=kong" \
                 postgres:9.6
 ```
 
@@ -45,6 +46,8 @@ $ docker run --rm \
     --link kong-database:kong-database \
     -e "KONG_DATABASE=postgres" \
     -e "KONG_PG_HOST=kong-database" \
+    -e "KONG_PG_USER=kong" \
+    -e "KONG_PG_PASSWORD=kong" \
     -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
     %%IMAGE%% kong migrations bootstrap
 ```
@@ -62,6 +65,7 @@ $ docker run -d --name kong \
     --link kong-database:kong-database \
     -e "KONG_DATABASE=postgres" \
     -e "KONG_PG_HOST=kong-database" \
+    -e "KONG_PG_PASSWORD=kong" \
     -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
     -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
     -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \


### PR DESCRIPTION
The existing example code for the postgres container implementation of Kong is broken and it does not work. 

running the following code ( From [here](https://registry.hub.docker.com/_/kong/) ) results in an error.
 ``` shell 
docker run --rm \
    --link kong-database:kong-database \
    -e "KONG_DATABASE=postgres" \
    -e "KONG_PG_HOST=kong-database" \
    -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
    kong kong migrations bootstrap

```

An error stating that 'There is no Postgres Password'  occurs when this command is run. 

Figured out that adding environmental variables POSTGRES_PASSWORD and KONG_PG_PASSWORD to the command arguments fixes the issue.

You can verify whether Kong is working as expected by running `curl http://localhost:8001` after running the 3 commands that were changed in this pull request.

This issue needs to be fixed at the earliest as many first time users of Kong might get turned away because of them not being able to get an environment up and running without hitting roadblocks.

If you have further suggestions / recommendations, I am happy to work with you.