### PR TITLE
Update docs to reflect AL 2023 GA release

### DIFF
--- a/amazonlinux/content.md
+++ b/amazonlinux/content.md
@@ -40,10 +40,10 @@ Similar to the Amazon Linux images for AWS EC2 and on-premises use, Amazon Linux
 
 ## What support is available for Amazon Linux outside AWS?
 
--   GitHub Issues: https://github.com/amazonlinux/container-images/issues
--	Documentation: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html
--	Amazon Linux Forums: https://forums.aws.amazon.com/forum.jspa?forumID=228
--	Paid Support from AWS: https://aws.amazon.com/premiumsupport/
+-    GitHub Issues: https://github.com/amazonlinux/container-images/issues
+-    Documentation: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html
+-    Amazon Linux Forums: https://forums.aws.amazon.com/forum.jspa?forumID=228
+-    Paid Support from AWS: https://aws.amazon.com/premiumsupport/
 
 ## Will AWS support the current versions of Amazon Linux going forward?
 

--- a/amazonlinux/content.md
+++ b/amazonlinux/content.md
@@ -4,51 +4,35 @@ Amazon Linux is provided by Amazon Web Services (AWS). It is designed to provide
 
 The Amazon Linux container image contains a minimal set of packages. To install additional packages, [use `yum`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/managing-software.html).
 
-AWS provides two versions of Amazon Linux: [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/) and [Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/).
+AWS provides three versions of Amazon Linux:
+-    [Amazon Linux 2023](https://aws.amazon.com/linux/amazon-linux-2023/) (recommended, latest)
+-    [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
+-    [Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/)
 
-**Please note, that Amazon Linux 2023 is currently in the Preview mode and is not recommended for production workloads. Review the Amazon Linux 2023 [documentation](https://docs.aws.amazon.com/linux/al2023/ug/what-is-amazon-linux.html) to learn more.**
+For information on security updates for Amazon Linux, please refer to:
+-    [Amazon Linux 2023 Security Advisories](https://alas.aws.amazon.com/alas2023.html)
+-    [Amazon Linux 2 Security Advisories](https://alas.aws.amazon.com/alas2.html)
+-    [Amazon Linux AMI Security Advisories](https://alas.aws.amazon.com/)
 
-For information on security updates for Amazon Linux, please refer to [Amazon Linux 2 Security Advisories](https://alas.aws.amazon.com/alas2.html) and [Amazon Linux AMI Security Advisories](https://alas.aws.amazon.com/). Note that Docker Hub's vulnerability scanning for Amazon Linux is currently based on RPM versions, which does not reflect the state of backported patches for vulnerabilities.
+Note that Docker Hub's vulnerability scanning for Amazon Linux is currently based on RPM versions, which does not reflect the state of backported patches for vulnerabilities.
 
 %%LOGO%%
+
+## What is Amazon Linux 2023?
+
+-    Amazon Linux 2023: https://aws.amazon.com/linux/amazon-linux-2023/
+-    2023.0 Release Notes: https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html
+-    FAQs: https://aws.amazon.com/linux/amazon-linux-2023/faqs/
+-    What's New: https://aws.amazon.com/about-aws/whats-new/2023/03/amazon-linux-2023/
+-    User Guide: https://docs.aws.amazon.com/linux/al2023/ug/what-is-amazon-linux.html
 
 ## Where can I run Amazon Linux container images?
 
 You can run Amazon Linux container images in any Docker based environment. Examples include, your laptop, in AWS EC2 instances, and ECS clusters.
 
-## How is Amazon Linux 2 different from Amazon Linux AMI?
-
-There are three major differences in Amazon Linux 2 from its predecessors:
-
-1.	it is available as a VM image for on-premises development and testing
-2.	it includes systemd service and systems manager as opposed to System V init system and also includes new version of compiler and build tools
-3.	it gives you the ability to install additional software packages through Extras mechanism without impacting the underlying LTS stability
-
-## Is Amazon Linux 2 build an official LTS build?
-
-Yes. Amazon Linux 2 end of support date (End of Life, or EOL) has been extended by two years from 2023-06-30 to 2025-06-30 to provide customers with ample time to migrate to the next version.
-
 ## What packages are available in the Amazon Linux containers?
 
-Amazon Linux Docker container images contain a subset of the packages in the images for use on EC2 and as VMs in on-premises scenarios. The container images can be configured to use any of the full set of packages in images for EC2 and on-premises use. The Amazon Linux 2 container images comes with Extras included.
-
-## What is an Amazon Linux 2 Extra?
-
-Extras is a new mechanism introduced in Amazon Linux 2 to enable the consumption of the newest versions of application software in a fully supported manner on a stable Amazon Linux 2 base. Extras help alleviate the compromise between stability of the OS and freshness of available software. For example, now you can install newer versions of Python being rest assured that the underlying operating system is stable. Examples of Extras include nginx, PostgreSQL, MariaDB, Go, and Rust.
-
-## How do Amazon Linux 2 Extras work?
-
-Extras introduces the notion of topics to select software bundles. Each topic contains all the dependencies required for the software to install and function on Amazon Linux 2. For example, Rust is an Extras topic in the curated list provide by Amazon. It provides the toolchain and runtimes for Rust, the systems programming language. This topic includes the cmake build system for Rust, cargo - the rust package manager, and the LLVM based compiler toolchain for Rust. The packages associated with each topic are consumed via the well-known yum installation process.
-
-## How are Amazon Linux 2 Extras topics different from the packages available in yum repositories?
-
-`yum` is a utility for package management of RPM packages. The base image of Amazon Linux 2 (LTS) includes access to repositories that already contain stable versions of popular packages that can be installed with `yum`. These packages are part of the long term support for Amazon Linux 2.
-
-However, if you need a new software package or a newer version of an existing software package that is not included in the base Amazon Linux 2 image, Extras provide a way to install those packages in a supported manner. Extras is essentially a simplified mechanism to point yum to AWS curated sets of packages for a selected topic.
-
-## How do I install a software package from Extras repository in Amazon Linux 2?
-
-Available packages can be listed with the `amazon-linux-extras` command. Packages can be installed with the `amazon-linux-extras install <package>` command. Example: `amazon-linux-extras install rust1`
+Amazon Linux Docker container images contain a subset of the packages in the images for use on EC2 and as VMs in on-premises scenarios. The container images can be configured to use any of the full set of packages in images for EC2 and on-premises use.
 
 ## Will updates be available for Amazon Linux containers?
 
@@ -56,18 +40,25 @@ Similar to the Amazon Linux images for AWS EC2 and on-premises use, Amazon Linux
 
 ## What support is available for Amazon Linux outside AWS?
 
+-   GitHub Issues: https://github.com/amazonlinux/container-images/issues
 -	Documentation: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html
 -	Amazon Linux Forums: https://forums.aws.amazon.com/forum.jspa?forumID=228
 -	Paid Support from AWS: https://aws.amazon.com/premiumsupport/
 
-## With the availability of Amazon Linux 2, are there any changes to the existing version of Amazon Linux AMI?
+## Will AWS support the current versions of Amazon Linux going forward?
 
-With the availability of Amazon Linux 2, we are announcing that 2018.03 release of Amazon Linux AMI container image will be the last release for the current generation of Amazon Linux. Going forward, AWS will provide newer versions only for Amazon Linux 2.
+Yes; in order to avoid any disruption to your existing applications and to facilitate migration to Amazon Linux 2023, AWS will provide regular security updates for Amazon Linux 2 and Amazon Linux 2018.03. Please refer to their FAQs for more information. You can also use all your existing support channels such as AWS Premium Support and Amazon Linux Discussion Forum to continue to submit support requests.
 
-## Will AWS support the current version of Amazon Linux going forward?
+## FAQs
 
-Yes; in order to avoid any disruption to your existing applications and to facilitate migration to Amazon Linux 2, AWS will provide regular security updates for Amazon Linux 2018.03 AMI and container image for 2 years after the final LTS build is announced. You can also use all your existing support channels such as AWS Premium Support and Amazon Linux Discussion Forum to continue to submit support requests.
+### Amazon Linux 2023
 
-## Is Amazon Linux 2 backward compatible with Amazon Linux AMI?
+-    FAQs: https://aws.amazon.com/linux/amazon-linux-2023/faqs/
 
-Due to the inclusion of new components in Amazon Linux 2 such as systemd, your applications running on the current version of Amazon Linux may require additional changes to run on Amazon Linux 2.
+### Amazon Linux 2
+
+-    FAQs: https://aws.amazon.com/amazon-linux-2/faqs/
+
+### Amazon Linux 1
+
+-    FAQs: https://aws.amazon.com/amazon-linux-ami/faqs/

--- a/amazonlinux/issues.md
+++ b/amazonlinux/issues.md
@@ -1,1 +1,2 @@
-[the Amazon Linux forums](https://forums.aws.amazon.com/forum.jspa?forumID=228)
+-    [amazonlinux/container-images/issues](https://github.com/amazonlinux/container-images/issues)
+-    [the Amazon Linux forums](https://forums.aws.amazon.com/forum.jspa?forumID=228)


### PR DESCRIPTION
Hi,

The updates now mention AL2023 as the latest and recommended version.
We also removed AL2 specific information and replaced it with FAQs link for each supported OS.

Thanks,
Sumit