### PR TITLE
Set explicit value for INFLUXDB_HTTP_AUTH_ENABLED

### DIFF
--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -197,7 +197,7 @@ Automatically initializes a database with the name of this environment variable.
 
 ##### INFLUXDB_HTTP_AUTH_ENABLED
 
-Enables authentication. Either this must be set or `auth-enabled = true` must be set within the configuration file for any authentication related options below to work.
+Enables authentication. Either this must be set to `true` or `auth-enabled = true` must be set within the configuration file for any authentication related options below to work.
 
 ##### INFLUXDB_ADMIN_USER
 


### PR DESCRIPTION
Setting the `INFLUXDB_HTTP_AUTH_ENABLED` variable to something other than `true` (eg. `INFLUXDB_HTTP_AUTH_ENABLED=1`) can result in errors in the init script. More details here : https://github.com/influxdata/influxdata-docker/issues/224