### PR TITLE
Add Alpine locale information for Postgres 15

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -180,7 +180,15 @@ ENV LANG de_DE.utf8
 
 Since database initialization only happens on container startup, this allows us to set the language before it is created.
 
-Also of note, Alpine-based variants do *not* support locales; see ["Character sets and locale" in the musl documentation](https://wiki.musl-libc.org/functional-differences-from-glibc.html#Character-sets-and-locale) for more details.
+Also of note, Alpine-based variants starting with Postgres 15 support [ICU locales](https://www.postgresql.org/docs/15/locale.html#id-1.6.11.3.7). Previous Postgres versions based on alpine do *not* support locales; see ["Character sets and locale" in the musl documentation](https://wiki.musl-libc.org/functional-differences-from-glibc.html#Character-sets-and-locale) for more details.
+
+You can extend the Alpine-based images with a simple `Dockerfile` to set a different locale. The following example will set the default locale to `de_DE.utf8`:
+
+```dockerfile
+FROM %%IMAGE%%:15-alpine
+ENV POSTGRES_INITDB_ARGS "--locale-provider=icu --icu-locale=de-DE"
+ENV LANG de_DE.utf8
+```
 
 ## Additional Extensions
 

--- a/postgres/content.md
+++ b/postgres/content.md
@@ -184,10 +184,8 @@ Also of note, Alpine-based variants starting with Postgres 15 support [ICU local
 
 You can extend the Alpine-based images with a simple `Dockerfile` to set a different locale. The following example will set the default locale to `de_DE.utf8`:
 
-```dockerfile
-FROM %%IMAGE%%:15-alpine
-ENV POSTGRES_INITDB_ARGS "--locale-provider=icu --icu-locale=de-DE"
-ENV LANG de_DE.utf8
+```console
+$ docker run -d -e LANG=de_DE.utf8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=de-DE" -e POSTGRES_PASSWORD=mysecretpassword %%IMAGE%%:15-alpine 
 ```
 
 ## Additional Extensions

--- a/postgres/content.md
+++ b/postgres/content.md
@@ -182,7 +182,7 @@ Since database initialization only happens on container startup, this allows us 
 
 Also of note, Alpine-based variants starting with Postgres 15 support [ICU locales](https://www.postgresql.org/docs/15/locale.html#id-1.6.11.3.7). Previous Postgres versions based on alpine do *not* support locales; see ["Character sets and locale" in the musl documentation](https://wiki.musl-libc.org/functional-differences-from-glibc.html#Character-sets-and-locale) for more details.
 
-You can extend the Alpine-based images with a simple `Dockerfile` to set a different locale. The following example will set the default locale to `de_DE.utf8`:
+You can set locales in the Alpine-based images with `POSTGRES_INITDB_ARGS` to set a different locale. The following example will set the default locale for a newly initialized database to `de_DE.utf8`:
 
 ```console
 $ docker run -d -e LANG=de_DE.utf8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=de-DE" -e POSTGRES_PASSWORD=mysecretpassword %%IMAGE%%:15-alpine 


### PR DESCRIPTION
Postgres 15 has support for ICU locales which Alpine uses as noted by @lukaromih https://github.com/docker-library/postgres/issues/1004#issuecomment-1280559846
>The key is in version 15 of Postgres. And the timing couldn't be better, because it's only like 3-4 days old.
>As mentioned in [PostgreSQL 15.0 release docs](https://www.postgresql.org/docs/release/15.0/):
>> Allow [ICU](https://www.postgresql.org/docs/15/locale.html) collations to be set as the default for clusters and databases (Peter Eisentraut)
>> 
>> Previously, only libc-based collations could be selected at the cluster and database levels. ICU collations could only be used via explicit COLLATE clauses.

Testing the example Dockerfile
```console
$ docker build -t postgres:test - << EOF
FROM postgres:15-alpine
ENV POSTGRES_INITDB_ARGS "--locale-provider=icu --icu-locale=de-DE"
ENV LANG de_DE.utf8
EOF

Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM postgres:15-alpine
 ---> cc994726847f
Step 2/3 : ENV POSTGRES_INITDB_ARGS "--locale-provider=icu --icu-locale=de-DE"
 ---> Running in ecc05cef08b9
Removing intermediate container ecc05cef08b9
 ---> af1ab7b94c26
Step 3/3 : ENV LANG de_DE.utf8
 ---> Running in 8b9dedc4b32e
Removing intermediate container 8b9dedc4b32e
 ---> 697bdaf0d622
Successfully built 697bdaf0d622
Successfully tagged postgres:test

$ docker run -d --rm --name postgres -e POSTGRES_PASSWORD=pass postgres:test
8d5ef0c94d0d6da97c825e5bd3b261ad7c4d262dd743edf939d59d9e65c67aa7

$ docker exec -it postgres psql -U postgres
psql (15.0)
Type "help" for help.

postgres=# \l
                                                List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    | ICU Locale | Locale Provider |   Access privileges
-----------+----------+----------+------------+------------+------------+-----------------+-----------------------
 postgres  | postgres | UTF8     | de_DE.utf8 | de_DE.utf8 | de-DE      | icu             |
 template0 | postgres | UTF8     | de_DE.utf8 | de_DE.utf8 | de-DE      | icu             | =c/postgres          +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 template1 | postgres | UTF8     | de_DE.utf8 | de_DE.utf8 | de-DE      | icu             | =c/postgres          +
           |          |          |            |            |            |                 | postgres=CTc/postgres
(3 rows)
```

Fixes https://github.com/docker-library/postgres/issues/1004