### PR TITLE
Add more description around OpenJDK to make status more clear

### DIFF
--- a/openjdk/README-short.txt
+++ b/openjdk/README-short.txt
@@ -1,1 +1,1 @@
-OpenJDK is an open-source implementation of the Java Platform, Standard Edition
+"Vanilla" builds of OpenJDK (an open-source implementation of the Java Platform, Standard Edition)

--- a/openjdk/deprecated.md
+++ b/openjdk/deprecated.md
@@ -1,0 +1,13 @@
+# **WARNING**
+
+If you are a user/consumer of Java, this image is probably not what you expect!
+
+These images contain "vanilla" builds of the OpenJDK project provided by [Oracle](https://jdk.java.net/) or [the relevant "updates project lead"](https://github.com/docker-library/openjdk/issues/320#issuecomment-494050246) (depending on the version).
+
+For a more "supported" experience, we recommend one of the following other Official Images (listed in alphabetical order with no intentional or implied preference):
+
+-	[`amazoncorretto`](https://hub.docker.com/_/amazoncorretto)
+-	[`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin)
+-	[`ibm-semeru-runtimes`](https://hub.docker.com/_/ibm-semeru-runtimes)
+-	[`ibmjava`](https://hub.docker.com/_/ibmjava)
+-	[`sapmachine`](https://hub.docker.com/_/sapmachine)

--- a/update.sh
+++ b/update.sh
@@ -106,8 +106,10 @@ for image in "${images[@]}"; do
 
 		deprecated=
 		if [ -f "$repo/deprecated.md" ]; then
-			deprecated=$'# **DEPRECATION NOTICE**\n\n'
-			deprecated+="$(cat "$repo/deprecated.md")"
+			deprecated="$(< "$repo/deprecated.md")"
+			if [ "${deprecated:0:2}" != '# ' ]; then
+				deprecated=$'# **DEPRECATION NOTICE**\n\n'"$deprecated"
+			fi
 			deprecated+=$'\n\n'
 		fi
 


### PR DESCRIPTION
This is an attempt to preemptively/proactively provide a bit more clarity to the OpenJDK image description ahead of https://github.com/docker-library/openjdk/pull/495 and in light of https://github.com/docker-library/openjdk/issues/493 -- this image _really_ is not a good choice for a well-supported Java implementation.