### PR TITLE
Only upload logos to `library/`

### DIFF
--- a/push.pl
+++ b/push.pl
@@ -175,7 +175,8 @@ while (my $repo = shift) { # 'library/hylang', 'tianon/perl', etc
 	
 	my $repoUrl = $dockerHub . '/v2/repositories/' . $repo . '/';
 	
-	if ($logos) {
+	if ($logos && $repo =~ m{ ^ library/ }x) {
+		# only DOI ("library"), DSOS, or DVP orgs can include a logo which is displayed in the Hub UI
 		# if we have a logo file, let's update that metadata first
 		my $repoLogo120 = $repoName . '/logo-120.png';
 		if (!-f $repoLogo120) {


### PR DESCRIPTION
Logos upload is not currently available on our arch-specifc namespaces. Follow up to https://github.com/docker-library/docs/pull/2373. This restores the condition that stops us from attempting to upload logos to the arch specific namespaces.

```console
converting adminer/logo.png to adminer/logo-120.png
POST to https://hub.docker.com/api/media/repos_logo/v1/amd64%2Fadminer/upload failed: {"message":"not enough permissions"}
```