### PR TITLE
Odoo: update documentation to the latest version

### DIFF
--- a/odoo/content.md
+++ b/odoo/content.md
@@ -1,6 +1,6 @@
 # What is Odoo?
 
-Odoo, formerly known as OpenERP, is a suite of open-source business apps written in Python and released under the AGPL license. This suite of applications covers all business needs, from Website/Ecommerce down to manufacturing, inventory and accounting, all seamlessly integrated. It is the first time ever a software editor managed to reach such a functional coverage. Odoo is the most installed business software in the world. Odoo is used by 2.000.000 users worldwide ranging from very small companies (1 user) to very large ones (300 000 users).
+Odoo, formerly known as OpenERP, is a suite of open-source business apps written in Python and released under the LGPL license. This suite of applications covers all business needs, from Website/Ecommerce down to manufacturing, inventory and accounting, all seamlessly integrated. It is the first time ever a software editor managed to reach such a functional coverage. Odoo is the most installed business software in the world. Odoo is used by 2.000.000 users worldwide ranging from very small companies (1 user) to very large ones (300 000 users).
 
 > [www.odoo.com](https://www.odoo.com)
 
@@ -13,7 +13,7 @@ This image requires a running PostgreSQL server.
 ## Start a PostgreSQL server
 
 ```console
-$ docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo -e POSTGRES_DB=postgres --name db postgres:10
+$ docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo -e POSTGRES_DB=postgres --name db postgres:13
 ```
 
 ## Start an Odoo instance
@@ -31,6 +31,24 @@ $ docker stop odoo
 $ docker start -a odoo
 ```
 
+## Use named volumes to preserve data
+
+When the Odoo container is created like described above, the odoo filestore is created inside the container. If the container is removed, the filestore is lost. The preferred way to prevent that is by using a Docker named [volume](https://docs.docker.com/storage/volumes/).
+
+```console
+$ docker run -v odoo-data:/var/lib/odoo -d -p 8069:8069 --name odoo --link db:db -t odoo
+```
+
+With the above command, the volume named `odoo-data` will persist even if the container is removed and can be re-used by issuing the same command.
+
+The path `/var/lib/odoo` used as the mount point of the volume must match the odoo `data_dir` in the config file or as CLI parameters.
+
+Note that the same principle applies to the Postgresql container and a named volume can be used to preserve the database when the container is removed. So the database container could be started like this (before the odoo container):
+
+```console
+$ docker run -d -v odoo-db:/var/lib/postgresql/data -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo -e POSTGRES_DB=postgres --name db postgres:13
+```
+
 ## Stop and restart a PostgreSQL server
 
 When a PostgreSQL server is restarted, the Odoo instances linked to that server must be restarted as well because the server address has changed and the link is thus broken.
@@ -45,7 +63,7 @@ The default configuration file for the server (located at `/etc/odoo/odoo.conf`)
 $ docker run -v /path/to/config:/etc/odoo -p 8069:8069 --name odoo --link db:db -t %%IMAGE%%
 ```
 
-Please use [this configuration template](https://github.com/odoo/docker/blob/master/12.0/odoo.conf) to write your custom configuration as we already set some arguments for running Odoo inside a Docker container.
+Please use [this configuration template](https://github.com/odoo/docker/blob/master/14.0/odoo.conf) to write your custom configuration as we already set some arguments for running Odoo inside a Docker container.
 
 You can also directly specify Odoo arguments inline. Those arguments must be given after the keyword `--` in the command-line, as follows
 
@@ -84,16 +102,16 @@ Tweak these environment variables to easily connect to a postgres server:
 The simplest `docker-compose.yml` file would be:
 
 ```yml
-version: '2'
+version: '3.1'
 services:
   web:
-    image: %%IMAGE%%:12.0
+    image: %%IMAGE%%:14.0
     depends_on:
       - db
     ports:
       - "8069:8069"
   db:
-    image: postgres:10
+    image: postgres:13
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_PASSWORD=odoo
@@ -103,10 +121,10 @@ services:
 If the default postgres credentials does not suit you, tweak the environment variables:
 
 ```yml
-version: '2'
+version: '3.1'
 services:
   web:
-    image: %%IMAGE%%:12.0
+    image: %%IMAGE%%:14.0
     depends_on:
       - mydb
     ports:
@@ -116,20 +134,25 @@ services:
     - USER=odoo
     - PASSWORD=myodoo
   mydb:
-    image: postgres:10
+    image: postgres:13
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_PASSWORD=myodoo
       - POSTGRES_USER=odoo
 ```
 
-Here's a last example showing you how to mount custom addons, how to use a custom configuration file and how to use volumes for the Odoo and postgres data dir:
+Here's a last example showing you how to
+
+-	mount custom addons located in `./addons`
+-	use a custom configuration file located in `.config/odoo.conf`
+-	use named volumes for the Odoo and postgres data dir
+-	use a `secrets` file named `odoo_pg_pass` that contains the postgreql password shared by both services
 
 ```yml
-version: '2'
+version: '3.1'
 services:
   web:
-    image: %%IMAGE%%:12.0
+    image: %%IMAGE%%:14.0
     depends_on:
       - db
     ports:
@@ -138,18 +161,28 @@ services:
       - odoo-web-data:/var/lib/odoo
       - ./config:/etc/odoo
       - ./addons:/mnt/extra-addons
+    environment:
+      - PASSWORD_FILE=/run/secrets/postgresql_password
+    secrets:
+      - postgresql_password
   db:
-    image: postgres:10
+    image: postgres:13
     environment:
       - POSTGRES_DB=postgres
-      - POSTGRES_PASSWORD=odoo
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgresql_password
       - POSTGRES_USER=odoo
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - odoo-db-data:/var/lib/postgresql/data/pgdata
+    secrets:
+      - postgresql_password
 volumes:
   odoo-web-data:
   odoo-db-data:
+
+secrets:
+  postgresql_password:
+    file: odoo_pg_pass
 ```
 
 To start your Odoo instance, go in the directory of the `docker-compose.yml` file you created from the previous examples and type:
@@ -164,7 +197,7 @@ Odoo images are updated on a regular basis to make them use recent releases (a n
 
 Suppose you created a database from an Odoo instance named old-odoo, and you want to access this database from a new Odoo instance named new-odoo, e.g. because you've just downloaded a newer Odoo image.
 
-By default, Odoo 12.0 uses a filestore (located at /var/lib/odoo/filestore/) for attachments. You should restore this filestore in your new Odoo instance by running
+By default, Odoo 14.0 uses a filestore (located at /var/lib/odoo/filestore/) for attachments. You should restore this filestore in your new Odoo instance by running
 
 ```console
 $ docker run --volumes-from old-odoo -p 8070:8069 --name new-odoo --link db:db -t %%IMAGE%%

--- a/odoo/license.md
+++ b/odoo/license.md
@@ -1,1 +1,1 @@
-View [license information](https://raw.githubusercontent.com/odoo/odoo/12.0/LICENSE) for the software contained in this image.
+View [license information](https://raw.githubusercontent.com/odoo/odoo/14.0/LICENSE) for the software contained in this image.


### PR DESCRIPTION
* Odoo license was updated from AGPL to LGPL a long time ago and never changed here
* Add a section for named volumes
* Adapt docker-compose example to show `secrets` usage