### PR TITLE
Ubuntu 22.10 (Kinetic Kudu) EOL

### DIFF
--- a/ubuntu/content.md
+++ b/ubuntu/content.md
@@ -34,6 +34,5 @@ The tarballs published by Canonical, referenced by `dist-*` tags in https://git.
 
 -	[Focal](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/focal/ubuntu-oci)
 -	[Jammy](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/jammy/ubuntu-oci)
--	[Kinetic](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/kinetic/ubuntu-oci)
 -	[Lunar](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/lunar/ubuntu-oci)
 -	[Mantic](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/mantic/ubuntu-oci)


### PR DESCRIPTION
Ubuntu 22.10 (Kinetic Kudu) reaches End of Life on July 20 2023. Remove
it from the README.