### PR TITLE
Arch Linux: Note new multilib-devel tags in the description, small updates

### DIFF
--- a/archlinux/content.md
+++ b/archlinux/content.md
@@ -10,18 +10,18 @@ Our strong community is diverse and helpful, and we pride ourselves on the range
 
 # About this image
 
-The root filesystem tarball for this image is auto-generated weekly at 00:00 UTC on Sunday in Arch Linux infrastructure. Given the rolling-release nature of Arch Linux, images are tagged with the included package group / meta package and the timestamp of the date they were generated. For example, `%%IMAGE%%:base-20201101.0.7893` was generated the First of November 2020 in [CI job #7893](https://gitlab.archlinux.org/archlinux/archlinux-docker/-/jobs/7893). The `latest` tag will always match the latest `base` tag.
+The root filesystem tarball for this image is auto-generated weekly at 00:00 UTC on Sunday in Arch Linux infrastructure. Given the rolling-release nature of Arch Linux, images are tagged with the included meta package and the timestamp of the date they were generated. For example, `%%IMAGE%%:base-20201101.0.7893` was generated the First of November 2020 in [CI job #7893](https://gitlab.archlinux.org/archlinux/archlinux-docker/-/jobs/7893). The `latest` tag will always match the latest `base` tag.
 
-Besides `base` we also provide images for the `base-devel` package group.
+Besides `base` we also provide images for the `base-devel` and `multilib-devel` meta packages.
 
 This image is intended to serve the following goals:
 
 -	Provide the Arch experience in a Docker Image
--	Provide simplest but complete image to base every other upon
+-	Provide simplest but complete image to `base`, `base-devel` and `multilib-devel` on a regular basis
 -	`pacman` needs to work out of the box
 -	All installed packages have to be kept unmodified
 
-> ⚠️⚠️⚠️ NOTE: For Security Reasons, these images strip the pacman lsign key. This is because the same key would be spread to all containers of the same image, allowing for malicious actors to inject packages (via, for example, a man-in-the-middle). In order to create an lsign-key run `pacman-key --init` on the first execution, but be careful to not redistribute that key. ⚠️⚠️⚠️
+> ⚠️⚠️⚠️ NOTE: For Security Reasons, these images strip the pacman lsign key. This is because the same key would be spread to all containers of the same image, allowing for malicious actors to inject packages (via, for example, a man-in-the-middle). In order to create a lsign-key run `pacman-key --init` on the first execution, but be careful to not redistribute that key. ⚠️⚠️⚠️
 
 ## Availability
 


### PR DESCRIPTION
The next Arch Linux MR for `official-images` will contain a new tag: `multilib-devel`. This PR updates the description to reference that.