### PR TITLE
Link to more Stack Exchange sites

### DIFF
--- a/.template-helpers/get-help.md
+++ b/.template-helpers/get-help.md
@@ -1,1 +1,1 @@
-[the Docker Community Forums](https://forums.docker.com/), [the Docker Community Slack](https://dockr.ly/slack), or [Stack Overflow](https://stackoverflow.com/search?tab=newest&q=docker)
+[the Docker Community Slack](https://dockr.ly/slack), [Server Fault](https://serverfault.com/help/on-topic), [Unix & Linux](https://unix.stackexchange.com/help/on-topic), or [Stack Overflow](https://stackoverflow.com/help/on-topic)


### PR DESCRIPTION
Also, link directly to their "What topics can I ask about here?" pages instead of to a search.