### PR TITLE
Include ME_CONFIG_MONGODB_URL

### DIFF
--- a/mongo/stack.yml
+++ b/mongo/stack.yml
@@ -18,4 +18,4 @@ services:
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
       ME_CONFIG_MONGODB_ADMINPASSWORD: example
-      ME_CONFIG_MONGODB_URL: "mongodb://root:example@mongo:27017/"
+      ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/

--- a/mongo/stack.yml
+++ b/mongo/stack.yml
@@ -18,3 +18,4 @@ services:
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
       ME_CONFIG_MONGODB_ADMINPASSWORD: example
+      ME_CONFIG_MONGODB_URL: "mongodb://root:example@mongo:27017/"


### PR DESCRIPTION
Without `ME_CONFIG_MONGODB_URL: "mongodb://root:example@mongo:27017/"`
<details>
<summary> docker-compose up </summary>

```console
$ docker-compose up -d
Creating network "root_default" with the default driver
Creating root_mongo_1         ... done
Creating root_mongo-express_1 ... done

$ docker logs root_mongo-express_1 2>/dev/null
Welcome to mongo-express
------------------------


Welcome to mongo-express
------------------------


Welcome to mongo-express
------------------------

```
![image](https://user-images.githubusercontent.com/26428991/128062882-9f6a8561-600f-41aa-a5c7-1e38d1a2dd79.png)

</details>

With `ME_CONFIG_MONGODB_URL: "mongodb://root:example@mongo:27017/"`

<details>
<summary> docker-compose up </summary>

```console
$ docker-compose up -d
Creating network "root_default" with the default driver
Creating root_mongo-express_1 ... done
Creating root_mongo_1         ... done

$ docker logs root_mongo-express_1 2>/dev/null
Welcome to mongo-express
------------------------


Welcome to mongo-express
------------------------


Welcome to mongo-express
------------------------


Mongo Express server listening at http://0.0.0.0:8081
```
![image](https://user-images.githubusercontent.com/26428991/128062701-5b51c2ba-4852-48d1-ae1f-94cc7ef15722.png)

</details>

Closes https://github.com/docker-library/mongo/issues/490