### PR TITLE
Fix mysql import in nextcloud readme

### DIFF
--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -548,7 +548,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 	```console
 	docker cp ./database.dmp nextcloud_db_1:/dmp
-	docker-compose exec db sh -c "mysql -u USER -p PASSWORD nextcloud < /dmp"
+	docker-compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
 	docker-compose exec db rm /dmp
 	```
 

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -548,7 +548,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 	```console
 	docker cp ./database.dmp nextcloud_db_1:/dmp
-	docker-compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
+	docker-compose exec db sh -c "mysql -u USER -p PASSWORD nextcloud < /dmp"
 	docker-compose exec db rm /dmp
 	```
 

--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -496,7 +496,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 	```console
 	docker cp ./database.dmp nextcloud_db_1:/dmp
-	docker-compose exec db sh -c "mysql -u USER -p PASSWORD nextcloud < /dmp"
+	docker-compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
 	docker-compose exec db rm /dmp
 	```
 


### PR DESCRIPTION
[README] In `docker-compose exec db sh -c "mysql -u USER -p PASSWORD nextcloud < /dmp"`:
Replaced `-p` with `--password` because of: _'If you use the short option form (-p), you cannot have a space between the option and the password.'_ - mysql man page.
Also replaced `-u` with `--user` for consistency.

This fix is necessary since the command otherwise failes because of a wrong password.