### PR TITLE
Enabling IBM JDK11 Docker Images

### DIFF
--- a/ibmjava/content.md
+++ b/ibmjava/content.md
@@ -25,7 +25,7 @@ Consider using [Alpine Linux](http://alpinelinux.org/) if you are concerned abou
 | Ubuntu | Alpine | Ubuntu | Alpine |
 | 305 MB | 184 MB | 220 MB | 101 MB |
 
-**Note: Alpine Linux is not an officially supported operating system for IBM® SDK, Java™ Technology Edition. **
+**Note: Alpine Linux is not an officially supported operating system for IBM® SDK, Java™ Technology Edition.**
 
 ##### Multi-Arch Image
 

--- a/ibmjava/content.md
+++ b/ibmjava/content.md
@@ -1,6 +1,6 @@
 ### Overview
 
-The images in this repository contain IBM® SDK, Java™ Technology Edition. For more information on the latest version and what's new, see [sdk8 on IBM developerWorks](https://developer.ibm.com/javasdk/downloads/sdk8/). See the license section for restrictions that relate to the use of this image. For more information about IBM® SDK, Java™ Technology Edition and API documentation as well as tutorials, recipes, and Java usage in IBM Cloud, see [IBM developerWorks](https://developer.ibm.com/javasdk/).
+The images in this repository contain IBM® SDK, Java™ Technology Edition. For more information on the latest version and what's new, see [sdk8 on IBM developerWorks](https://developer.ibm.com/javasdk/downloads/sdk8/) and [jdk11 on IBM developerWorks](https://developer.ibm.com/javasdk/downloads/java-sdk-downloads-version-110/). See the license section for restrictions that relate to the use of this image. For more information about IBM® SDK, Java™ Technology Edition and API documentation as well as tutorials, recipes, and Java usage in IBM Cloud, see [IBM developerWorks](https://developer.ibm.com/javasdk/).
 
 Java and all Java-based trademarks and logos are trademarks or registered trademarks of Oracle and/or its affiliates.
 
@@ -25,7 +25,7 @@ Consider using [Alpine Linux](http://alpinelinux.org/) if you are concerned abou
 | Ubuntu | Alpine | Ubuntu | Alpine |
 | 305 MB | 184 MB | 220 MB | 101 MB |
 
-**Note: Alpine Linux is not an officially supported operating system for IBM® SDK, Java™ Technology Edition.**
+**Note: Alpine Linux is not an officially supported operating system for IBM® SDK, Java™ Technology Edition. **
 
 ##### Multi-Arch Image
 

--- a/ibmjava/license.md
+++ b/ibmjava/license.md
@@ -2,5 +2,5 @@ The Dockerfiles and associated scripts are licensed under the [Apache License 2.
 
 Licenses for the products installed within the images:
 
--	IBM® SDK, Java™ Technology Edition Version 8: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PMAA-A3Z8P2&title=IBM® SDK, Java™ Technology Edition Docker Image, Version 8.0&l=en).
--	IBM® SDK, Java™ Technology Edition Version 9 Early Access: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-JWOD-AFSFP8&title=IBM® SDK, Java™ Technology Edition Version 9.0 Early Access&l=en).
+-	IBM® SDK, Java™ Technology Edition Version 8: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-SMKR-AVSEUH&title=IBM%AE+SDK%2C+Java%99+Technology+Edition%2C+Version+8.0&l=en).
+-	IBM® SDK, Java™ Technology Edition Version 11: [International License Agreement for Non-Warranted Programs](http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-PARM-BMVULC&title=IBM%AE+SDK%2C+Java%99+Technology+Edition%2C+Version+11.0&l=en).


### PR DESCRIPTION
Documentation update to include JDK11 