### PR TITLE
Always persist caddy data directory/volume

### DIFF
--- a/caddy/README.md
+++ b/caddy/README.md
@@ -201,8 +201,11 @@ services:
 
 volumes:
   caddy_data:
+    external: true
   caddy_config:
 ```
+
+Defining the data volume as [`external`](https://docs.docker.com/compose/compose-file/compose-file-v3/#external) makes sure `docker-compose down` does not delete the volume. You may need to create it manually using `docker volume create [project-name]_caddy_data`.
 
 # Image Variants
 

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -201,11 +201,8 @@ services:
 
 volumes:
   caddy_data:
-    external: true
   caddy_config:
 ```
-
-Defining the data volume as [`external`](https://docs.docker.com/compose/compose-file/compose-file-v3/#external) makes sure `docker-compose down` does not delete the volume. You may need to create it manually using `docker volume create [project-name]_caddy_data`.
 
 # Image Variants
 

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -131,5 +131,8 @@ services:
 
 volumes:
   caddy_data:
+    external: true
   caddy_config:
 ```
+
+Defining the data volume as [`external`](https://docs.docker.com/compose/compose-file/compose-file-v3/#external) makes sure `docker-compose down` does not delete the volume. You may need to create it manually using `docker volume create [project-name]_caddy_data`.


### PR DESCRIPTION
This defines the volume as external in order to avoid the problem that `docker-compose down` removes the volume.
This makes sure the volume is not accidentally removed.

This is important, because of the reasons the Readme describes further above. That volume must not be treated as temporary.

See https://docs.docker.com/compose/compose-file/compose-file-v3/#external
Ref https://forums.docker.com/t/why-docker-compose-down-deletes-my-volume-how-to-define-volume-as-external/67433?u=rugk