### PR TITLE
Fix badges urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the image documentation for each of the Docker Official
 
 All Markdown files here are run through [tianon's fork of `markdownfmt`](https://github.com/tianon/markdownfmt), and verified as formatted correctly via GitHub Actions.
 
--	[![GitHub CI status badge](https://img.shields.io/github/workflow/status/docker-library/docs/GitHub%20CI/master?label=GitHub%20CI)](https://github.com/docker-library/docs/actions?query=workflow%3A%22GitHub+CI%22+branch%3Amaster)
+-	[![GitHub CI status badge](https://img.shields.io/github/actions/workflow/status/docker-library/docs/ci.yml?branch=master&label=GitHub%20CI)](https://github.com/docker-library/docs/actions?query=workflow%3A%22GitHub+CI%22+branch%3Amaster)
 -	[![library update.sh status badge](https://img.shields.io/jenkins/s/https/doi-janky.infosiftr.net/job/docs/job/library.svg?label=Automated%20library%20update.sh)](https://doi-janky.infosiftr.net/job/docs/job/library/)
 	-	[![amd64 update.sh status badge](https://img.shields.io/jenkins/s/https/doi-janky.infosiftr.net/job/docs/job/amd64.svg?label=Automated%20amd64%20update.sh)](https://doi-janky.infosiftr.net/job/docs/job/amd64/)
 	-	[![arm32v5 update.sh status badge](https://img.shields.io/jenkins/s/https/doi-janky.infosiftr.net/job/docs/job/arm32v5.svg?label=Automated%20arm32v5%20update.sh)](https://doi-janky.infosiftr.net/job/docs/job/arm32v5/)

--- a/generate-repo-stub-readme.sh
+++ b/generate-repo-stub-readme.sh
@@ -72,17 +72,9 @@ toTest=(
 	# "image badge link/href"
 	# "badge test URL (to determine whether badge applies)"
 
-	"https://img.shields.io/github/workflow/status/$githubRepoName/GitHub%20CI/$branch?label=GitHub%20CI"
+	"https://img.shields.io/github/actions/workflow/status/$githubRepoName/ci.yml?branch=$branch&label=GitHub%20CI"
 	"https://github.com/$githubRepoName/actions?query=workflow%3A%22GitHub+CI%22+branch%3A$branch"
 	"https://github.com/$githubRepoName/blob/$branch/.github/workflows/ci.yml"
-
-	"https://img.shields.io/travis/$githubRepoName/$branch.svg?label=Travis%20CI"
-	"https://travis-ci.org/$githubRepoName/branches"
-	"https://github.com/$githubRepoName/blob/$branch/.travis.yml"
-
-	"https://img.shields.io/appveyor/ci/$githubRepoName/$branch.svg?label=AppVeyor"
-	"https://ci.appveyor.com/project/$githubRepoName"
-	"https://github.com/$githubRepoName/blob/$branch/.appveyor.yml"
 
 	"https://img.shields.io/jenkins/s/https/doi-janky.infosiftr.net/job/update.sh/job/$repo.svg?label=Automated%20update.sh"
 	"https://doi-janky.infosiftr.net/job/update.sh/job/$repo/"


### PR DESCRIPTION
Apply changes for https://github.com/badges/shields/issues/8671. This will need to also be used to generate all of our repo readme files to fix https://github.com/docker-library/python/issues/779.

Also drop unused travis and appveyor urls.