### PR TITLE
nginx - Fix container path for cache dir to prevent error mkdir() "/var/cache/nginx/client_temp" failed (2: No such file or directory)

### DIFF
--- a/nginx/content.md
+++ b/nginx/content.md
@@ -110,7 +110,7 @@ This behavior can be changed via the following environment variables:
 
 ## Running %%IMAGE%% in read-only mode
 
-To run %%IMAGE%% in read-only mode, you will need to mount a Docker volume to every location where %%IMAGE%% writes information. The default %%IMAGE%% configuration requires write access to `/var/cache` and `/var/run`. This can be easily accomplished by running %%IMAGE%% as follows:
+To run %%IMAGE%% in read-only mode, you will need to mount a Docker volume to every location where %%IMAGE%% writes information. The default %%IMAGE%% configuration requires write access to `/var/cache/nginx` and `/var/run`. This can be easily accomplished by running %%IMAGE%% as follows:
 
 ```console
 $ docker run -d -p 80:80 --read-only -v $(pwd)/nginx-cache:/var/cache/nginx -v $(pwd)/nginx-pid:/var/run nginx


### PR DESCRIPTION
The code block contains the paths that should be mapped, `/var/cache/nginx` and `/var/run` for readonly cases. However, the description immediately above the code block also listed two paths. The first, `/var/cache`, would require additional dirs to already exist within the dir. For example, the application will fail to start if the host didn't create an `nginx` dir prior to starting the container.

This change updates the path in the description so it matches the path mapped in the code block and no dirs need to exist before starting the container.

When the path from the description was used instead of the path shown in the code block an error occurred:

```console
$ docker run -d -p 80:80 --read-only -v $(pwd)/nginx-cache:/var/cache -v $(pwd)/nginx-pid:/var/run nginx
```

Results in the following error

```
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: can not modify /etc/nginx/conf.d/default.conf (read-only file system?)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2022/09/21 00:18:37 [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (2: No such file or directory)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (2: No such file or directory)
```
