### PR TITLE
update: registry readme

### DIFF
--- a/registry/content.md
+++ b/registry/content.md
@@ -2,7 +2,7 @@
 
 %%LOGO%%
 
-This image contains an implementation of the Docker Registry HTTP API V2 for use with Docker 1.6+. See [github.com/distribution/distribution](https://github.com/distribution/distribution) for more details about what it is.
+This image contains an implementation of the OCI Distribution spec. See [github.com/opencontainers/distribution-spec](https://github.com/opencontainers/distribution-spec) for more details about what it is. You can find the full source code in [github.com/distribution/distribution](https://github.com/distribution/distribution).
 
 ## Run a local registry: Quick Version
 


### PR DESCRIPTION
Replace references to Docker HTTP API V2 with OCI distribution spec links.

CC: @thaJeztah 