### PR TITLE
Adjust GitHub issues URL to include PRs + closed

### DIFF
--- a/.template-helpers/issues.md
+++ b/.template-helpers/issues.md
@@ -1,1 +1,1 @@
-[%%GITHUB-REPO%%/issues](%%GITHUB-REPO%%/issues)
+[%%GITHUB-REPO%%/issues](%%GITHUB-REPO%%/issues?q=)


### PR DESCRIPTION
Hopefully this helps users find PRs and closed issues more easily when they're going to file an issue.

Compare for example:
- https://github.com/docker-library/docs/issues
- https://github.com/docker-library/docs/issues?q=