### PR TITLE
Added an example of starting pgAdmin4.

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -99,8 +99,8 @@ postgres=# SELECT 1;
 ```
 
 ## ... via [`docker stack deploy`](https://docs.docker.com/engine/reference/commandline/stack_deploy/) or [`docker-compose`](https://github.com/docker/compose)
-
-Example `stack.yml` for `postgres`:
+---
+Example with [adminer](https://www.adminer.org/) `stack.yml` for `postgres`:
 
 ```yaml
 # Use postgres/example user/password credentials
@@ -122,7 +122,37 @@ services:
 ```
 
 [![Try in PWD](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/docker-library/docs/9efeec18b6b2ed232cf0fbd3914b6211e16e242c/postgres/stack.yml)
+---
+Example with [pgAdmin4](https://www.pgadmin.org/) `stack.yml` for `postgres`:
 
+```yaml
+# Start PostgreSQL and Pgadmin4
+version: '3.8'
+
+services:
+
+  database:
+    container_name: postgres
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: example
+      POSTGRES_DB: test_db
+    ports:
+      - "5432:5432"
+
+  pgadmin:
+    container_name: pgadmin4
+    image: dpage/pgadmin4
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+```
+---
 Run `docker stack deploy -c stack.yml postgres` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 # How to extend this image


### PR DESCRIPTION
There was no description of how to set up pgAdmin4, which is perhaps the most used postgres database tool. I added this file to make it easier for people to get setup with this tool if they do not wish to use adminer.