### PR TITLE
redis: prefer "--save" over "--appendonly"

### DIFF
--- a/redis/content.md
+++ b/redis/content.md
@@ -25,10 +25,10 @@ $ docker run --name some-redis -d %%IMAGE%%
 ## start with persistent storage
 
 ```console
-$ docker run --name some-redis -d %%IMAGE%% redis-server --appendonly yes
+$ docker run --name some-redis -d %%IMAGE%% redis-server --save 60 1 --loglevel warning
 ```
 
-If persistence is enabled, data is stored in the `VOLUME /data`, which can be used with `--volumes-from some-volume-container` or `-v /docker/host/dir:/data` (see [docs.docker volumes](https://docs.docker.com/engine/tutorials/dockervolumes/)).
+There are several different persistence strategies to choose from. This one will save a snapshot of the DB every 60 seconds if at least 1 write operation was performed (it will also lead to more logs, so the `loglevel` option may be desirable). If persistence is enabled, data is stored in the `VOLUME /data`, which can be used with `--volumes-from some-volume-container` or `-v /docker/host/dir:/data` (see [docs.docker volumes](https://docs.docker.com/engine/tutorials/dockervolumes/)).
 
 For more about Redis Persistence, see [http://redis.io/topics/persistence](http://redis.io/topics/persistence).
 


### PR DESCRIPTION
The `--appendonly` options has some cons that, IMO, lend the `--save` option to be a more appropriate suggestion in these docs.

I recently found out that in a local `docker-compose`, the `appendonly.aof` file had ballooned to over 1.3GB in my `redis` service, thanks to following the default suggestion here.

I think steering people towards `--save` in this simple example is probably better.