### PR TITLE
Updated ReadME for clearer deploy instructions

### DIFF
--- a/ghost/README.md
+++ b/ghost/README.md
@@ -74,7 +74,7 @@ If you'd like to be able to access the instance from the host without the contai
 $ docker run -d --name some-ghost -e url=http://localhost:3001 -p 3001:2368 ghost
 ```
 
-If all goes well, you'll be able to access your new site on `http://localhost:3001` and `http://localhost:3001/ghost` to access Ghost Admin (or `http://host-ip:3001` and `http://host-ip:3001/ghost`, respectively).
+If all goes well, you'll be able to access your new site on `http://localhost:3001` and `http://localhost:3001/ghost` to access Ghost Admin (or `http://host-ip:3001` and `http://host-ip:3001/ghost`, respectively). If accessing from outside the host, set the environment variable to `-e url=http://host-ip` without the port.
 
 ### Upgrading Ghost
 


### PR DESCRIPTION
If on a remote machine, setting the -e flag to `(http://host-ip)` rather than `http://host-ip:port` is necessary as the port is already specified using the -p flag. Makes deploy instructions clearer.