### PR TITLE
[SonarQube] added licence information

### DIFF
--- a/sonarqube/license.md
+++ b/sonarqube/license.md
@@ -1,1 +1,1 @@
-View [license information](http://www.gnu.org/licenses/lgpl.txt) for the software contained in this image.
+SonarQube Community Edition is licensed under [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt). SonarQube Developer, Enterprise, and Data Center Editions are licensed under [SonarSource Terms and Conditions](https://www.sonarsource.com/docs/sonarsource_terms_and_conditions.pdf).


### PR DESCRIPTION
The License information for the sonarqube docker image were a little bit misleading as only the community edition is under LGPL. 