### PR TITLE
Update Rakudo Star

### DIFF
--- a/rakudo-star/content.md
+++ b/rakudo-star/content.md
@@ -2,13 +2,11 @@
 
 Rakudo Star is a Raku (formerly known as Perl 6) distribution designed for use by early adopters of the language. It includes a virtual machine (the JVM or MoarVM), the Rakudo compiler, and a suite of modules that users may find useful. This image includes the MoarVM backend for the compiler.
 
-Project homepage: [http://rakudo.org](http://rakudo.org)
+-	Project homepage: https://rakudo.org/
+-	Raku Language Specification: https://github.com/Raku/roast
+-	Raku Language Documentation: https://docs.raku.org/
 
-GitHub repository: [https://github.com/rakudo/star](https://github.com/rakudo/star)
-
-The Dockerfile responsible: [http://github.com/raku/docker/tree/master/Dockerfile](http://github.com/raku/docker/tree/master/Dockerfile)
-
-Raku Language Documentation: [http://docs.raku.org/](http://docs.raku.org/)
+> [wikipedia.org/wiki/Rakudo](https://en.wikipedia.org/wiki/Rakudo)
 
 %%LOGO%%
 
@@ -32,4 +30,4 @@ $ docker run -it %%IMAGE%% raku -e 'say "Hello!"'
 
 Many Raku developers are present on #raku on Freenode.
 
-Issues for Rakudo are tracked in [on GitHub](https://github.com/rakudo/rakudo/issues/).
+Issues for Rakudo are tracked in [on GitHub](https://github.com/rakudo/rakudo/issues).

--- a/rakudo-star/github-repo
+++ b/rakudo-star/github-repo
@@ -1,1 +1,1 @@
-https://github.com/perl6/docker
+https://github.com/Raku/docker

--- a/rakudo-star/maintainer.md
+++ b/rakudo-star/maintainer.md
@@ -1,1 +1,1 @@
-[the Perl 6 Community](%%GITHUB-REPO%%)
+[the Raku Community](%%GITHUB-REPO%%)


### PR DESCRIPTION
- Fix missing rename to Raku
- Change the scheme of external links to `https`
- Add a link to the [Language Specification](https://github.com/Raku/roast)
- Add a link to a [Wikipedia article](https://en.wikipedia.org/wiki/Rakudo)
- Use [GFM's extended Autolinks](https://github.github.com/gfm/#autolinks-extension-)