### PR TITLE
adding the "run" command to example

### DIFF
--- a/varnish/README.md
+++ b/varnish/README.md
@@ -16,41 +16,41 @@ WARNING:
 
 # Quick reference
 
--	**Maintained by**:  
-	[the Varnish Docker Community](https://github.com/varnish/docker-varnish)
+- **Maintained by**:  
+  [the Varnish Docker Community](https://github.com/varnish/docker-varnish)
 
--	**Where to get help**:  
-	[the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)
+- **Where to get help**:  
+  [the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)
 
 # Supported tags and respective `Dockerfile` links
 
--	[`6.0`, `6.0.7-1`, `6.0.7`, `stable`](https://github.com/varnish/docker-varnish/blob/51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa/stable/debian/Dockerfile)
--	[`6.6`, `6.6.0-1`, `6.6.0`, `6`, `latest`, `fresh`](https://github.com/varnish/docker-varnish/blob/51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa/fresh/debian/Dockerfile)
+- [`6.0`, `6.0.7-1`, `6.0.7`, `stable`](https://github.com/varnish/docker-varnish/blob/51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa/stable/debian/Dockerfile)
+- [`6.6`, `6.6.0-1`, `6.6.0`, `6`, `latest`, `fresh`](https://github.com/varnish/docker-varnish/blob/51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa/fresh/debian/Dockerfile)
 
 # Quick reference (cont.)
 
--	**Where to file issues**:  
-	[https://github.com/varnish/docker-varnish/issues](https://github.com/varnish/docker-varnish/issues)
+- **Where to file issues**:  
+  [https://github.com/varnish/docker-varnish/issues](https://github.com/varnish/docker-varnish/issues)
 
--	**Supported architectures**: ([more info](https://github.com/docker-library/official-images#architectures-other-than-amd64))  
-	[`amd64`](https://hub.docker.com/r/amd64/varnish/)
+- **Supported architectures**: ([more info](https://github.com/docker-library/official-images#architectures-other-than-amd64))  
+  [`amd64`](https://hub.docker.com/r/amd64/varnish/)
 
--	**Published image artifact details**:  
-	[repo-info repo's `repos/varnish/` directory](https://github.com/docker-library/repo-info/blob/master/repos/varnish) ([history](https://github.com/docker-library/repo-info/commits/master/repos/varnish))  
-	(image metadata, transfer size, etc)
+- **Published image artifact details**:  
+  [repo-info repo's `repos/varnish/` directory](https://github.com/docker-library/repo-info/blob/master/repos/varnish) ([history](https://github.com/docker-library/repo-info/commits/master/repos/varnish))  
+  (image metadata, transfer size, etc)
 
--	**Image updates**:  
-	[official-images repo's `library/varnish` label](https://github.com/docker-library/official-images/issues?q=label%3Alibrary%2Fvarnish)  
-	[official-images repo's `library/varnish` file](https://github.com/docker-library/official-images/blob/master/library/varnish) ([history](https://github.com/docker-library/official-images/commits/master/library/varnish))
+- **Image updates**:  
+  [official-images repo's `library/varnish` label](https://github.com/docker-library/official-images/issues?q=label%3Alibrary%2Fvarnish)  
+  [official-images repo's `library/varnish` file](https://github.com/docker-library/official-images/blob/master/library/varnish) ([history](https://github.com/docker-library/official-images/commits/master/library/varnish))
 
--	**Source of this description**:  
-	[docs repo's `varnish/` directory](https://github.com/docker-library/docs/tree/master/varnish) ([history](https://github.com/docker-library/docs/commits/master/varnish))
+- **Source of this description**:  
+  [docs repo's `varnish/` directory](https://github.com/docker-library/docs/tree/master/varnish) ([history](https://github.com/docker-library/docs/commits/master/varnish))
 
 # What is Varnish?
 
 Varnish is an HTTP accelerator designed for content-heavy dynamic web sites as well as APIs. In contrast to other web accelerators, such as Squid, which began life as a client-side cache, or Apache and nginx, which are primarily origin servers, Varnish was designed as an HTTP accelerator. Varnish is focused exclusively on HTTP, unlike other proxy servers that often support FTP, SMTP and other network protocols.
 
-> [wikipedia.org/wiki/Varnish_(software)](https://en.wikipedia.org/wiki/Varnish_(software))
+> [wikipedia.org/wiki/Varnish\_(software)](<https://en.wikipedia.org/wiki/Varnish_(software)>)
 
 ![logo](https://raw.githubusercontent.com/docker-library/docs/5ca8e315af01e76381d499a2928f7f47a6787f49/varnish/logo.png)
 
@@ -87,7 +87,7 @@ COPY default.vcl /etc/varnish/
 Place this file in the same directory as your `default.vcl`, run `docker build -t my-varnish .`, then start your container:
 
 ```console
-$ docker --tmpfs /var/lib/varnish:exec my-varnish
+$ docker run --tmpfs /var/lib/varnish:exec my-varnish
 ```
 
 ### Additional configuration


### PR DESCRIPTION

just adding the "run" command to the example that explains build and execution. It was noticed the lack of the docker run ...