### PR TITLE
Remove large Vault logo from readme

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -48,14 +48,11 @@ WARNING:
 -	**Source of this description**:  
 	[docs repo's `vault/` directory](https://github.com/docker-library/docs/tree/master/vault) ([history](https://github.com/docker-library/docs/commits/master/vault))
 
-# Vault
-
+# Vault 
 Vault is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. Vault provides a unified interface to any secret, while providing tight access control and recording a detailed audit log. For more information, please see:
 
 -	[Vault documentation](https://www.vaultproject.io/)
 -	[Vault on GitHub](https://github.com/hashicorp/vault)
-
-![logo](https://raw.githubusercontent.com/docker-library/docs/fab4b16599d1424cee888d47af850e0ba07e6a37/vault/logo.svg?sanitize=true)
 
 # Using the Container
 


### PR DESCRIPTION
Removed a full width Vault logo that was making the page difficult to read