### PR TITLE
[oraclelinux] update docs to improve the first use experience

### DIFF
--- a/oraclelinux/content.md
+++ b/oraclelinux/content.md
@@ -4,15 +4,13 @@
 
 Oracle Linux is an open-source operating system available under the GNU General Public License (GPLv2). Suitable for general purpose or Oracle workloads, it benefits from rigorous testing of more than 128,000 hours per day with real- world workloads and includes unique innovations such as Ksplice for zero- downtime kernel patching, DTrace for real-time diagnostics, the powerful Btrfs file system, and more.
 
-## Changelog
-
-Oracle maintains a [CHANGELOG](https://github.com/oracle/container-images/blob/main/CHANGELOG.md) that documents by release date the errata applied and any CVE(s) that are mitigated in each update to the official images.
+> **NOTE:** the `oraclelinux` image intentionally does *not* provide a `latest` tag. You must specify [an existing tag](https://hub.docker.com/_/oraclelinux?tab=tags) when referencing this image. See *"Removal of the `latest` tag"* below for further details.
 
 ## How to use these images
 
-The Oracle Linux images are intended for use in the **FROM** field of a downstream `Dockerfile`. For example, to use the latest optimized Oracle Linux 8 i mage, specify `FROM %%IMAGE%%:8`.
+The Oracle Linux images are intended for use in the **FROM** field of a downstream `Dockerfile`. For example, to use the latest optimized Oracle Linux 8 image, specify `FROM %%IMAGE%%:8`.
 
-### Removal of `latest` tag
+## Removal of `latest` tag
 
 The `latest` tag was removed from the Oracle Linux official images in June 2020 to avoid breaking any downstream images caused by backwards-incompatible changes introduced by the release of a new version. Downstream images must specify the version, i.e. `oraclelinux:7` or `oraclelinux:8`.
 
@@ -26,7 +24,11 @@ The `oraclelinux:8-slim` variant is intended primarily to provide "just enough u
 
 For images that want an Oracle Linux 7 user space, Oracle recommends using `oraclelinux:7-slim` as the base layer as it contains just enough packages for `yum` to be able to install more packages.
 
-The `oraclelinux:7` images is based on the package set of what would be installed on a bare-metal server when performing a Minimal install of Oracle Linux.
+The `oraclelinux:7` images is based on the package set of what would be installed on a bare-metal server when performing a minimal install of Oracle Linux.
+
+## Changelog
+
+Oracle maintains a [CHANGELOG](https://github.com/oracle/container-images/blob/main/CHANGELOG.md) that documents by release date the errata applied and any CVE(s) that are mitigated in each update to the official images.
 
 ## Official Resources
 


### PR DESCRIPTION
I'm trying to make that fact more obvious in the docs that the Docker Hub autogenerated pull command at the top of the page is invalid for this image.

Related: is there any way we can reduce or remove the Quick Start/Tags content at the top of the page? Or move it lower down somewhere? Or fix Docker Hub so it knows not to autogenerate invalid pull commands?

Signed-off-by: Avi Miller <avi.miller@oracle.com>