### PR TITLE
optimization in git clone using --depth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ ENV LANG C.UTF-8
 
 RUN mkdir ~/.vim ~/.vim/bundle ~/.vim/autoload
 RUN set -x \
-	&& git clone https://github.com/tpope/vim-pathogen.git ~/.vim/bundle/pathogen \
+	&& git clone --depth 1 https://github.com/tpope/vim-pathogen.git ~/.vim/bundle/pathogen \
 	&& ln -s ../bundle/pathogen/autoload/pathogen.vim ~/.vim/autoload/
-RUN git clone https://github.com/jtratner/vim-flavored-markdown.git ~/.vim/bundle/ghmarkdown
-RUN git clone https://github.com/nanotech/jellybeans.vim.git ~/.vim/bundle/jellybeans
+RUN git clone --depth 1 https://github.com/jtratner/vim-flavored-markdown.git ~/.vim/bundle/ghmarkdown
+RUN git clone --depth 1 https://github.com/nanotech/jellybeans.vim.git ~/.vim/bundle/jellybeans
 RUN { \
 		echo 'scriptencoding utf-8'; \
 		\


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>