### PR TITLE
Update Haskell Debian support notes

### DIFF
--- a/haskell/content.md
+++ b/haskell/content.md
@@ -10,13 +10,13 @@ A large number of production-quality Haskell libraries are available from [Hacka
 
 ## About this image
 
-This image ships a minimal Haskell toolchain (`ghc` and `cabal-install`) from the upstream [downloads.haskell.org](https://launchpad.net/~hvr/+archive/ubuntu/ghc) Debian repository as well as the `stack` tool ([https://www.haskellstack.org/](https://www.haskellstack.org/)).
+This image ships a minimal Haskell toolchain (`ghc` and `cabal-install`) as well as the `stack` tool ([https://www.haskellstack.org/](https://www.haskellstack.org/)).
 
 Note: The GHC developers do not support legacy release branches (i.e. `7.8.x`). While older GHC release tags are available in this DockerHub repository, only the two most recent minor releases will receive updates or be shown in the "Supported tags ..." section at the top of this page.
 
-Additionally, we support the two most versions of Debian (`stable` and `oldstable`) as variants, with the most recent being the default if not specified.
+Additionally, we aim to support the two most recent versions of Debian (`stable` and `oldstable`) as variants, with the most recent being the default if not specified.
 
-> Note: `%%IMAGE%%:8.8.3` was updated from Debian Stretch to Buster, so you will need to specify `%%IMAGE%%:8.8.3-stretch` to stick with Stretch in this particular case.
+> Note: Currently `stable` Debian is version 11 bullseye, however it is not yet supported by Haskell tooling. Until that time the default will remain Debian 10 buster. We have dropped support for Debian 9 stretch.
 
 ## How to use this image
 


### PR DESCRIPTION
We are dropping support for debian 9 stretch - https://github.com/haskell/docker-haskell/issues/48

- Also correct that we don't install via debian repository anymore.
- Another minor wording improvement.

Thanks