### PR TITLE
Adjust wording since Wordpress_db is no longer auto created

### DIFF
--- a/wordpress/content.md
+++ b/wordpress/content.md
@@ -23,7 +23,7 @@ The following environment variables are also honored for configuring your WordPr
 -	`-e WORDPRESS_DEBUG=1` (defaults to disabled, non-empty value will enable `WP_DEBUG` in `wp-config.php`)
 -	`-e WORDPRESS_CONFIG_EXTRA=...` (defaults to nothing, non-empty value will be embedded verbatim inside `wp-config.php` -- especially useful for applying extra configuration values this image does not provide by default such as `WP_ALLOW_MULTISITE`; see [docker-library/wordpress#142](https://github.com/docker-library/wordpress/pull/142) for more details)
 
-If the `WORDPRESS_DB_NAME` specified does not already exist on the given MySQL server, it will be created automatically upon startup of the `%%REPO%%` container, provided that the `WORDPRESS_DB_USER` specified has the necessary permissions to create it.
+The `WORDPRESS_DB_NAME` needs to already exist on the given MySQL server; it will not be created by the `%%REPO%%` container.
 
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 


### PR DESCRIPTION
Fixes documentation for changes in https://github.com/docker-library/wordpress/pull/572

Closes https://github.com/docker-library/wordpress/pull/575