### PR TITLE
Refresh SonarQube Docs

### DIFF
--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -1,12 +1,12 @@
 # What is SonarQube?
 
-[SonarQube](https://www.sonarqube.org/) is an open source product for continuous inspection of code quality.
+[SonarQube](https://www.sonarqube.org/) is the leading tool for continuously inspecting the Code Quality and Security of your codebases, and guiding development teams during Code Reviews. Covering 27 programming languages, while pairing-up with your existing software pipeline, SonarQube provides clear remediation guidance for developers to understand and fix issues, and for teams overall to deliver better and safer software. With over 225,000 deployments helping small development teams as well as global organizations, SonarQube provides the means for all teams and companies around the world to own and impact their Code Quality and Security.
 
 %%LOGO%%
 
 # How to use this image
 
-Here you'll find the Docker images for the Community Edition, Developer Edition, Enterprise Edition, and DataCenter Edition of SonarQube.
+Here you'll find the Docker images for the Community Edition, Developer Edition, Enterprise Edition, and Data Center Edition of SonarQube.
 
 ## Docker Host Requirements
 
@@ -15,15 +15,21 @@ Because SonarQube uses an embedded Elasticsearch, make sure that your Docker hos
 For example, on Linux, you can set the recommended values for the current session by running the following commands as root on the host:
 
 ```console
-sysctl -w vm.max_map_count=262144
-sysctl -w fs.file-max=65536
-ulimit -n 65536
-ulimit -u 4096
+sysctl -w vm.max_map_count=524288
+sysctl -w fs.file-max=131072
+ulimit -n 131072
+ulimit -u 8192
 ```
 
-## Get Started in Two Minutes Guide
+## Try Out SonarQube
 
-To quickly run a demo instance, see Using Docker on the [Get Started in Two Minutes Guide](https://docs.sonarqube.org/latest/setup/get-started-2-minutes/) page. When you are ready to move to a more sustainable setup, take some time to read the **Configuration** section below.
+To quickly run a demo instance, see Using Docker on the [Try Out SonarQube](https://docs.sonarqube.org/latest/setup/get-started-2-minutes/) page. When you are ready to move to a more sustainable setup, take some time to read the **Installation** and **Configuration** sections below.
+
+## Installation
+
+For installation instructions, see Installing the Server from the Docker Image on the [Install the Server](https://docs.sonarqube.org/latest/setup/install-server/) page.
+
+To run a cluster with the Data Center Edition, please refer to Installing SonarQube from the Docker Image on the [Install the Server as a Cluster](https://docs.sonarqube.org/latest/setup/install-cluster/) page.
 
 ## Configuration
 
@@ -31,7 +37,7 @@ To quickly run a demo instance, see Using Docker on the [Get Started in Two Minu
 
 By default, the image will use an embedded H2 database that is not suited for production.
 
-> **Warning:** Only a single instance of SonarQube can connect to a database schema. If you're using a Docker Swarm or Kubernetes, make sure that multiple SonarQube instances are never running on the same database schema simultaneously. This will cause SonarQube to behave unpredictably and data will be corrupted. There is no safeguard until [SONAR-10362](https://jira.sonarsource.com/browse/SONAR-10362). The Datacenter Edition has the same limitation in that only one cluster can connect to one database schema at the same time.
+> **Warning:** Only a single instance of SonarQube can connect to a database schema. If you're using a Docker Swarm or Kubernetes, make sure that multiple SonarQube instances are never running on the same database schema simultaneously. This will cause SonarQube to behave unpredictably and data will be corrupted. There is no safeguard until [SONAR-10362](https://jira.sonarsource.com/browse/SONAR-10362). The Data Center Edition has the same limitation in that only one cluster can connect to one database schema at the same time.
 
 Set up a database by following the "Installing the Database" section of https://docs.sonarqube.org/latest/setup/install-server/.
 
@@ -39,18 +45,12 @@ Set up a database by following the "Installing the Database" section of https://
 
 We recommend creating volumes for the following directories:
 
--	`/opt/sonarqube/conf`: **for Version 7.9.x only**, configuration files, such as `sonar.properties`.
 -	`/opt/sonarqube/data`: data files, such as the embedded H2 database and Elasticsearch indexes
 -	`/opt/sonarqube/logs`: contains SonarQube logs about access, web process, CE process, Elasticsearch logs
 -	`/opt/sonarqube/extensions`: for 3rd party plugins
 
 > **Warning:** You cannot use the same volumes on multiple instances of SonarQube.
 
-## First Installation
-
-For installation instructions, see Installing the Server from the Docker Image on the [Install the Server](https://docs.sonarqube.org/latest/setup/install-server/) page.
-
-To run a cluster with the DataCenter Edition, please refer to Installing SonarQube from the Docker Image on the [Install the Server as a Cluster](https://docs.sonarqube.org/latest/setup/install-cluster/) page.
 
 ## Upgrading
 
@@ -63,8 +63,8 @@ For upgrade instructions, see Upgrading from the Docker Image on the [Upgrade th
 In some environments, it may make more sense to prepare a custom image containing your configuration. A `Dockerfile` to achieve this may be as simple as:
 
 ```dockerfile
-FROM sonarqube:8.2-community
-COPY sonar.properties /opt/sonarqube/conf/
+FROM sonarqube:8.9-community
+COPY sonar-custom-plugin-1.0.jar /opt/sonarqube/extensions/
 ```
 
 You could then build and try the image with something like:
@@ -76,7 +76,7 @@ $ docker run -ti sonarqube-custom
 
 ### Avoid hard termination of SonarQube
 
-Starting from SonarQube 7.8, SonarQube stops gracefully, waiting for any tasks in progress to finish. Waiting for in-progress tasks to finish can take a large amount of time which the docker does not expect by default when stopping. To avoid having the SonarQube instance killed by the Docker daemon after 10 seconds, it is best to configure a timeout to stop the container with `--stop-timeout`. For example:
+A SonarQube instance will stop gracefully, waiting for any tasks in progress to finish. Waiting for in-progress tasks to finish can take a large amount of time which the docker does not expect by default when stopping. To avoid having the SonarQube instance killed by the Docker daemon after 10 seconds, it is best to configure a timeout to stop the container with `--stop-timeout`. For example:
 
 ```console
 docker run --stop-timeout 3600 %%IMAGE%%

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -51,7 +51,6 @@ We recommend creating volumes for the following directories:
 
 > **Warning:** You cannot use the same volumes on multiple instances of SonarQube.
 
-
 ## Upgrading
 
 For upgrade instructions, see Upgrading from the Docker Image on the [Upgrade the Server](https://docs.sonarqube.org/latest/setup/upgrading/) page.


### PR DESCRIPTION
Hello! SonarSourcer here proposing some changes (alongside the Product Team) to the Docs:

* **What is SonarQube?**
  * We have Boilerplate guidelines when describing SonarQube we could use, beyond the current 12 word description. It has been added.
* **How to use this image**
  * Using “Data Center” Edition rather than DataCenter Edition
* **Docker Host Requirements**
  * Due for an update based on [current requirements](https://docs.sonarqube.org/latest/requirements/requirements/#header-5)
* **Get Started in Two Minutes Guide**
  * We’ve moved towards wording like **Try Out SonarQube**
* **First Installation**
  * The "first" installation is usually when they've tried out SonarQube above? This section is where they get serious about installation (and then configuration), so it's been renamed.
* **Configuration > Database**
  * “Data Center” Edition rather than Datacenter Edition
* **Configuration > Use volumes**
  * Now that v7.9 LTS is EOL, can we remove reference to the /opt/sonarqube/conf persistent volume
  * “Data Center” Edition rather than DataCenter Edition
* **Advanced configuration > Customized Image**
  * Time to bump this example to sonarqube:8.9-community which means removing the /opt/sonarqube/conf/ example and replacing it with another (adding a custom plugin)
* **Advanced configuration > Avoid hard termination of SonarQube**
  * SonarQube v7.8 was a while ago (and EOL). We now avoid mentioning it and just stick to discussing the hard termination of SonarQube.