### PR TITLE
mediawiki: Update maintainer description

### DIFF
--- a/mediawiki/maintainer.md
+++ b/mediawiki/maintainer.md
@@ -1,1 +1,1 @@
-[Wikimedia Foundation & Docker Community](%%GITHUB-REPO%%)
+[MediaWiki community & Docker Community](%%GITHUB-REPO%%)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T266186 raise some questions on who is
actually maintaining this image. I think it makes more sense to describe this
as something done by MediaWiki community members rather than as by
the Wikimedia Foundation.

cc @davidbarratt and @addshore