### PR TITLE
Adjust ghost docs to use "development" mode to use sqlite

### DIFF
--- a/ghost/content.md
+++ b/ghost/content.md
@@ -8,7 +8,7 @@ Ghost is a free and open source blogging platform written in JavaScript and dist
 
 # How to use this image
 
-This will start a Ghost instance listening on the default Ghost port of 2368.
+This will start a Ghost development instance listening on the default Ghost port of 2368.
 
 ```console
 $ docker run -d --name some-ghost -e NODE_ENV=development %%IMAGE%%
@@ -68,6 +68,12 @@ $ docker exec <container-id> node --version
 ## Note about Ghost-CLI
 
 While the Docker images do have Ghost-CLI available and do use some of its commands to set up the base Ghost image, many of the other Ghost-CLI commands won't work correctly, and really aren't designed/intended to. For more info see [docker-library/ghost#156 (comment)](https://github.com/docker-library/ghost/issues/156#issuecomment-428159861)
+
+## Production mode
+
+To run Ghost for production you'll also need to be running with MySQL 8, https, and a reverse proxy configured with appropriate `X-Forwarded-For`, `X-Forwared-Host`, and `X-Forwarded-Proto` (`https`) headers.
+
+The following example demonstrates some of the necessary configuration for running with MySQL. For more detail, see [Ghost's "Configuration options" documentation](https://ghost.org/docs/config/#configuration-options).
 
 ## %%STACK%%
 

--- a/ghost/content.md
+++ b/ghost/content.md
@@ -11,7 +11,7 @@ Ghost is a free and open source blogging platform written in JavaScript and dist
 This will start a Ghost instance listening on the default Ghost port of 2368.
 
 ```console
-$ docker run -d --name some-ghost %%IMAGE%%
+$ docker run -d --name some-ghost -e NODE_ENV=development %%IMAGE%%
 ```
 
 ## Custom port
@@ -19,7 +19,7 @@ $ docker run -d --name some-ghost %%IMAGE%%
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 
 ```console
-$ docker run -d --name some-ghost -e url=http://localhost:3001 -p 3001:2368 %%IMAGE%%
+$ docker run -d --name some-ghost -e NODE_ENV=development -e url=http://localhost:3001 -p 3001:2368 %%IMAGE%%
 ```
 
 If all goes well, you'll be able to access your new site on `http://localhost:3001` and `http://localhost:3001/ghost` to access Ghost Admin (or `http://host-ip:3001` and `http://host-ip:3001/ghost`, respectively).
@@ -35,7 +35,7 @@ For upgrading your Ghost container you will want to mount your data to the appro
 Mount your existing content. In this example we also use the Alpine base image.
 
 ```console
-$ docker run -d --name some-ghost -p 3001:2368 -v /path/to/ghost/blog:/var/lib/ghost/content %%IMAGE%%:alpine
+$ docker run -d --name some-ghost -e NODE_ENV=development -p 3001:2368 -v /path/to/ghost/blog:/var/lib/ghost/content %%IMAGE%%:alpine
 ```
 
 ### Docker Volume
@@ -43,19 +43,15 @@ $ docker run -d --name some-ghost -p 3001:2368 -v /path/to/ghost/blog:/var/lib/g
 Alternatively you can use a named [docker volume](https://docs.docker.com/storage/volumes/) instead of a direct host path for `/var/lib/ghost/content`:
 
 ```console
-$ docker run -d --name some-ghost -v some-ghost-data:/var/lib/ghost/content %%IMAGE%%
+$ docker run -d --name some-ghost -e NODE_ENV=development -v some-ghost-data:/var/lib/ghost/content %%IMAGE%%
 ```
-
-### SQLite Database
-
-This Docker image for Ghost uses SQLite. There is nothing special to configure.
 
 ## Configuration
 
 All Ghost configuration parameters (such as `url`) can be specified via environment variables. See [the Ghost documentation](https://ghost.org/docs/concepts/config/#running-ghost-with-config-env-variables) for details about what configuration is allowed and how to convert a nested configuration key into the appropriate environment variable name:
 
 ```console
-$ docker run -d --name some-ghost -e url=http://some-ghost.example.com %%IMAGE%%
+$ docker run -d --name some-ghost -e NODE_ENV=development -e url=http://some-ghost.example.com %%IMAGE%%
 ```
 
 (There are further configuration examples in the `stack.yml` listed below.)

--- a/ghost/stack.yml
+++ b/ghost/stack.yml
@@ -1,6 +1,3 @@
-# by default, the Ghost image will use SQLite (and thus requires no separate database container)
-# we have used MySQL here merely for demonstration purposes (especially environment-variable-based configuration)
-
 version: '3.1'
 
 services:


### PR DESCRIPTION
MySQL is the default db for production mode now; to avoid all the envs for connecting to a `mysql` instance on every `docker run`, we'll just use dev mode; stack file still has an example of production mode with a MySQL server.

Related to https://github.com/docker-library/ghost/pull/323

Perhaps we need a specific call out directing to the stack for a production example? Other notes that should be added?