### PR TITLE
Update Ubuntu's maintainer.md

### DIFF
--- a/ubuntu/maintainer.md
+++ b/ubuntu/maintainer.md
@@ -1,1 +1,1 @@
-[Canonical](https://launchpad.net/cloud-images) and [Tianon (Debian Developer)](%%GITHUB-REPO%%)
+[Canonical](https://launchpad.net/cloud-images)


### PR DESCRIPTION
Given the new OCI-based image submission workflow, the Maintainance of the Ubuntu container image can solely be assigned to Canonical.