### PR TITLE
Improve Hashicorp Vault docker run example for server mode

### DIFF
--- a/vault/content.md
+++ b/vault/content.md
@@ -45,16 +45,24 @@ As an example:
 $ docker run --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:1234' %%IMAGE%%
 ```
 
-## Running Vault in Server Mode
+## Running Vault in Server Mode for Development
 
 ```console
 $ docker run --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG={"storage": {"file": {"path": "/vault/file"}}, "listener": [{"tcp": { "address": "0.0.0.0:8200", "tls_disable": true}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h", "ui": true}' -p 8200:8200 %%IMAGE%% server
 ```
 
-This runs a Vault server using the `file` storage backend at path `/vault/file`, with a default secret lease duration of one week and a maximum of 30 days.
+This runs a Vault server with TLS disabled, the `file` storage backend at path `/vault/file` and a default secret lease duration of one week and a maximum of 30 days. Disabling TLS and using the `file` storage backend are not recommended for production use.
 
 Note the `--cap-add=IPC_LOCK`: this is required in order for Vault to lock memory, which prevents it from being swapped to disk. This is highly recommended. In a non-development environment, if you do not wish to use this functionality, you must add `"disable_mlock: true"` to the configuration information.
 
 At startup, the server will read configuration HCL and JSON files from `/vault/config` (any information passed into `VAULT_LOCAL_CONFIG` is written into `local.json` in this directory and read as part of reading the directory for configuration files). Please see Vault's [configuration documentation](https://www.vaultproject.io/docs/config/index.html) for a full list of options.
+
+We suggest volume mounting a directory into the Docker image in order to give both the configuration and TLS certificates to Vault. You can accomplish this with:
+
+```console
+$ docker run --volume config/:/vault/config.d ...
+```
+
+For more scalability and reliability, we suggest running containerized Vault in an orchestration environment like k8s or OpenShift.
 
 Since 0.6.3 this container also supports the `VAULT_REDIRECT_INTERFACE` and `VAULT_CLUSTER_INTERFACE` environment variables. If set, the IP addresses used for the redirect and cluster addresses in Vault's configuration will be the address of the named interface inside the container (e.g. `eth0`).

--- a/vault/content.md
+++ b/vault/content.md
@@ -48,7 +48,7 @@ $ docker run --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DE
 ## Running Vault in Server Mode
 
 ```console
-$ docker run --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG={"backend": {"file": {"path": "/vault/file"}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' %%IMAGE%% server
+$ docker run --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG={"storage": {"file": {"path": "/vault/file"}}, "listener": [{"tcp": { "address": "0.0.0.0:8200", "tls_disable": true}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h", "ui": true}' -p 8200:8200 %%IMAGE%% server
 ```
 
 This runs a Vault server using the `file` storage backend at path `/vault/file`, with a default secret lease duration of one week and a maximum of 30 days.


### PR DESCRIPTION
… to actually be directly usable and fix backend to current wording of storage.

Current version leaves new user of HashiCorp image questioning on how to progress. Vault starts without any listener, doesn't open any port and is hence not usable for any quickstart or test. With this change, a user can directly call localhost:8200 in his browser and initialize and navigate in Vault UI. 

Further, its important to change wording from `backend` to `storage` as there aren't many examples of Vault JSON config out there and with the example naming the storage  `backend` it might be misleading for new users that HCL configs can't be translated easily to JSON configs. 