### PR TITLE
nginx: Update command to generate host config file

### DIFF
--- a/nginx/content.md
+++ b/nginx/content.md
@@ -42,9 +42,7 @@ You can mount your configuration file, or build a new image with it.
 If you wish to adapt the default configuration, use something like the following to get it from a running nginx container:
 
 ```console
-$ docker run --name tmp-nginx-container -d %%IMAGE%%
-$ docker cp tmp-nginx-container:/etc/nginx/nginx.conf /host/path/nginx.conf
-$ docker rm -f tmp-nginx-container
+$ docker run --rm --entrypoint=cat nginx /etc/nginx/nginx.conf > /host/path/nginx.conf
 ```
 
 And then edit `/host/path/nginx.conf` in your host file system.

--- a/nginx/content.md
+++ b/nginx/content.md
@@ -42,7 +42,7 @@ You can mount your configuration file, or build a new image with it.
 If you wish to adapt the default configuration, use something like the following to get it from a running nginx container:
 
 ```console
-$ docker run --rm --entrypoint=cat nginx /etc/nginx/nginx.conf > /host/path/nginx.conf
+$ docker run --rm --entrypoint=cat %%IMAGE%% /etc/nginx/nginx.conf > /host/path/nginx.conf
 ```
 
 And then edit `/host/path/nginx.conf` in your host file system.


### PR DESCRIPTION
Currently, instructions to copy the default configuration from the nginx container to the host uses three commands. This can be done more efficiently with one command (assuming the presence of "cat" in the container which should be a safe).

Update the instructions to use the single command.