### PR TITLE
Update amazoncorretto documentation regarding base images

### DIFF
--- a/amazoncorretto/content.md
+++ b/amazoncorretto/content.md
@@ -27,3 +27,15 @@ Amazon will provide security updates for Corretto 8 until at least June 2023. Up
 ### Can I use Corretto as a drop-in replacement for other JDKs?
 
 Corretto is designed as a drop-in replacement for all Java SE distributions unless you are using features (e.g., Java Flight Recorder) not available in OpenJDK. Once Corretto binaries are installed on a host and correctly invoked to run your Java applications (e.g., using the alternatives command on Linux), existing command-line options, tuning parameters, monitoring, and anything else in place will continue to work as before.
+
+### Why does security scanner show that a docker image has a CVE?
+
+If a security scanner reports that an amazoncorretto image includes a CVE, the first recommended action is to pull an updated version of this image.
+
+If no updated image is available, run the appropriate command to update packages for the platform, ie. run "apk -U upgrade" for Alpine or "yum update -y --security" for AmazonLinux in your Dockerfiles or systems to resolve the issue immediately.
+
+If no updated package is available, please treat this as a potential security issue and follow [these instructions](https://aws.amazon.com/security/vulnerability-reporting/) or email AWS security directly at [aws-security@amazon.com](mailto:aws-security@amazon.com).
+
+It is the responsibility of the base docker image supplier to provide timely security updates to images and packages. The amazoncorretto images are automatically rebuilt when a new base image is made available, but we do not make changes to our Dockerfiles to pull in one-off package updates. If a new base image has not yet been made generally available by a base docker image maintainer, please contact that maintainer to request that the issue be addressed.
+
+Note that there are multiple reasons why a CVE may appear to be present in a docker image, as explained in the [docker library FAQs](https://github.com/docker-library/faq/tree/73f10b0daf2fb8e7b38efaccc0e90b3510919d51#why-does-my-security-scanner-show-that-an-image-has-cves).


### PR DESCRIPTION
Add some extra guidance on what to do when a vulnerability is present in an image. We have had frequent contacts regarding this issue.

We added this change to our own corretto-docker repository:
https://github.com/corretto/corretto-docker/pull/69