### PR TITLE
Remove contradictory sentence in Environment Vars

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -128,7 +128,7 @@ There are many ways to extend the `postgres` image. Without trying to support ev
 
 ## Environment Variables
 
-The PostgreSQL image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+The PostgreSQL image uses several environment variables which are easy to miss. The only variable required is `POSTGRES_PASSWORD`, the rest are optional.
 
 **Warning**: the Docker specific variables will only have an effect if you start the container with a data directory that is empty; any pre-existing database will be left untouched on container startup.
 


### PR DESCRIPTION
The sentence stated that no environment variables are required to use this image. However, the very first variable - `POSTGRES_PASSWORD` is stated as required. This is a direct contradiction. This change removes that contradiction and clarifies that the password is required.