### PR TITLE
Improve docker-compose install instructions

### DIFF
--- a/mediawiki/README.md
+++ b/mediawiki/README.md
@@ -147,6 +147,8 @@ volumes:
 
 Run `docker stack deploy -c stack.yml mediawiki` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
+When specifying the database host as part of the wiki setup process, make sure to use `database://localhost`.
+
 ## Adding additional libraries / extensions
 
 This image does not provide any additional PHP extensions or other libraries, even if they are required by popular plugins. There are an infinite number of possible plugins, and they potentially require any extension PHP supports. Including every PHP extension that exists would dramatically increase the image size.


### PR DESCRIPTION
Add more-specific instructions as to what to make the database host if using docker-compose. I was having trouble connecting using `localhost` until I realized you need to use `database://localhost`. This change specifies this more-directly.