### PR TITLE
Update OpenJDK short description to be more precise

### DIFF
--- a/openjdk/README-short.txt
+++ b/openjdk/README-short.txt
@@ -1,1 +1,1 @@
-"Vanilla" builds of OpenJDK (an open-source implementation of the Java Platform, Standard Edition)
+Pre-release / non-production builds of OpenJDK


### PR DESCRIPTION
This is a successor/companion to https://github.com/docker-library/docs/pull/2162 to make the pre-release-only status of the `openjdk` image hopefully more clear.