### PR TITLE
Remove extraneous license-common.md text

### DIFF
--- a/couchbase/license.md
+++ b/couchbase/license.md
@@ -7,9 +7,3 @@ Couchbase Server comes in 2 Editions: Enterprise Edition and Community Edition. 
 By default, the `latest` Docker tag points to the latest Enterprise Edition. If you want the Community Edition instead, you should add the appropriate tag, such as
 
 `docker run -d --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase:community-6.6.0`
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-Some additional license information which was able to be auto-detected might be found in [the repo-info repository's couchbase/ directory](https://github.com/docker-library/repo-info/tree/master/repos/couchbase).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.


### PR DESCRIPTION
Whoops, didn't realise this text was coming from a common template. It's currently [doubled up](https://github.com/docker-library/docs/commit/8677375b458b3c11dc73f995489f4a327b65dbe7#diff-4f6ab524664e06540c0000665ba72488957c67cee2b878f461335ceb59d47d1cR231-R237) as a result.