### PR TITLE
Add note about read only possibility

### DIFF
--- a/haproxy/content.md
+++ b/haproxy/content.md
@@ -41,6 +41,8 @@ $ docker run -d --name my-running-haproxy my-haproxy
 
 You may need to publish the ports your HAProxy is listening on to the host by specifying the -p option, for example -p 8080:80 to publish port 8080 from the container host to port 80 in the container. Make sure the port you're using is free.
 
+Note: for added security, it is possible to run the container in read-only mode, as HAProxy doesn't need to write to the filesystem. You can pass the `--read-only` flag to the `docker run` command or add `read_only: true` to your `docker-compose` configuration file.
+
 ## Directly via bind mount
 
 ```console


### PR DESCRIPTION
Running containers as read only filesystems is considered best practices. Add a note to mention this possibility with this image.