### PR TITLE
ubuntu: Update Git references to Launchpad

### DIFF
--- a/ubuntu/content.md
+++ b/ubuntu/content.md
@@ -10,7 +10,7 @@ Development of Ubuntu is led by Canonical Ltd. Canonical generates revenue throu
 
 # What's in this image?
 
-This image is built from official rootfs tarballs provided by Canonical (specifically, https://partner-images.canonical.com/oci/ for Bionic and later and https://partner-images.canonical.com/core/ for older releases).
+This image is built from official rootfs tarballs provided by Canonical (see `dist-*` tags at https://git.launchpad.net/cloud-images/+oci/ubuntu-base).
 
 The `%%IMAGE%%:latest` tag points to the "latest LTS", since that's the version recommended for general use. The `%%IMAGE%%:rolling` tag points to the latest release (regardless of LTS status).
 
@@ -30,4 +30,10 @@ ENV LANG en_US.utf8
 
 # How is the rootfs built?
 
-The [tarballs published by Canonical](https://partner-images.canonical.com/oci/) are built from scripts that live in [the livecd-rootfs project](https://code.launchpad.net/~ubuntu-core-dev/livecd-rootfs/+git/livecd-rootfs/+ref/ubuntu/master), especially `live-build/auto/build`.
+The tarballs published by Canonical, referenced by `dist-*` tags in https://git.launchpad.net/cloud-images/+oci/ubuntu-base Git repository, are built from scripts that live in [the livecd-rootfs project](https://code.launchpad.net/~ubuntu-core-dev/livecd-rootfs/+git/livecd-rootfs/+ref/ubuntu/master), especially `live-build/auto/build`. The builds are run on Launchpad. For build history see `livefs` build pages of individual releases on Launchpad:
+
+-	[Bionic](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/bionic/ubuntu-oci)
+-	[Focal](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/focal/ubuntu-oci)
+-	[Jammy](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/jammy/ubuntu-oci)
+-	[Kinetic](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/kinetic/ubuntu-oci)
+-	[Lunar](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/lunar/ubuntu-oci)

--- a/ubuntu/github-repo
+++ b/ubuntu/github-repo
@@ -1,1 +1,1 @@
-https://github.com/tianon/docker-brew-ubuntu-core
+https://git.launchpad.net/cloud-images/+oci/ubuntu-base


### PR DESCRIPTION
Ubuntu base images rootfs tarballs are now fetched from Launchpad Git
repository. The location https://partner-images.canonical.com/oci/ is no
longer used. Update links in the documentation to refer to the
https://git.launchpad.net/cloud-images/+oci/ubuntu-base Git repository
URL instead.

The Launchpad Git repository URL is also set in github-repo file. This
shouldn't matter because the fact that an URL is a GitHub URL is used
only to fetch badges from open-source CI/CD services, and in case the
URL is not a GitHub URL, the HTTP request will just fail, and no badge
will be included.

closes #2227 