### PR TITLE
chore: ⬆ update to Go 1.21

### DIFF
--- a/golang/content.md
+++ b/golang/content.md
@@ -15,7 +15,7 @@ Go (a.k.a., Golang) is a programming language first developed at Google. It is a
 The most straightforward way to use this image is to use a Go container as both the build and runtime environment. In your `Dockerfile`, writing something along the lines of the following will compile and run your project (assuming it uses `go.mod` for dependency management):
 
 ```dockerfile
-FROM %%IMAGE%%:1.20
+FROM %%IMAGE%%:1.21
 
 WORKDIR /usr/src/app
 
@@ -41,13 +41,13 @@ $ docker run -it --rm --name my-running-app my-golang-app
 There may be occasions where it is not appropriate to run your app inside a container. To compile, but not run your app inside the Docker instance, you can write something like:
 
 ```console
-$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.20 go build -v
+$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.21 go build -v
 ```
 
 This will add your current directory as a volume to the container, set the working directory to the volume, and run the command `go build` which will tell go to compile the project in the working directory and output the executable to `myapp`. Alternatively, if you have a `Makefile`, you can run the `make` command inside your container.
 
 ```console
-$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.20 make
+$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.21 make
 ```
 
 ## Cross-compile your app inside the Docker container
@@ -55,13 +55,13 @@ $ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.20 make
 If you need to compile your application for a platform other than `linux/amd64` (such as `windows/386`):
 
 ```console
-$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp -e GOOS=windows -e GOARCH=386 %%IMAGE%%:1.20 go build -v
+$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp -e GOOS=windows -e GOARCH=386 %%IMAGE%%:1.21 go build -v
 ```
 
 Alternatively, you can build for multiple platforms at once:
 
 ```console
-$ docker run --rm -it -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.20 bash
+$ docker run --rm -it -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:1.21 bash
 $ for GOOS in darwin linux; do
 >   for GOARCH in 386 amd64; do
 >     export GOOS GOARCH


### PR DESCRIPTION
## What?
Update the golang documentation to use the latest version available.

## Why?
A new major version was released on the 8th of August: https://go.dev/blog/go1.21

## How?
Replaced all the occurrences of `%%IMAGE%%:1.20` by `%%IMAGE%%:1.21`.