### PR TITLE
Updating Liberty docs

### DIFF
--- a/open-liberty/README-short.txt
+++ b/open-liberty/README-short.txt
@@ -1,1 +1,1 @@
-Official Open Liberty image.
+Open Liberty multi-architecture images based on Ubuntu 18.04

--- a/open-liberty/content.md
+++ b/open-liberty/content.md
@@ -1,8 +1,6 @@
 # Overview
 
-The images in this repository contain Open Liberty. For more information about Open Liberty, see the [Open Liberty Website](https://openliberty.io/) site.
-
-This repository contains OpenLiberty based on top of OpenJDK 8 Eclipse OpenJ9 with Ubuntu images only. See [here](https://hub.docker.com/r/openliberty/open-liberty) for Open Liberty based on Red Hat's Universal Base Image, which includes additional java options.
+All of the images in this repository use Ubuntu as the Operating System. For variants that use the Universal Base Image, please see [this repository](https://hub.docker.com/r/openliberty/open-liberty/).
 
 # Image User
 

--- a/open-liberty/content.md
+++ b/open-liberty/content.md
@@ -2,6 +2,8 @@
 
 All of the images in this repository use Ubuntu as the Operating System. For variants that use the Universal Base Image, please see [this repository](https://hub.docker.com/r/openliberty/open-liberty/).
 
+For more information on these images please see our [GitHub repository](https://github.com/OpenLiberty/ci.docker#container-images).
+
 # Image User
 
 This image runs by default with `USER 1001` (non-root), as part of group `0`. Please make sure you read below to set the appropriate folder and file permissions.

--- a/websphere-liberty/README-short.txt
+++ b/websphere-liberty/README-short.txt
@@ -1,1 +1,1 @@
-Official IBM WebSphere Application Server for Developers Liberty image.
+WebSphere Liberty multi-architecture images based on Ubuntu 18.04

--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -2,6 +2,8 @@
 
 All of the images in this repository use Ubuntu as the Operating System. For variants that use the Universal Base Image, please see [this repository](https://hub.docker.com/r/ibmcom/websphere-liberty/).
 
+For more information on these images please see our [GitHub repository](https://github.com/WASdev/ci.docker#container-images).
+
 # Image User
 
 This image runs by default with `USER 1001` (non-root), as part of group `0`. Please make sure you read below to set the appropriate folder and file permissions.

--- a/websphere-liberty/content.md
+++ b/websphere-liberty/content.md
@@ -1,8 +1,6 @@
 # Overview
 
-The images in this repository contain WebSphere Liberty application server and the IBM Java Runtime Environment. For more information please see our [official repository](https://github.com/WASdev/ci.docker).
-
-This repository contains WebSphere Liberty based on top of IBM Java 8 with Ubuntu images only. See [here](https://hub.docker.com/r/ibmcom/websphere-liberty/) for WebSphere Liberty based on Red Hat's Universal Base Image, which includes additional java options.
+All of the images in this repository use Ubuntu as the Operating System. For variants that use the Universal Base Image, please see [this repository](https://hub.docker.com/r/ibmcom/websphere-liberty/).
 
 # Image User
 


### PR DESCRIPTION
Updating documentation for WebSphere Liberty and Open Liberty to cross link the non-official repos.  Addresses https://github.com/OpenLiberty/ci.docker/issues/216