### PR TITLE
Improve documentation example

### DIFF
--- a/mariadb/content.md
+++ b/mariadb/content.md
@@ -15,10 +15,12 @@ The intent is also to maintain high compatibility with MySQL, ensuring a "drop-i
 Starting a MariaDB instance is simple:
 
 ```console
-$ docker run --name some-%%REPO%% -e MYSQL_ROOT_PASSWORD=my-secret-pw -d %%IMAGE%%:tag
+# Create the network
+$ docker network create some-network
+$ docker run --net some-network --name some-%%REPO%% -e MYSQL_ROOT_PASSWORD=my-secret-pw -d %%IMAGE%%:tag
 ```
 
-... where `some-%%REPO%%` is the name you want to assign to your container, `my-secret-pw` is the password to be set for the MySQL root user and `tag` is the tag specifying the MySQL version you want. See the list above for relevant tags.
+...  where `some-network` is newly created network (other than `bridge` as the default network), where `some-%%REPO%%` is the name you want to assign to your container, `my-secret-pw` is the password to be set for the MySQL root user and `tag` is the tag specifying the MySQL version you want. See the list above for relevant tags.
 
 ## Connect to MariaDB from the MySQL command line client
 


### PR DESCRIPTION
- Documentation said that mysql client used in second container could
use `some-network`. Problema with this (for the new users at least) is
how to create the new network and that `some-network` excludes `bridge`
network. Here is an example:
```
$ docker network create mariadb-net
$ docker network ls
NETWORK ID     NAME          DRIVER    SCOPE
6619c329efd7   bridge        bridge    local
c40fe8f5347a   host          host      local
ddff491eb0b3   mariadb-net   bridge    local
03bba7bb6438   none          null      local

$ docker run --network bridge --name mariadb-c1 -e MYSQL_ROOT_PASSWORD=root -d mariadb:10.5
9c64c725816e9950e92dfd2a0a65eb37e8c801e452ae2e5c3eb78c6907ef4d9d
$ docker run -it --network bridge --rm mariadb:10.5 mysql -hmariadb-c1 -uroot -proot
ERROR 2005 (HY000): Unknown MySQL server host 'mariadb-c1' (-2)

$ docker stop mariadb-c1 && docker rm mariadb-c1

$ docker run --network mariadb-net --name mariadb-c1 -e MYSQL_ROOT_PASSWORD=root -d mariadb:10.5

$ docker run -it --net mariadb-net --rm mariadb:10.5 mysql -hmariadb-c1 -uroot -proot
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 3
Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]>
```
- Also in documentation when second/client container is created reference to
  `some-network` is not explained and this patch solves that.