### PR TITLE
Typo fixes

### DIFF
--- a/amazonlinux/content.md
+++ b/amazonlinux/content.md
@@ -23,7 +23,7 @@ Note that Docker Hub's vulnerability scanning for Amazon Linux is currently base
 ## What is Amazon Linux 2023?
 
 -	Amazon Linux 2023: https://aws.amazon.com/linux/amazon-linux-2023/
--	2023.0 Release Notes: https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html
+-	2023 Release Notes: https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html
 -	FAQs: https://aws.amazon.com/linux/amazon-linux-2023/faqs/
 -	What's New: https://aws.amazon.com/about-aws/whats-new/2023/03/amazon-linux-2023/
 -	User Guide: https://docs.aws.amazon.com/linux/al2023/ug/what-is-amazon-linux.html

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -90,7 +90,7 @@ FROM %%IMAGE%%:<version>
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 ```
 
-Note the second `FROM` instruction - this produces a much smaller image by simply overlaying the newly-built binary on top of the the regular `%%IMAGE%%` image.
+Note the second `FROM` instruction - this produces a much smaller image by simply overlaying the newly-built binary on top of the regular `%%IMAGE%%` image.
 
 The [`xcaddy`](https://caddyserver.com/docs/build#xcaddy) tool is used to [build a new Caddy entrypoint](https://github.com/caddyserver/caddy/blob/4217217badf220d7d2c25f43f955fdc8454f2c64/cmd/caddy/main.go#L15..L25), with the provided modules. You can specify just a module name, or a name with a version (separated by `@`). You can also specify a specific version (can be a version tag or commit hash) of Caddy to build from. Read more about [`xcaddy` usage](https://github.com/caddyserver/xcaddy#command-usage).
 

--- a/cassandra/content.md
+++ b/cassandra/content.md
@@ -80,7 +80,7 @@ There are a small number of environment variables supported by the image which w
 
 -	`CASSANDRA_START_RPC`: This variable is for controlling if the thrift rpc server is started. It will set the [`start_rpc`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__start_rpc) option in `cassandra.yaml`.
 
--	`CASSANDRA_SEEDS`: This variable is the comma-separated list of IP addresses used by gossip for bootstrapping new nodes joining a cluster. It will set the `seeds` value of the [`seed_provider`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__seed_provider) option in `cassandra.yaml`. The `CASSANDRA_BROADCAST_ADDRESS` will be added the the seeds passed in so that the server will talk to itself as well.
+-	`CASSANDRA_SEEDS`: This variable is the comma-separated list of IP addresses used by gossip for bootstrapping new nodes joining a cluster. It will set the `seeds` value of the [`seed_provider`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__seed_provider) option in `cassandra.yaml`. The `CASSANDRA_BROADCAST_ADDRESS` will be added the seeds passed in so that the server will talk to itself as well.
 
 -	`CASSANDRA_CLUSTER_NAME`: This variable sets the name of the cluster and must be the same for all nodes in the cluster. It will set the [`cluster_name`](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__cluster_name) option of `cassandra.yaml`.
 

--- a/drupal/stack.yml
+++ b/drupal/stack.yml
@@ -15,7 +15,7 @@ version: '3.1'
 services:
 
   drupal:
-    image: drupal:8-apache
+    image: drupal:10-apache
     ports:
       - 8080:80
     volumes:
@@ -29,7 +29,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres:10
+    image: postgres:16
     environment:
       POSTGRES_PASSWORD: example
     restart: always

--- a/ghost/stack.yml
+++ b/ghost/stack.yml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
 
   ghost:
-    image: ghost:4-alpine
+    image: ghost:5-alpine
     restart: always
     ports:
       - 8080:2368

--- a/joomla/stack.yml
+++ b/joomla/stack.yml
@@ -13,7 +13,7 @@ services:
       JOOMLA_DB_PASSWORD: example
 
   joomladb:
-    image: mysql:5.6
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example

--- a/lightstreamer/content.md
+++ b/lightstreamer/content.md
@@ -43,7 +43,7 @@ Alternatively, the above tasks can be executed by deriving a new image through a
 ```dockerfile
 FROM %%IMAGE%%
 
-# Please specify a COPY command only for the the required custom configuration file
+# Please specify a COPY command only for the required custom configuration file
 COPY my-lightstreamer_conf.xml /lightstreamer/conf/lightstreamer_conf.xml
 COPY my-lightstreamer_log_conf.xml /lightstreamer/conf/lightstreamer_log_conf.xml
 ```

--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -278,7 +278,7 @@ Then run `docker-compose up -d`, now you can access Nextcloud at http://localhos
 
 ## Base version - FPM
 
-When using the FPM image, you need another container that acts as web server on port 80 and proxies the requests to the Nextcloud container. In this example a simple nginx container is combined with the Nextcloud-fpm image and a MariaDB database container. The data is stored in docker volumes. The nginx container also needs access to static files from your Nextcloud installation. It gets access to all the volumes mounted to Nextcloud via the `volumes_from` option.The configuration for nginx is stored in the configuration file `nginx.conf`, that is mounted into the container. An example can be found in the examples section [here](https://github.com/nextcloud/docker/tree/master/.examples).
+When using the FPM image, you need another container that acts as web server on port 80 and proxies the requests to the Nextcloud container. In this example a simple nginx container is combined with the Nextcloud-fpm image and a MariaDB database container. The data is stored in docker volumes. The nginx container also needs access to static files from your Nextcloud installation. It gets access to all the volumes mounted to Nextcloud via the `volumes_from` option. The configuration for nginx is stored in the configuration file `nginx.conf`, that is mounted into the container. An example can be found in the examples section [here](https://github.com/nextcloud/docker/tree/master/.examples).
 
 As this setup does **not include encryption**, it should be run behind a proxy.
 

--- a/postfixadmin/stack.yml
+++ b/postfixadmin/stack.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 1

--- a/redmine/stack.yml
+++ b/redmine/stack.yml
@@ -13,7 +13,7 @@ services:
       REDMINE_SECRET_KEY_BASE: supersecretkey
 
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example

--- a/satosa/content.md
+++ b/satosa/content.md
@@ -62,7 +62,7 @@ SATOSA uses encrypted cookies to track the progress of an authentication flow. T
 
 ### `SAML2_BACKEND_DISCO_SRV`
 
-When part of a SAML2 multilateral federation, SATOSA will ask the user to choose an identity provider using a SAML discovery service. This environment variable optionally sets the the discovery service URL, which defaults to [SeamlessAccess](https://seamlessaccess.org/).
+When part of a SAML2 multilateral federation, SATOSA will ask the user to choose an identity provider using a SAML discovery service. This environment variable optionally sets the discovery service URL, which defaults to [SeamlessAccess](https://seamlessaccess.org/).
 
 ### `SAML2_BACKEND_CERT` and `SAML2_BACKEND_KEY`
 

--- a/wordpress/stack.yml
+++ b/wordpress/stack.yml
@@ -16,7 +16,7 @@ services:
       - wordpress:/var/www/html
 
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_DATABASE: exampledb


### PR DESCRIPTION
And some `stack.yml` version updates.

Carry/fix all these PRs that changed `README` instead of `content`:
- fixes https://github.com/docker-library/docs/pull/2357
- fixes https://github.com/docker-library/docs/pull/2381
- fixes https://github.com/docker-library/docs/pull/2382
- fixes https://github.com/docker-library/docs/pull/2336