### PR TITLE
Added -p 80:80 in Apache example

### DIFF
--- a/php/variant-apache.md
+++ b/php/variant-apache.md
@@ -13,7 +13,7 @@ Where `src/` is the directory containing all your PHP code. Then, run the comman
 
 ```console
 $ docker build -t my-php-app .
-$ docker run -d --name my-running-app my-php-app
+$ docker run -d -p 80:80 --name my-running-app my-php-app
 ```
 
 We recommend that you add a `php.ini` configuration file; see the "Configuration" section for details.


### PR DESCRIPTION
It is already there in the "Apache without a Dockerfile" section,
added it in the "Apache with Dockerfile" too.
It won't work without the "-p 80:80"