### PR TITLE
Fix broken link to Telegraf docs

### DIFF
--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -54,7 +54,7 @@ WARNING:
 
 Telegraf is an open source agent written in Go for collecting metrics and data on the system it's running on or from other services. Telegraf writes data it collects to InfluxDB in the correct format.
 
-[Telegraf Official Docs](https://docs.influxdata.com/telegraf/latest/introduction/getting_started/)
+[Telegraf Official Docs](https://docs.influxdata.com/telegraf/latest/introduction/getting-started/)
 
 ![logo](https://raw.githubusercontent.com/docker-library/docs/43d87118415bb75d7bb107683e79cd6d69186f67/telegraf/logo.png)
 


### PR DESCRIPTION
Fix broken link to Telegraf docs. Closes https://github.com/influxdata/docs-v2/issues/2431