### PR TITLE
chore(mediawiki): add explicit volume definitions

### DIFF
--- a/mediawiki/stack.yml
+++ b/mediawiki/stack.yml
@@ -12,7 +12,7 @@ services:
     links:
       - database
     volumes:
-      - /var/www/html/images
+      - images:/var/www/html/images
       # After initial setup, download LocalSettings.php to the same directory as
       # this yaml and uncomment the following line and use compose to restart
       # the mediawiki service
@@ -27,3 +27,9 @@ services:
       MYSQL_USER: wikiuser
       MYSQL_PASSWORD: example
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  images:
+  db:


### PR DESCRIPTION
Going by example of [Wordpress](https://github.com/docker-library/docs/blob/master/wordpress/stack.yml), I added explicit volume definitions to the example `stack.yml` so it's sufficient to copy and paste the configuration and have persistence.

Fixes #2146.