### PR TITLE
Update elixir to link to alternative and similarly offical images

### DIFF
--- a/elixir/content.md
+++ b/elixir/content.md
@@ -10,6 +10,12 @@ Elixir leverages the Erlang VM, known for running low-latency, distributed and f
 
 # How to use this image
 
+## Consider alternatives
+
+The image tags are retroactively updated when there are changes to the upstream images this image depends on. This means that if the same tag is pulled at different points in time, the base Erlang or OS version could be different.
+
+There are [alternative Docker images](https://hub.docker.com/r/hexpm/elixir) produced by the team behind Hex, Elixir's official package manager. These images are built and tagged automatically for each Elixir/Erlang/OS combination and are never updated once tagged.
+
 ## Run it as the REPL
 
 ```console

--- a/elixir/get-help.md
+++ b/elixir/get-help.md
@@ -1,0 +1,1 @@
+The online communities listed on the [elixir repository's wiki](https://github.com/elixir-lang/elixir/wiki).


### PR DESCRIPTION
The official Elixir docker image is maintained by the Erlang and Elixir Foundation, but there are alternative images maintained by Hex, Elixir's official package manager.

There are a number of issues with the official image at the moment:
* Updated manually, so there is a few days delay between a new release, and image availability. E.g. see this [elixir forum post](https://elixirforum.com/t/fail-to-deploy-1-14-0-via-docker/49945).
* Issues with breaking changes for existing tags. Here are some examples of issues reported:
  * https://github.com/erlef/docker-elixir/issues/41
  * https://github.com/erlef/docker-elixir/issues/50
  * https://github.com/erlef/docker-elixir/issues/23

The images produced by Hex do not have these issues because they are built automatically whenever there is a new version and the tags are immutable - if a user wants to update a dependency, they need to update the relevant tag.

Because of this image's offical status, many users are unaware of the alternative option, which for Elixir deployments can often be the preferred choice. This PR breifly mentions the issue about breaking changes, and links to the hexpm images so people have the information to choose the solution that works best for them.

I also updated the get-help section to link to the Elixir repository wiki, which has a maintained list of help resources.