### PR TITLE
Fix incorrect link for Telegraf Official Docs

### DIFF
--- a/telegraf/content.md
+++ b/telegraf/content.md
@@ -2,7 +2,7 @@
 
 Telegraf is an open source agent written in Go for collecting metrics and data on the system it's running on or from other services. Telegraf writes data it collects to InfluxDB in the correct format.
 
-[Telegraf Official Docs](https://docs.influxdata.com/telegraf/latest/introduction/getting-started/)
+[Telegraf Official Docs](https://docs.influxdata.com/telegraf/latest/get_started/)
 
 %%LOGO%%
 


### PR DESCRIPTION
Replace Telegraf Official Docs link with https://docs.influxdata.com/telegraf/latest/get_started/

Reported in https://github.com/influxdata/docs-v2/issues/4715