### PR TITLE
Adjust OpenJDK image deprecation notice to fully deprecate

### DIFF
--- a/openjdk/deprecated.md
+++ b/openjdk/deprecated.md
@@ -1,13 +1,11 @@
-# **WARNING**
-
-If you are a user/consumer of Java, this image is probably not what you expect!
-
-These images contain "vanilla" builds of the OpenJDK project provided by [Oracle](https://jdk.java.net/) or [the relevant "updates project lead"](https://github.com/docker-library/openjdk/issues/320#issuecomment-494050246) (depending on the version).
-
-For a more "supported" experience, we recommend one of the following other Official Images (listed in alphabetical order with no intentional or implied preference):
+This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. Some examples of other Official Image alternatives (listed in alphabetical order with no intentional or implied preference):
 
 -	[`amazoncorretto`](https://hub.docker.com/_/amazoncorretto)
 -	[`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin)
 -	[`ibm-semeru-runtimes`](https://hub.docker.com/_/ibm-semeru-runtimes)
 -	[`ibmjava`](https://hub.docker.com/_/ibmjava)
 -	[`sapmachine`](https://hub.docker.com/_/sapmachine)
+
+See [docker-library/openjdk#505](https://github.com/docker-library/openjdk/issues/505) for more information.
+
+The only tags which will continue to receive updates beyond July 2022 will be Early Access builds (which are sourced from [jdk.java.net](https://jdk.java.net/)), as those are not published/supported by any of the above projects.


### PR DESCRIPTION
Closes https://github.com/docker-library/openjdk/issues/505 (see also)

The information in https://snyk.io/jvm-ecosystem-report-2021/ (from that thread) is really interesting/useful IMO.

I think we probably need to try and do _more_ than just this, but maybe this is an OK start?
(I checked some metrics on the five-years-deprecated old `java` image and the amount of _active_ usage still today hurt me :weary::sob:)