### PR TITLE
Update rocky linux documentation about latest tag and minimal builds

### DIFF
--- a/rockylinux/content.md
+++ b/rockylinux/content.md
@@ -11,7 +11,11 @@ Thank you for using Rocky Linux! We appreciate your feedback and welcome you to 
 
 # Rocky Linux image documentation
 
-The `%%IMAGE%%:latest` tag is always the most recent version currently available.
+The `%%IMAGE%%:latest` tag is intentionally missing. Please choose a major version (currently 8 or 9) tag, or a more specific tag to ensure you are pulling the version of Rocky Linux you want: e.g. `%%IMAGE%%:8` or `%%IMAGE%%:9`
+
+## Minimal variant
+
+In addition to the Base container, a Minimal container with microdnf and a stripped down dependency set is available by using any of the `-minimal` tags e.g. `%%IMAGE%%:9-minimal`
 
 ## Rolling builds
 


### PR DESCRIPTION
Clarify for rocky-linux/sig-cloud-instance-images#31 and docker-library/official-images#12797 why there is no latest tag