### PR TITLE
Fix Elixir image official repo URL

### DIFF
--- a/elixir/github-repo
+++ b/elixir/github-repo
@@ -1,1 +1,1 @@
-https://github.com/c0b/docker-elixir
+https://github.com/erlef/docker-elixir

--- a/elixir/maintainer.md
+++ b/elixir/maintainer.md
@@ -1,1 +1,1 @@
-[the Docker Community](%%GITHUB-REPO%%), [with Elixir's support](https://github.com/docker-library/official-images/pull/1398#issuecomment-180484549)
+[the Erlang Ecosystem Foundation](%%GITHUB-REPO%%)


### PR DESCRIPTION
Elixir images had been building from a new Github repo [since October 2020](https://github.com/docker-library/official-images/pull/8979), but URL in the description is still wrong. Let's fix that issue.