### PR TITLE
Remove ONBUILD references from Mono content.md

### DIFF
--- a/mono/content.md
+++ b/mono/content.md
@@ -9,29 +9,21 @@ Sponsored by Xamarin, Mono is an open source implementation of Microsoft's .NET 
 
 # How to use this image
 
-This image will run stand-alone Mono console apps.
-
-## Create a `Dockerfile` in your Mono app project
-
-This example Dockerfile will run an executable called `TestingConsoleApp.exe`.
+To run a pre-built .exe file with the Mono image, use the following commands:
 
 ```dockerfile
-FROM %%IMAGE%%:3.10-onbuild
-CMD [ "mono",  "./TestingConsoleApp.exe" ]
+FROM %%IMAGE%%:latest
+RUN mkdir /opt/app
+COPY HelloWorld.exe /opt/app
+CMD ["mono", "/opt/app/HelloWorld.exe"]
 ```
 
-Place this file in the root of your app, next to the `.sln` solution file. Modify the exectuable name to match what you want to run.
-
-This image includes `ONBUILD` triggers that adds your app source code to `/usr/src/app/source`, restores NuGet packages and compiles the app, placing the output in `/usr/src/app/build`.
-
-With the Dockerfile in place, you can build and run a Docker image with your app:
+You can build and run the Docker Image as shown in the following example:
 
 ```console
-$ docker build -t my-app .
-$ docker run my-app
+docker build -t monoapp .
+docker run -it --rm monoapp
 ```
-
-You should see any output from your app now.
 
 # Credits
 


### PR DESCRIPTION
The onbuild variant was removed a long time ago, but I wasn't aware of this doc.