### PR TITLE
Adjust debian doc to not reference `jessie` or `stretch`

### DIFF
--- a/.template-helpers/variant.sh
+++ b/.template-helpers/variant.sh
@@ -102,7 +102,7 @@ if [ -n "$text" ]; then
 	default+=$'\n' # parameter expansion eats the trailing newline
 
 	if [ "$repo" != 'debian' ] && [ "$repo" != 'ubuntu' ]; then
-		# what is 'jessie', 'stretch' and 'sid'
+		# what is 'bullseye', 'buster' and 'sid'
 		# https://github.com/docker-library/python/issues/343
 		debian=( $(bashbrew list --uniq "$(_repo 'debian')" | grep -vE 'stable|slim|backports|experimental|testing' | cut -d: -f2) )
 		ubuntu=( $(bashbrew list "$(_repo 'ubuntu')" | grep -vE 'devel|latest|[0-9]' | cut -d: -f2) )

--- a/debian/content.md
+++ b/debian/content.md
@@ -8,7 +8,7 @@ Debian is an operating system which is composed primarily of free and open-sourc
 
 # About this image
 
-The `%%IMAGE%%:latest` tag will always point the latest stable release (which is, at the time of this writing, `%%IMAGE%%:buster`). Stable releases are also tagged with their version (ie, `%%IMAGE%%:9` is an alias for `%%IMAGE%%:stretch`, `%%IMAGE%%:8` is an alias for `%%IMAGE%%:jessie`, etc).
+The `%%IMAGE%%:latest` tag will always point the latest stable release. Stable releases are also tagged with their version (ie, `%%IMAGE%%:11` is an alias for `%%IMAGE%%:bullseye`, `%%IMAGE%%:10` is an alias for `%%IMAGE%%:buster`, etc).
 
 The rolling tags (`%%IMAGE%%:stable`, `%%IMAGE%%:testing`, etc) use the rolling suite names in their `/etc/apt/sources.list` file (ie, `deb http://deb.debian.org/debian testing main`).
 


### PR DESCRIPTION
Also make the `content.md` less likely to be out of date.

Related to https://github.com/debuerreotype/docker-debian-artifacts/issues/167