### PR TITLE
Update golang/content.md to explain when and how to install git-lfs

### DIFF
--- a/golang/content.md
+++ b/golang/content.md
@@ -70,50 +70,6 @@ $ for GOOS in darwin linux; do
 > done
 ```
 
-## Enable `git lfs`
+## Git LFS
 
-If your application fails to `go mod verify` inside the Go container with a "_checksum mismatch_" error, like so:
-
-> ```console
->  > [builder 4/7] RUN go mod download && go mod verify:
-> 5.888 verifying <module-import-path>: checksum mismatch
-> 5.888 	downloaded: h1:broICiQ+pcdcV/2qtCYrIIAnhQH65LuA9UvmaNjcy/w=
-> 5.888 	go.sum:     h1:maNCe3B0zkLaBfPUpJk3CBGavDPAI9ONaI4wKq2GUv0=
-> ```
-
-And the following condition apply:
-- The `<module-import-path>` archive is downloaded directly (as opposed to downloading from the [Go proxy](https://proxy.golang.org/))
-- The verified module contains files committed to the hosting repository using [Git Large File Storage](https://git-lfs.com/)
-
-Then the failure may be a result of the Go toolchain inside the container not resolving these Git LFS objects. In this case, the hash of the downloaded archive is computed using the pointer files, instead of the actual files that were used the development machines and eventually written to `go.sum`.
-
-**Note:** this scenario mostly concerns projects with multiple private modules.
-
-To enable `git lfs` on the Go container where the application is compiled:
-
-```dockerfile
-FROM %%IMAGE%%:1.21
-...
-
-# install git-lfs for Go modules with LFS committed files, before go mod download
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends git-lfs; \
-	rm -rf /var/lib/apt/lists/*
-
-RUN go mod download && go mod verify
-...
-```
-
-For alpine images run:
-
-```
-FROM %%IMAGE%%:1.21-alpine
-...
-
-# install git-lfs for Go modules with LFS committed files, before go mod download
-RUN apk add --no-cache git-lfs
-
-RUN go mod download && go mod verify
-...
-```
+If downloading your dependencies results in an error like "checksum mismatch", you should check whether they are using [Git LFS](https://git-lfs.com/) (and thus need it installed for downloading them and calculating correct `go.sum` values).


### PR DESCRIPTION
The Go toolchain uses the local git installation to fetch archives of modules from Git servers directly. My company commits large files using Git LFS which happen to be part of our Go module source tree. Without _git-lfs_ installed, the local git installation does not automatically resolve those files which causes "_checksum mismatch_" against the committed `go.sum`.

This pull-request aims to ease the strain on developers that encounter that unfortunately under-documented scenario, and lower the barrier of entry for companies to the Golang world.