### PR TITLE
Warn about Docker host charset and newlines with httpd custom config

### DIFF
--- a/httpd/content.md
+++ b/httpd/content.md
@@ -42,6 +42,12 @@ To customize the configuration of the httpd server, first obtain the upstream de
 $ docker run --rm %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
 ```
 
+Note that stdout redirection will be handled by the Docker host. Some systems (notably Windows) will alter character encoding and newlines, which might prevent your custom configuration from being parsed properly and httpd from starting. You might need to use an host-specific binary-safe command to prevent this. E.g. on Windows PowerShell:
+
+```powershell
+Start-Process -FilePath "powershell" -ArgumentList "docker run --rm %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf" -NoNewWindow -Wait -RedirectStandardOutput my-httpd.conf
+```
+
 You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`:
 
 ```dockerfile

--- a/httpd/content.md
+++ b/httpd/content.md
@@ -42,13 +42,7 @@ To customize the configuration of the httpd server, first obtain the upstream de
 $ docker run --rm %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
 ```
 
-Note that stdout redirection will be handled by the Docker host. Some systems (notably Windows) will alter character encoding and newlines, which might prevent your custom configuration from being parsed properly and httpd from starting. You might need to use an host-specific binary-safe command to prevent this. E.g. on Windows PowerShell:
-
-```powershell
-Start-Process -FilePath "powershell" -ArgumentList "docker run --rm %%IMAGE%%:2.4 cat /usr/local/apache2/conf/httpd.conf" -NoNewWindow -Wait -RedirectStandardOutput my-httpd.conf
-```
-
-You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`:
+Keep in mind that the stdout redirection will be handled by the Docker host's shell. Make sure your shell redirects in a binary-safe way, to avoid any problem regarding character encoding and newlines. You can then `COPY` your custom configuration in as `/usr/local/apache2/conf/httpd.conf`:
 
 ```dockerfile
 FROM %%IMAGE%%:2.4


### PR DESCRIPTION
Greetings,

`httpd` Docker image's `README.md` is quite concise and useful. However I found a small problem in the *Configuration* section, more particularly with this shell command:
```console
$ docker run --rm httpd:2.4 cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
```
If this command is run in Windows, `httpd.conf`'s charset is converted to UTF-16 LE BOM and newlines go from `LF` to `CRLF`. This makes the configuration parsing fail when the resulting file is copied back into a Docker container based on `httpd`.

Since this command transfers data from a Docker container to the host system, I think it would be worth at least mentioning that stdout redirection can alter charset on non-Linux operating systems. I also added a Windows version of the command since this might help many.