### PR TITLE
Add deprecation notice to Vault

### DIFF
--- a/vault/content.md
+++ b/vault/content.md
@@ -5,8 +5,6 @@ Vault is a tool for securely accessing secrets. A secret is anything that you wa
 -	[Vault documentation](https://www.vaultproject.io/)
 -	[Vault on GitHub](https://github.com/hashicorp/vault)
 
-> **Warning** Upcoming in Vault 1.14 we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from “hashicorp/vault” instead of “vault”. More information is available on our [deprecation page](https://developer.hashicorp.com/vault/docs/deprecation).
-
 %%LOGO%%
 
 # Using the Container

--- a/vault/content.md
+++ b/vault/content.md
@@ -5,6 +5,8 @@ Vault is a tool for securely accessing secrets. A secret is anything that you wa
 -	[Vault documentation](https://www.vaultproject.io/)
 -	[Vault on GitHub](https://github.com/hashicorp/vault)
 
+> **Warning** Upcoming in Vault 1.14 we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from “hashicorp/vault” instead of “vault”. More information is available on our [deprecation page](https://developer.hashicorp.com/vault/docs/deprecation).
+
 %%LOGO%%
 
 # Using the Container

--- a/vault/deprecated.md
+++ b/vault/deprecated.md
@@ -1,0 +1,2 @@
+Upcoming in Vault 1.14, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) instead of [vault](https://hub.docker.com/_/vault). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/vault.
+

--- a/vault/deprecated.md
+++ b/vault/deprecated.md
@@ -1,2 +1,1 @@
 Upcoming in Vault 1.14, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) instead of [vault](https://hub.docker.com/_/vault). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/vault.
-


### PR DESCRIPTION
I'd like to update our docker image docs to warn about an impending switch to publishing only the Verified Publisher images per a deprecation notice here: https://developer.hashicorp.com/vault/docs/deprecation.

I've also gotten the Verified Publisher documentation (https://hub.docker.com/r/hashicorp/vault) updated though it doesn't have all the fancy updates from the update script.