### PR TITLE
Start Ghost in development mode

### DIFF
--- a/ghost/README.md
+++ b/ghost/README.md
@@ -147,6 +147,8 @@ services:
       database__connection__user: root
       database__connection__password: example
       database__connection__database: ghost
+      # if you want to start ghost in development mode uncomment next line
+      # NODE_ENV: development
       # this url value is just an example, and is likely wrong for your environment!
       url: http://localhost:8080
 


### PR DESCRIPTION
A pair off lines on the stack.yml to give some info on how to start Ghost in development mode if the image is to be used for development purposes, like theme edition.