### PR TITLE
caddy: Declare volumes in docker-compose example

### DIFF
--- a/caddy/content.md
+++ b/caddy/content.md
@@ -128,4 +128,8 @@ services:
       - $PWD/site:/srv
       - caddy_data:/data
       - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:
 ```


### PR DESCRIPTION
As noted by a user on our community forums, the docker-compose example was missing the volume declarations, leading to errors if copied verbatim. https://caddy.community/t/trouble-running-caddy-in-docker-id-love-some-help/10067/2