### PR TITLE
Update MariaDB docs run command

### DIFF
--- a/mariadb/content.md
+++ b/mariadb/content.md
@@ -13,7 +13,7 @@ The intent is also to maintain high compatibility with MySQL, ensuring a library
 Starting a MariaDB instance is simple:
 
 ```console
-$ docker run --port 127.0.0.1:3306:3306  --name some-%%REPO%% -e MYSQL_ROOT_PASSWORD=my-secret-pw -d %%IMAGE%%:tag
+$ docker run -p 127.0.0.1:3306:3306  --name some-%%REPO%% -e MYSQL_ROOT_PASSWORD=my-secret-pw -d %%IMAGE%%:tag
 ```
 
 or:


### PR DESCRIPTION
The current docs for the MariaDB image incorrectly use the `--port` long form flag which is no longer supported:

![image](https://user-images.githubusercontent.com/226109/111880099-caba7000-897f-11eb-8828-d843ba78a1e3.png)
