### PR TITLE
Environment variables in docker-compose section

### DIFF
--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -216,9 +216,14 @@ services:
       - 8080:80
     links:
       - db
+    restart: always
     volumes:
       - nextcloud:/var/www/html
-    restart: always
+    environment:
+      - MYSQL_PASSWORD=
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_HOST=db
 ```
 
 Then run `docker-compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.


### PR DESCRIPTION
Docker-compose file in the example was missing database configuration environment variables of the app container, making the stack to use SQLite by default instead of the DB container.