### PR TITLE
fix(influxdb-v2): Revise and update image description and v2 instructions

### DIFF
--- a/influxdb/README-short.txt
+++ b/influxdb/README-short.txt
@@ -1,1 +1,1 @@
-InfluxDB is an open source time series database for recording metrics, events, and analytics.
+InfluxDB is the open source time series database built for real-time analytic workloads.

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -550,7 +550,7 @@ Inserting into the DB:
 curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
-Read more about this in the [official documentation](https://docs.influxdata.com/influxdb/latest/guides/writing_data/)
+Read more about this in the [official documentation](https://docs.influxdata.com/influxdb/latest/guides/writing_data/).
 
 CLI / SHELL
 -----------

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -77,7 +77,7 @@ Replace the following with your own values:
 
 ### Automated setup options
 
-In setup mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or upgrade mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`), InfluxDB supports the following Docker-specific environment variables:
+In setup mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or upgrade mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`), you can specify the following Docker-specific environment variables to provide initial setup values:
 
 -	`DOCKER_INFLUXDB_INIT_USERNAME`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
 -	`DOCKER_INFLUXDB_INIT_PASSWORD`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -1,20 +1,21 @@
-# What is InfluxDB?
+What is InfluxDB?
+=================
 
-InfluxDB is the time series platform designed to handle high write and query loads.
-InfluxDB enables real-time analytics by serving as a purpose-built database that optimizes processing and scaling for large time series data workloads.
-Using InfluxDB, you can collect, store, and process large amounts of timestamped data, including metrics and events for use cases such as DevOps monitoring, application metrics, IoT sensors, and event monitoring.
+InfluxDB is the time series data platform designed to handle high write and query workloads. Using InfluxDB, you can collect, store, and process large amounts of timestamped data, including metrics and events for use cases such as DevOps monitoring, application metrics, IoT sensors, and event monitoring.
+
+Use the InfluxDB Docker Hub image to write, query, and process time series data in [InfluxDB v2](https://docs.influxdata.com/influxdb/v2/) or [InfluxDB v1](https://docs.influxdata.com/influxdb/v1/).
 
 For more information, visit https://influxdata.com.
 
 %%LOGO%%
 
-Use the InfluxDB Docker Hub image to run and set up [InfluxDB v2](https://docs.influxdata.com/influxdb/v2/) or [InfluxDB v1](https://docs.influxdata.com/influxdb/v1/) to write and query time series data.
-
-# How to use this image for InfluxDB OSS v2
+How to use this image for InfluxDB OSS v2
+=========================================
 
 **Quick start**: See the guide to [Install InfluxDB v2 for Docker](https://docs.influxdata.com/influxdb/v2/install/?t=Docker) and get started using InfluxDB v2.
 
-## Start InfluxDB v2 and set up with the UI, CLI, or API
+Start InfluxDB v2 and set up with the UI, CLI, or API
+-----------------------------------------------------
 
 To start an InfluxDB v2 container that you can then set up using the included UI, the `influx` CLI, or the HTTP API, enter the following command:
 
@@ -28,32 +29,30 @@ docker run \
 
 Replace the following with your own values:
 
-- `$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
-- `$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+-	`$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+-	`$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
 
-After the container starts, the UI and API are accessible at http://localhost:8086 on the host.
-You're ready to set up an initial admin user, token, and bucket from outside or inside the container--choose one of the following:
+After the container starts, the UI and API are accessible at http://localhost:8086 on the host. You're ready to set up an initial admin user, token, and bucket from outside or inside the container--choose one of the following:
 
-- **Set up InfluxDB from outside the container**:
-[Set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) from the host or network using the UI, `influx` CLI, or HTTP API.
+-	**Set up InfluxDB from outside the container**:[Set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) from the host or network using the UI, `influx` CLI, or HTTP API.
 
-- **Set up InfluxDB from inside the container**:
-Use `docker exec` to run the `influx` CLI installed in the container--for example:
+-	**Set up InfluxDB from inside the container**: Use `docker exec` to run the `influx` CLI installed in the container--for example:
 
-  ```console
-  docker exec influxdb2 influx setup \
-      --username $USERNAME \
-      --password $PASSWORD \
-      --org $ORGANIZATION \
-      --bucket $BUCKET \
-      --force
-  ```
+	```console
+	docker exec influxdb2 influx setup \
+	  --username $USERNAME \
+	  --password $PASSWORD \
+	  --org $ORGANIZATION \
+	  --bucket $BUCKET \
+	  --force
+	```
 
-  See the [`influx setup` documentation](https://docs.influxdata.com/influxdb/v2/reference/cli/influx/setup/) for the full list of options.
+See the [`influx setup` documentation](https://docs.influxdata.com/influxdb/v2/reference/cli/influx/setup/) for the full list of options.
 
-  _If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file._
+*If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file.*
 
-## Start InfluxDB v2 with automated setup
+Start InfluxDB v2 with automated setup
+--------------------------------------
 
 To start and set up InfluxDB v2 with a single command, specify `-e DOCKER_INFLUXDB_INIT_MODE=setup` and `-e DOCKER_INFLUXDB_INIT_` environment variables for the initial user, password, bucket, and organization--for example:
 
@@ -71,27 +70,25 @@ docker run -d -p 8086:8086 \
 
 Replace the following with your own values:
 
-- `$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
-- `$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
-- `<USERNAME>`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
-- `<PASSWORD>`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
-- `<ORG_NAME>`: A name for your initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/)
-- `<BUCKET_NAME>`: A name for your initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/) (database)
+-	`$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+-	`$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+-	`<USERNAME>`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+-	`<PASSWORD>`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+-	`<ORG_NAME>`: A name for your initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/)
+-	`<BUCKET_NAME>`: A name for your initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/) (database)
 
-_If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file._
+*If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file.*
 
 ### Automated setup options
 
 In setup mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or upgrade mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`), InfluxDB supports the following Docker-specific environment variables:
 
-- `DOCKER_INFLUXDB_INIT_USERNAME`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
-- `DOCKER_INFLUXDB_INIT_PASSWORD`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
-- `DOCKER_INFLUXDB_INIT_ORG`: A name for your initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/).
-- `DOCKER_INFLUXDB_INIT_BUCKET`: A name for your initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/).
-- Optional: `DOCKER_INFLUXDB_INIT_RETENTION`: A [duration](https://docs.influxdata.com/influxdb/v2/reference/glossary/#duration) to use as the initial bucket's [retention period](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/#bucket-retention-period).
-  Default: `0` (infinite; doesn't delete data).
-- Optional: `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: A string value to set for the [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token).
-  Default: a generated token.
+-	`DOCKER_INFLUXDB_INIT_USERNAME`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
+-	`DOCKER_INFLUXDB_INIT_PASSWORD`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
+-	`DOCKER_INFLUXDB_INIT_ORG`: A name for your initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/).
+-	`DOCKER_INFLUXDB_INIT_BUCKET`: A name for your initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/).
+-	Optional: `DOCKER_INFLUXDB_INIT_RETENTION`: A [duration](https://docs.influxdata.com/influxdb/v2/reference/glossary/#duration) to use as the initial bucket's [retention period](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/#bucket-retention-period). Default: `0` (infinite; doesn't delete data).
+-	Optional: `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: A string value to set for the [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token). Default: a generated token.
 
 The following example shows how to pass values for all initial setup options:
 
@@ -109,41 +106,37 @@ docker run -d -p 8086:8086 \
     %%IMAGE%%:2
 ```
 
-_To upgrade from InfluxDB 1.x to InfluxDB 2.x, see the **Upgrading from InfluxDB 1.x** section below._
+*To upgrade from InfluxDB 1.x to InfluxDB 2.x, see the **Upgrading from InfluxDB 1.x** section below.\*
 
 With InfluxDB set up and running, see the [Get started](https://docs.influxdata.com/influxdb/v2/get-started/) tutorial to create tokens and write and query data.
 
 ### Custom Initialization Scripts
 
-In `setup` mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or `upgrade` mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`),
-the InfluxDB Docker Hub image supports running custom initialization scripts.
-After the setup process completes, scripts are executed in lexical sort order by name.
+In `setup` mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or `upgrade` mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`), the InfluxDB Docker Hub image supports running custom initialization scripts. After the setup process completes, scripts are executed in lexical sort order by name.
 
 For the container to run scripts, they must:
 
-- Be mounted in the container's `/docker-entrypoint-initdb.d` directory
-- Be named using the `.sh` file name extension
-- Be executable by the user running the `docker run` command--for example, to allow the current use to execute a script with `docker run`:
-  
-  ```console
-  chmod +x ./scripts/<yourscript.sh>
-  ```
+-	Be mounted in the container's `/docker-entrypoint-initdb.d` directory
+-	Be named using the `.sh` file name extension
+-	Be executable by the user running the `docker run` command--for example, to allow the current use to execute a script with `docker run`:
+
+	```console
+	chmod +x ./scripts/<yourscript.sh>
+	```
 
 > #### Grant permissions to mounted files
 >
-> By default, Docker runs containers using the user and group IDs of the user executing the `docker run` command.
-> When files are bind mounted into the container, Docker preserves the user and group ownership from the host system.
+> By default, Docker runs containers using the user and group IDs of the user executing the `docker run` command. When files are bind mounted into the container, Docker preserves the user and group ownership from the host system.
 
-The image exports a number of variables into the environment before executing scripts.
-The following variables are available for you to use in your scripts:
+The image exports a number of variables into the environment before executing scripts. The following variables are available for you to use in your scripts:
 
-- `INFLUX_CONFIGS_PATH`: Path to the `influx` CLI connection configurations file written by `setup`/`upgrade`
-- `INFLUX_HOST`: URL to the `influxd` instance running `setup`/`upgrade`
-- `DOCKER_INFLUXDB_INIT_USER_ID`: ID of the initial admin user created by `setup`/`upgrade`
-- `DOCKER_INFLUXDB_INIT_ORG_ID`: ID of the initial organization created by `setup`/`upgrade`
-- `DOCKER_INFLUXDB_INIT_BUCKET_ID`: ID of the initial bucket created by `setup`/`upgrade`
+-	`INFLUX_CONFIGS_PATH`: Path to the `influx` CLI connection configurations file written by `setup`/`upgrade`
+-	`INFLUX_HOST`: URL to the `influxd` instance running `setup`/`upgrade`
+-	`DOCKER_INFLUXDB_INIT_USER_ID`: ID of the initial admin user created by `setup`/`upgrade`
+-	`DOCKER_INFLUXDB_INIT_ORG_ID`: ID of the initial organization created by `setup`/`upgrade`
+-	`DOCKER_INFLUXDB_INIT_BUCKET_ID`: ID of the initial bucket created by `setup`/`upgrade`
 
-For example, to grant an InfluxDB 1.x client _write_ permission to your initial bucket, create a `$PWD/scripts/setup-v1.sh` file that contains the following:
+For example, to grant an InfluxDB 1.x client *write* permission to your initial bucket, create a `$PWD/scripts/setup-v1.sh` file that contains the following:
 
 ```bash
 #!/bin/bash
@@ -188,28 +181,30 @@ docker run -p 8086:8086 \
 >
 > This behavior allows for the InfluxDB container to reboot post-setup and avoid overwriting migrated data, `DB is already set up` errors, and errors from non-idempotent script commands.
 
-## Access InfluxDB v2 file system and ports
+Access InfluxDB v2 file system and ports
+----------------------------------------
 
 When starting an InfluxDB container, we recommend the following for easy access to your data, configurations, and InfluxDB v2 instance:
 
-- Publish the container's `8086` port to make the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) accessible from the host system.
-- Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) outside containers.
+-	Publish the container's `8086` port to make the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) accessible from the host system.
+-	Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) outside containers.
 
 ### Default file system and networking ports
 
 For InfluxDB v2, the InfluxDB Docker Hub image uses the following default ports and file system paths:
 
-- TCP port `8086`: the default port for the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/).
-  To specify a different port or address, use the [`http-bind-address` configuration option](https://docs.influxdata.com/influxdb/v2/reference/config-options/#http-bind-address).
-- `/var/lib/influxdb2/`: the [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout)
-  - `/engine/`: Default InfluxDB [Storage engine path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#engine-path)
-  - `influxd.bolt`: Default [Bolt path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#bolt-path)
-  - `influxd.sqlite`: Default [SQLite path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#sqlite-path)
+-	TCP port `8086`: the default port for the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/). To specify a different port or address, use the [`http-bind-address` configuration option](https://docs.influxdata.com/influxdb/v2/reference/config-options/#http-bind-address).
+-	`/var/lib/influxdb2/`: the [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout)
 
-- `/etc/influxdb2`: the [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout)
-  - `/etc/influxdb2/configs`: `influx` CLI connection configurations file
-  - `/etc/influxdb2/influx-configs`: `influx` CLI connection configurations file, _if you run setup from within the container_
-  - Optional: `/etc/influxdb2/config.[yml, json, toml]`: Your customized InfluxDB [configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/) file
+	-	`/engine/`: Default InfluxDB [Storage engine path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#engine-path)
+	-	`influxd.bolt`: Default [Bolt path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#bolt-path)
+	-	`influxd.sqlite`: Default [SQLite path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#sqlite-path)
+
+-	`/etc/influxdb2`: the [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout)
+
+	-	`/etc/influxdb2/configs`: `influx` CLI connection configurations file
+	-	`/etc/influxdb2/influx-configs`: `influx` CLI connection configurations file, *if you run setup from within the container*
+	-	Optional: `/etc/influxdb2/config.[yml, json, toml]`: Your customized InfluxDB [configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/) file
 
 ### Configure InfluxDB v2 in a container
 
@@ -219,85 +214,81 @@ To customize InfluxDB, specify [server configuration options](https://docs.influ
 
 To customize and mount an InfluxDB configuration file, do the following:
 
-1. If you haven't already, [set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) to initialize an API [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token).
-   You'll need the Operator token in the next step.
+1.	If you haven't already, [set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) to initialize an API [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token). You'll need the Operator token in the next step.
 
-2. Run the `influx server-config` CLI command to output the current server configuration to a file in the mounted configuration directory--for example, enter the following command to use the container's `influx` CLI and default Operator token:
+2.	Run the `influx server-config` CLI command to output the current server configuration to a file in the mounted configuration directory--for example, enter the following command to use the container's `influx` CLI and default Operator token:
 
-   ```sh
-   docker exec -it influxdb2 influx server-config > $PWD/config/config.yml
-   ```
+	```sh
+	docker exec -it influxdb2 influx server-config > $PWD/config/config.yml
+	```
 
-   Replace `$PWD/config/` with the host directory that you mounted at the container's `/etc/influxdb2` InfluxDB configuration directory path.
+Replace `$PWD/config/` with the host directory that you mounted at the container's `/etc/influxdb2` InfluxDB configuration directory path.
 
-3. Edit the `config.yml` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
-4. Restart the container.
+1.	Edit the `config.yml` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
+2.	Restart the container.
 
-   ```sh
-   docker restart influxdb2
-   ```
+	```sh
+	docker restart influxdb2
+	```
 
 #### Use environment variables and command line flags
 
 To override specific [configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options), use environment variables or command line flags.
 
-- Pass `INFLUXD_` environment variables to Docker to override the configuration file--for example:
+-	Pass `INFLUXD_` environment variables to Docker to override the configuration file--for example:
 
-  ```sh
-  docker run -p 8086:8086 \
-    -e INFLUXD_STORAGE_WAL_FSYNC_DELAY=15m \
-    influxdb:2 
-  ```
+	```sh
+	docker run -p 8086:8086 \
+	-e INFLUXD_STORAGE_WAL_FSYNC_DELAY=15m \
+	influxdb:2 
+	```
 
-- Pass `influxd` command line flags to override environment variables and the configuration file--for example:
+-	Pass `influxd` command line flags to override environment variables and the configuration file--for example:
 
-  ```console
-  docker run -p 8086:8086 \
-      %%IMAGE%%:2 --storage-wal-fsync-delay=15m
-  ```
+	```console
+	docker run -p 8086:8086 \
+	  %%IMAGE%%:2 --storage-wal-fsync-delay=15m
+	```
 
 To learn more, see [InfluxDB configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options).
 
 ### Upgrading from InfluxDB 1.x
 
-InfluxDB 2.x provides a [1.x-compatible API](https://docs.influxdata.com/influxdb/v2/reference/api/influxdb-1x/), but expects a different storage layout on disk.
-To account for these differences, the InfluxDB Docker Hub image provides an `upgrade` feature that migrates 1.x data and configuration to 2.x before starting the `influxd` server.
+InfluxDB 2.x provides a [1.x-compatible API](https://docs.influxdata.com/influxdb/v2/reference/api/influxdb-1x/), but expects a different storage layout on disk. To account for these differences, the InfluxDB Docker Hub image provides an `upgrade` feature that migrates 1.x data and configuration to 2.x before starting the `influxd` server.
 
 The automated upgrade process creates the following in the InfluxDB v2 container:
 
-- an initial admin user
-- an initial organization
-- an initial bucket
-- InfluxDB v2 data files (the default path is `/var/lib/influxdb2`)
-- InfluxDB v2 configuration files (the default path is `/etc/influxdb2`)
+-	an initial admin user
+-	an initial organization
+-	an initial bucket
+-	InfluxDB v2 data files (the default path is `/var/lib/influxdb2`\)
+-	InfluxDB v2 configuration files (the default path is `/etc/influxdb2`\)
 
-_Mount volumes at both paths to avoid losing data._
+*Mount volumes at both paths to avoid losing data.*
 
 To run the automated upgrade, specify the following when you start the container:
 
-- InfluxDB v2 initialization environment variables:
+-	InfluxDB v2 initialization environment variables:
 
-  - `DOCKER_INFLUXDB_INIT_MODE=upgrade`
-  - `DOCKER_INFLUXDB_INIT_USERNAME`: A name for the initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
-  - `DOCKER_INFLUXDB_INIT_PASSWORD`: A password for the initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
-  - `DOCKER_INFLUXDB_INIT_ORG`: A name for the initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/)
-  - `DOCKER_INFLUXDB_INIT_BUCKET`: A name for the initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/)
-  - Optional: `DOCKER_INFLUXDB_INIT_RETENTION`: A [duration](https://docs.influxdata.com/influxdb/v2/reference/glossary/#duration) for the bucket [retention period](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/#bucket-retention-period).
-    Default: `0` (infinite; doesn't delete data)
-  - Optional: `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: A value to set for the [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token).
-    Default: generates a token.
+	-	`DOCKER_INFLUXDB_INIT_MODE=upgrade`
+	-	`DOCKER_INFLUXDB_INIT_USERNAME`: A name for the initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+	-	`DOCKER_INFLUXDB_INIT_PASSWORD`: A password for the initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+	-	`DOCKER_INFLUXDB_INIT_ORG`: A name for the initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/)
+	-	`DOCKER_INFLUXDB_INIT_BUCKET`: A name for the initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/)
+	-	Optional: `DOCKER_INFLUXDB_INIT_RETENTION`: A [duration](https://docs.influxdata.com/influxdb/v2/reference/glossary/#duration) for the bucket [retention period](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/#bucket-retention-period). Default: `0` (infinite; doesn't delete data)
+	-	Optional: `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: A value to set for the [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token). Default: generates a token.
 
-- 1.x data and configuration paths:
+-	1.x data and configuration paths:
 
-  - A 1.x data volume, specified by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable or mounted at `/var/lib/influxdb`
-  - Optional: a 1.x custom configuration file, specified by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable or mounted at `/etc/influxdb/influxdb.conf`
+	-	A 1.x data volume, specified by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable or mounted at `/var/lib/influxdb`
+	-	Optional: a 1.x custom configuration file, specified by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable or mounted at `/etc/influxdb/influxdb.conf`
 
 The upgrade process searches for mounted 1.x data and configuration paths in the following order of precedence:
 
-1. A configuration file referenced by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable
-2. A data directory referenced by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable
-3. A configuration file mounted at `/etc/influxdb/influxdb.conf`
-4. A data directory mounted at `/var/lib/influxdb`
+1.	A configuration file referenced by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable
+2.	A data directory referenced by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable
+3.	A configuration file mounted at `/etc/influxdb/influxdb.conf`
+4.	A data directory mounted at `/var/lib/influxdb`
 
 > #### Automated setup and upgrade ignored if already setup
 >
@@ -315,8 +306,7 @@ docker run -p 8086:8086 \
     %%IMAGE%%:1.8
 ```
 
-To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container,
-and then run the following command:
+To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container, and then run the following command:
 
 ```console
 docker run -p 8086:8086 \
@@ -332,7 +322,7 @@ docker run -p 8086:8086 \
 
 #### Upgrade InfluxDB 1.x: custom configuration
 
-Assume you've been running an InfluxDB 1.x deployment with customized configuration (`/etc/influxdb/influxdb.conf`):
+Assume you've been running an InfluxDB 1.x deployment with customized configuration (`/etc/influxdb/influxdb.conf`\):
 
 ```console
 docker run -p 8086:8086 \
@@ -341,8 +331,7 @@ docker run -p 8086:8086 \
     %%IMAGE%%:1.8
 ```
 
-To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container,
-and then run the following command:
+To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container, and then run the following command:
 
 ```console
 docker run -p 8086:8086 \
@@ -412,11 +401,9 @@ To learn more about the upgrade process, see the [v1-to-v2 upgrade guide](https:
 
 ### Upgrading from quay.io-hosted InfluxDB 2.x image
 
-Early Docker builds of InfluxDB 2.x were hosted at `quay.io/influxdb/influxdb` and contained the `influx` and `influxd` binaries without any default configuration or helper scripts.
-By default, the `influxd` process stored data in `/root/.influxdbv2`.
+Early Docker builds of InfluxDB 2.x were hosted at `quay.io/influxdb/influxdb` and contained the `influx` and `influxd` binaries without any default configuration or helper scripts. By default, the `influxd` process stored data in `/root/.influxdbv2`.
 
-Starting with `v2.0.4`, we restored the InfluxDB Docker Hub build, which defaults to storing data in `/var/lib/influxdb2`.
-If you upgrade directly from `quay.io/influxdb/influxdb` to `influxdb:2.0.4` using the default settings, InfluxDB won't be able to find your existing data files.
+Starting with `v2.0.4`, we restored the InfluxDB Docker Hub build, which defaults to storing data in `/var/lib/influxdb2`. If you upgrade directly from `quay.io/influxdb/influxdb` to `influxdb:2.0.4` using the default settings, InfluxDB won't be able to find your existing data files.
 
 To avoid this problem when migrating from `quay.io/influxdb/influxdb` to `influxdb:2.0`, choose one of the following:
 
@@ -461,7 +448,8 @@ docker run -p 8086:8086 \
       %%IMAGE%%:2
 ```
 
-# How to use this image for InfluxDB v1
+How to use this image for InfluxDB v1
+=====================================
 
 Use the InfluxDB Docker Hub image to run and set up an [InfluxDB 1.x](https://docs.influxdata.com/influxdb/v1/) container.
 
@@ -477,19 +465,19 @@ docker run -p 8086:8086 \
 
 The command passes the following arguments:
 
-- `-p 8086:8086`: Exposes the InfluxDB [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) on host port `8086`.
-- `-v $PWD:/var/lib/influxdb`: Mounts the host's `$PWD` directory to the [InfluxDB data directory](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/) to persist data outside the container.
+-	`-p 8086:8086`: Exposes the InfluxDB [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) on host port `8086`.
+-	`-v $PWD:/var/lib/influxdb`: Mounts the host's `$PWD` directory to the [InfluxDB data directory](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/) to persist data outside the container.
 
 Replace `$PWD` with the host directory where you want InfluxDB to store data.
 
-_Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/)._
+*Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/).*
 
 ### Networking ports
 
 InfluxDB uses the following networking ports:
 
-- TCP port `8086`: the default port for the [HTTP API](https://docs.influxdata.com/influxdb/v1/tools/api/)
-- TCP port `2003`: the port for the Graphite protocol (if enabled)
+-	TCP port `8086`: the default port for the [HTTP API](https://docs.influxdata.com/influxdb/v1/tools/api/)
+-	TCP port `2003`: the port for the Graphite protocol (if enabled)
 
 Using the `docker run` [`-P, --publish-all` flag](https://docs.docker.com/reference/cli/docker/container/run/#publish-all) exposes the InfluxDB HTTP API to the host.
 
@@ -501,26 +489,25 @@ To configure InfluxDB v1 in a container, use a configuration file or environment
 
 To customize and mount a configuration file, do the following:
 
-1. Output the current server configuration to a file in the mounted configuration directory--for example:
+1.	Output the current server configuration to a file in the mounted configuration directory--for example:
 
-   ```console
-   docker run --rm %%IMAGE%%:1.8 influxd config > influxdb.conf
-   ```
+	```console
+	docker run --rm %%IMAGE%%:1.8 influxd config > influxdb.conf
+	```
 
-2. Edit the `influxdb.conf` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
+2.	Edit the `influxdb.conf` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
 
-   ```console
-   docker run -p 8086:8086 \
-       -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
-       %%IMAGE%%:1.8 -config /etc/influxdb/influxdb.conf
-   ```
+	```console
+	docker run -p 8086:8086 \
+	  -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
+	  %%IMAGE%%:1.8 -config /etc/influxdb/influxdb.conf
+	```
 
-   Replace `$PWD` with the host directory where you want to store the configuration file.
+	Replace `$PWD` with the host directory where you want to store the configuration file.
 
 #### Use environment variables
 
-Pass [`INFLUXDB_` environment variables](https://docs.influxdata.com/influxdb/v1/administration/config/#environment-variables) to override specific InfluxDB v1 configuration options.
-An environment variable overrides the equivalent option in the configuration file.
+Pass [`INFLUXDB_` environment variables](https://docs.influxdata.com/influxdb/v1/administration/config/#environment-variables) to override specific InfluxDB v1 configuration options. An environment variable overrides the equivalent option in the configuration file.
 
 ```console
 docker run -p 8086:8086 \

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -573,16 +573,18 @@ Or run the influx client in a separate container:
 docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
 ```
 
-Database Initialization
------------------------
+InfluxDB v1 database initialization
+-----------------------------------
 
-The InfluxDB image contains some extra functionality for initializing a database. These options are not suggested for production, but are quite useful when running standalone instances for testing.
+The InfluxDB Docker Hub image lets you set initialization options when creating an InfluxDB v1 container.
 
-The database initialization script will only be called when running `influxd`. It will not be executed when running any other program.
+**WARNING**: We **don't** recommend using these options for production scenarios, but they're useful when running standalone instances for testing.
 
-### Environment Variables
+The database initialization script is only called when running `influxd`.
 
-The InfluxDB image uses several environment variables to automatically configure certain parts of the server. They may significantly aid you in using this image.
+### Environment variables
+
+During the InfluxDB v1 set up process, the InfluxDB image uses environment variables to automatically configure some server options. You can override the following environment variables to customize set up options.
 
 #### INFLUXDB_DB
 
@@ -590,7 +592,7 @@ Automatically initializes a database with the name of this environment variable.
 
 #### INFLUXDB_HTTP_AUTH_ENABLED
 
-Enables authentication. Either this must be set or `auth-enabled = true` must be set within the configuration file for any authentication related options below to work.
+Enables authentication. Either this must be set or `auth-enabled = true` must be set within the configuration file for any authentication-related options below to work.
 
 #### INFLUXDB_ADMIN_USER
 
@@ -634,11 +636,13 @@ To manually initialize the database and exit, the `/init-influxdb.sh` script can
 
 ```console
 docker run --rm \
-   -e INFLUXDB_DB=db0 \
-   -e INFLUXDB_ADMIN_USER=admin -e INFLUXDB_ADMIN_PASSWORD=supersecretpassword \
-   -e INFLUXDB_USER=telegraf -e INFLUXDB_USER_PASSWORD=secretpassword \
-   -v $PWD:/var/lib/influxdb \
-   %%IMAGE%%:1.8 /init-influxdb.sh
+    -e INFLUXDB_DB=db0 \
+    -e INFLUXDB_ADMIN_USER=admin \
+    -e INFLUXDB_ADMIN_PASSWORD=supersecretpassword \
+    -e INFLUXDB_USER=telegraf -e \
+    -e INFLUXDB_USER_PASSWORD=secretpassword \
+    -v $PWD:/var/lib/influxdb \
+    %%IMAGE%%:1.8 /init-influxdb.sh
 ```
 
 The above would create the database `db0`, create an admin user with the password `supersecretpassword`, then create the `telegraf` user with your telegraf's secret password. It would then exit and leave behind any files it created in the volume that you mounted.

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -1,5 +1,4 @@
-What is InfluxDB?
-=================
+# What is InfluxDB?
 
 InfluxDB is the time series data platform designed to handle high write and query workloads. Using InfluxDB, you can collect, store, and process large amounts of timestamped data, including metrics and events for use cases such as DevOps monitoring, application metrics, IoT sensors, and event monitoring.
 
@@ -9,13 +8,11 @@ For more information, visit https://influxdata.com.
 
 %%LOGO%%
 
-How to use this image for InfluxDB v2
-=====================================
+# How to use this image for InfluxDB v2
 
 **Quick start**: See the guide to [Install InfluxDB v2 for Docker](https://docs.influxdata.com/influxdb/v2/install/?t=Docker) and get started using InfluxDB v2.
 
-Start InfluxDB v2 and set up with the UI, CLI, or API
------------------------------------------------------
+## Start InfluxDB v2 and set up with the UI, CLI, or API
 
 To start an InfluxDB v2 container that you can then set up using the included UI, the `influx` CLI, or the HTTP API, enter the following command:
 
@@ -51,8 +48,7 @@ See the [`influx setup` documentation](https://docs.influxdata.com/influxdb/v2/r
 
 *If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file.*
 
-Start InfluxDB v2 with automated setup
---------------------------------------
+## Start InfluxDB v2 with automated setup
 
 To start and set up InfluxDB v2 with a single command, specify `-e DOCKER_INFLUXDB_INIT_MODE=setup` and `-e DOCKER_INFLUXDB_INIT_` environment variables for the initial user, password, bucket, and organization--for example:
 
@@ -181,8 +177,7 @@ docker run -p 8086:8086 \
 >
 > This behavior allows for the InfluxDB container to reboot post-setup and avoid overwriting migrated data, `DB is already set up` errors, and errors from non-idempotent script commands.
 
-Access InfluxDB v2 file system and ports
-----------------------------------------
+## Access InfluxDB v2 file system and ports
 
 When starting an InfluxDB container, we recommend the following for easy access to your data, configurations, and InfluxDB v2 instance:
 
@@ -261,8 +256,8 @@ The automated upgrade process creates the following in the InfluxDB v2 container
 -	an initial admin user
 -	an initial organization
 -	an initial bucket
--	InfluxDB v2 data files (the default path is `/var/lib/influxdb2`\)
--	InfluxDB v2 configuration files (the default path is `/etc/influxdb2`\)
+-	InfluxDB v2 data files (the default path is `/var/lib/influxdb2`)
+-	InfluxDB v2 configuration files (the default path is `/etc/influxdb2`)
 
 *Mount volumes at both paths to avoid losing data.*
 
@@ -322,7 +317,7 @@ docker run -p 8086:8086 \
 
 #### Upgrade InfluxDB 1.x: custom configuration
 
-Assume you've been running an InfluxDB 1.x deployment with customized configuration (`/etc/influxdb/influxdb.conf`\):
+Assume you've been running an InfluxDB 1.x deployment with customized configuration (`/etc/influxdb/influxdb.conf`):
 
 ```console
 docker run -p 8086:8086 \
@@ -448,13 +443,11 @@ docker run -p 8086:8086 \
     %%IMAGE%%:2
 ```
 
-How to use this image for InfluxDB v1
-=====================================
+# How to use this image for InfluxDB v1
 
 Use the InfluxDB Docker Hub image to run and set up an [InfluxDB 1.x](https://docs.influxdata.com/influxdb/v1/) container.
 
-Running the container
----------------------
+## Running the container
 
 To start an InfluxDB 1.x container, enter the following command:
 
@@ -473,8 +466,7 @@ Replace `$PWD` with the host directory where you want InfluxDB to store data.
 
 *Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/).*
 
-Networking ports
-----------------
+## Networking ports
 
 InfluxDB uses the following networking ports:
 
@@ -483,8 +475,7 @@ InfluxDB uses the following networking ports:
 
 Using the `docker run` [`-P, --publish-all` flag](https://docs.docker.com/reference/cli/docker/container/run/#publish-all) exposes the InfluxDB HTTP API to the host.
 
-Configure InfluxDB v1 in a container
-------------------------------------
+## Configure InfluxDB v1 in a container
 
 To configure InfluxDB v1 in a container, use a configuration file or environment variables.
 
@@ -522,8 +513,7 @@ docker run -p 8086:8086 \
 
 Learn more about [configuring InfluxDB v1](https://docs.influxdata.com/influxdb/v1.8/administration/config/).
 
-Graphite
---------
+## Graphite
 
 InfluxDB supports the Graphite line protocol, but the service and ports are not exposed by default. To run InfluxDB with Graphite support enabled, you can either use a configuration file or set the appropriate environment variables. Run InfluxDB with the default Graphite configuration:
 
@@ -535,8 +525,7 @@ docker run -p 8086:8086 -p 2003:2003 \
 
 See the [README on GitHub](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) for more detailed documentation to set up the Graphite service. In order to take advantage of graphite templates, you should use a configuration file by outputting a default configuration file using the steps above and modifying the `[[graphite]]` section.
 
-InfluxDB v1 HTTP API
---------------------
+## InfluxDB v1 HTTP API
 
 Creating a DB named mydb:
 
@@ -552,8 +541,7 @@ curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_sho
 
 Read more about this in the [official documentation](https://docs.influxdata.com/influxdb/latest/guides/writing_data/).
 
-CLI / SHELL
------------
+## CLI / SHELL
 
 Start the container:
 
@@ -573,8 +561,7 @@ Or run the influx client in a separate container:
 docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
 ```
 
-InfluxDB v1 database initialization
------------------------------------
+## InfluxDB v1 database initialization
 
 ### Not recommended for production
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -1,194 +1,149 @@
-# InfluxDB
+# What is InfluxDB?
 
-InfluxDB is a time series database built from the ground up to handle high write and query loads. InfluxDB is meant to be used as a backing store for any use case involving large amounts of timestamped data, including DevOps monitoring, application metrics, IoT sensor data, and real-time analytics.
+InfluxDB is the time series platform designed to handle high write and query loads.
+InfluxDB enables real-time analytics by serving as a purpose-built database that optimizes processing and scaling for large time series data workloads.
+Using InfluxDB, you can collect, store, and process large amounts of timestamped data, including metrics and events for use cases such as DevOps monitoring, application metrics, IoT sensors, and event monitoring.
 
-[InfluxDB Documentation](https://docs.influxdata.com/influxdb/latest/)
+For more information, visit https://influxdata.com.
 
 %%LOGO%%
 
-## Using this Image - InfluxDB 2.x
+Use the InfluxDB Docker Hub image to run and set up [InfluxDB v2](https://docs.influxdata.com/influxdb/v2/) or [InfluxDB v1](https://docs.influxdata.com/influxdb/v1/) to write and query time series data.
 
-### Quick start
+# How to use this image for InfluxDB OSS v2
 
-Using this image is pretty easy, but there are a few things you should know.
+**Quick start**: See the guide to [Install InfluxDB v2 for Docker](https://docs.influxdata.com/influxdb/v2/install/?t=Docker) and get started using InfluxDB v2.
 
--	You should forward TCP port 8086
--	You should mount a volume in /var/lib/influxdb2
+## Start InfluxDB v2 and set up with the UI, CLI, or API
+
+To start an InfluxDB v2 container that you can then set up using the included UI, the `influx` CLI, or the HTTP API, enter the following command:
 
 ```console
-$ docker run \
-      -p 8086:8086 \
-      -v myInfluxVolume:/var/lib/influxdb2 \
-      %%IMAGE%%:latest
+docker run \
+    -p 8086:8086 \
+    -v $PWD/data:/var/lib/influxdb2 \
+    -v $PWD/config:/etc/influxdb2 \
+    %%IMAGE%%:2
 ```
 
-After starting the container you can use the web interface at http://localhost:8086/ to setup and customize your Influx database.
+Replace the following with your own values:
 
-Find more about API Endpoints & Ports [here](https://docs.influxdata.com/influxdb/v2.5/reference/api/).
+- `$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+- `$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
 
-### Configuration
+After the container starts, the UI and API are accessible at http://localhost:8086 on the host.
+You're ready to set up an initial admin user, token, and bucket from outside or inside the container--choose one of the following:
 
-InfluxDB can be configured using a mix of a config file, environment variables, and CLI options. To mount a configuration file and use it with the server, you can use this command to generate the default configuration file:
+- **Set up InfluxDB from outside the container**:
+[Set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) from the host or network using the UI, `influx` CLI, or HTTP API.
 
-```console
-$ docker run --rm %%IMAGE%%:2.0 influxd print-config > config.yml
-```
+- **Set up InfluxDB from inside the container**:
+Use `docker exec` to run the `influx` CLI installed in the container--for example:
 
-Modify the default configuration, which will now be available under `$PWD`. Then start the InfluxDB container:
-
-```console
-$ docker run -p 8086:8086 \
-      -v $PWD/config.yml:/etc/influxdb2/config.yml \
-      %%IMAGE%%:2.0
-```
-
-Modify `$PWD` to be the directory where you want to store the configuration file.
-
-Individual config settings can be overridden by environment variables. The variables must be named using the format `INFLUXD_${SNAKE_CASE_NAME}`. The `SNAKE_CASE_NAME` for an option will be the option's name with all dashes (`-`) replaced by underscores (`_`), in all caps.
-
-Examples:
-
-```console
-# Config setting: bolt-path
-INFLUXD_BOLT_PATH=/root/influxdb.bolt
-# Config setting: no-tasks
-INFLUXD_NO_TASKS=true
-# Config setting: storage-wal-fsync-delay
-INFLUXD_STORAGE_WAL_FSYNC_DELAY=15m
-```
-
-Finally, all config options can be passed as CLI options:
-
-```console
-$ docker run -p 8086:8086 \
-      %%IMAGE%%:2.0 --storage-wal-fsync-delay=15m
-```
-
-CLI options take precedence over environment variables.
-
-Find more about configuring InfluxDB [here](https://docs.influxdata.com/influxdb/v2.0/reference/config-options/).
-
-### Database Setup
-
-InfluxDB 2.x requires authentication. A special API exists to bootstrap the first super-user in the database, along with an initial organization and bucket. It's possible to access this API manually, or to run it automatically via environment variables.
-
-#### Manual Setup
-
-If your InfluxDB container is running locally (or on a host exposed to the network), you can perform initial setup from outside the container using either the UI or the `influx` CLI. Find more about setting up InfluxDB using these methods [here](https://docs.influxdata.com/influxdb/v2.0/get-started/#set-up-influxdb).
-
-It's also possible to perform manual setup from within the container using `docker exec`. For example, if you start the container:
-
-```console
-$ docker run -d -p 8086:8086 \
-      --name influxdb2 \
-      -v $PWD:/var/lib/influxdb2 \
-      %%IMAGE%%:2.0
-```
-
-You can then run the `influx` client in the container:
-
-```console
-$ docker exec influxdb2 influx setup \
+  ```console
+  docker exec influxdb2 influx setup \
       --username $USERNAME \
       --password $PASSWORD \
       --org $ORGANIZATION \
       --bucket $BUCKET \
       --force
-```
+  ```
 
-Running setup from within the container will cause CLI configs to be written to `/etc/influxdb2/influx-configs`. You can then use the `influx` CLI from within the container to extract the generated admin token:
+  See the [`influx setup` documentation](https://docs.influxdata.com/influxdb/v2/reference/cli/influx/setup/) for the full list of options.
 
-```console
-# Using table output + cut
-$ docker exec influxdb2 influx auth list \
-      --user $USERNAME \
-      --hide-headers | cut -f 3
+  _If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file._
 
-# Using JSON output + jq
-$ docker exec influxdb2 influx auth list \
-      --user $USERNAME \
-      --json | jq -r '.[].token'
-```
+## Start InfluxDB v2 with automated setup
 
-Alternatively, you could configure your initial InfluxDB run to mount `/etc/influxdb2` as a volume:
+To start and set up InfluxDB v2 with a single command, specify `-e DOCKER_INFLUXDB_INIT_MODE=setup` and `-e DOCKER_INFLUXDB_INIT_` environment variables for the initial user, password, bucket, and organization--for example:
 
 ```console
-$ docker run -d -p 8086:8086 \
-      --name influxdb2 \
-      -v $PWD/data:/var/lib/influxdb2 \
-      -v $PWD/config:/etc/influxdb2 \
-      %%IMAGE%%:2.0
+docker run -d -p 8086:8086 \
+  -v $PWD/data:/var/lib/influxdb2 \
+  -v $PWD/config:/etc/influxdb2 \
+  -e DOCKER_INFLUXDB_INIT_MODE=setup \
+  -e DOCKER_INFLUXDB_INIT_USERNAME=<USERNAME> \
+  -e DOCKER_INFLUXDB_INIT_PASSWORD=<PASSWORD> \
+  -e DOCKER_INFLUXDB_INIT_ORG=<ORG_NAME> \
+  -e DOCKER_INFLUXDB_INIT_BUCKET=<BUCKET_NAME> \
+  %%IMAGE%%:2
 ```
 
-This will make the generated CLI configs available to the host.
+Replace the following with your own values:
 
-#### Automated Setup
+- `$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+- `$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
+- `<USERNAME>`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+- `<PASSWORD>`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+- `<ORG_NAME>`: A name for your initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/)
+- `<BUCKET_NAME>`: A name for your initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/) (database)
 
-The InfluxDB image contains some extra functionality to automatically bootstrap the system. This functionality is enabled by setting the `DOCKER_INFLUXDB_INIT_MODE` environment variable to the value `setup` when running the container. Additional environment variables are used to configure the setup logic:
+_If you run setup from within the container, InfluxDB stores `influx` CLI [connection configurations](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials) in the container's `/etc/influxdb2/influx-configs` file._
 
--	`DOCKER_INFLUXDB_INIT_USERNAME`: The username to set for the system's initial super-user (**Required**).
--	`DOCKER_INFLUXDB_INIT_PASSWORD`: The password to set for the system's inital super-user (**Required**).
--	`DOCKER_INFLUXDB_INIT_ORG`: The name to set for the system's initial organization (**Required**).
--	`DOCKER_INFLUXDB_INIT_BUCKET`: The name to set for the system's initial bucket (**Required**).
--	`DOCKER_INFLUXDB_INIT_RETENTION`: The duration the system's initial bucket should retain data. If not set, the initial bucket will retain data forever.
--	`DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: The authentication token to associate with the system's initial super-user. If not set, a token will be auto-generated by the system.
+### Automated setup options
 
-Automated setup will generate metadata files and CLI configurations. It's recommended to mount volumes at both paths to avoid losing data.
+In setup mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or upgrade mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`), InfluxDB supports the following Docker-specific environment variables:
 
-For example, a minimal invocation of automated setup is:
+- `DOCKER_INFLUXDB_INIT_USERNAME`: A name for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
+- `DOCKER_INFLUXDB_INIT_PASSWORD`: A password for your initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/).
+- `DOCKER_INFLUXDB_INIT_ORG`: A name for your initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/).
+- `DOCKER_INFLUXDB_INIT_BUCKET`: A name for your initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/).
+- Optional: `DOCKER_INFLUXDB_INIT_RETENTION`: A [duration](https://docs.influxdata.com/influxdb/v2/reference/glossary/#duration) to use as the initial bucket's [retention period](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/#bucket-retention-period).
+  Default: `0` (infinite; doesn't delete data).
+- Optional: `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: A string value to set for the [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token).
+  Default: a generated token.
+
+The following example shows how to pass values for all initial setup options:
 
 ```console
-$ docker run -d -p 8086:8086 \
-      -v $PWD/data:/var/lib/influxdb2 \
-      -v $PWD/config:/etc/influxdb2 \
-      -e DOCKER_INFLUXDB_INIT_MODE=setup \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      %%IMAGE%%:2.0
+docker run -d -p 8086:8086 \
+    -v $PWD/data:/var/lib/influxdb2 \
+    -v $PWD/config:/etc/influxdb2 \
+    -e DOCKER_INFLUXDB_INIT_MODE=setup \
+    -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+    -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+    -e DOCKER_INFLUXDB_INIT_ORG=my-org \
+    -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+    -e DOCKER_INFLUXDB_INIT_RETENTION=1w \
+    -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token \
+    %%IMAGE%%:2
 ```
 
-And an example using all available options is:
+_To upgrade from InfluxDB 1.x to InfluxDB 2.x, see the **Upgrading from InfluxDB 1.x** section below._
 
-```console
-$ docker run -d -p 8086:8086 \
-      -v $PWD/data:/var/lib/influxdb2 \
-      -v $PWD/config:/etc/influxdb2 \
-      -e DOCKER_INFLUXDB_INIT_MODE=setup \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      -e DOCKER_INFLUXDB_INIT_RETENTION=1w \
-      -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token \
-      %%IMAGE%%:2.0
-```
-
-**NOTE:** Automated setup will not run if an existing boltdb file is found at the configured path. This behavior allows for the InfluxDB container to reboot post-setup without encountering "DB is already set up" errors.
-
-### Interacting with InfluxDB
-
-Once an InfluxDB instance has completed initial setup, its APIs will unlock. See the main documentation site for reference information and examples on:
-
--	[Writing data](https://docs.influxdata.com/influxdb/v2.0/write-data/)
--	[Reading data](https://docs.influxdata.com/influxdb/v2.0/query-data/)
--	[Configuring security](https://docs.influxdata.com/influxdb/v2.0/security/)
--	[And more!](https://docs.influxdata.com/influxdb/v2.0/)
+With InfluxDB set up and running, see the [Get started](https://docs.influxdata.com/influxdb/v2/get-started/) tutorial to create tokens and write and query data.
 
 ### Custom Initialization Scripts
 
-The InfluxDB image supports running arbitrary initialization scripts after initial system setup, on both the `setup` and `upgrade` paths. Scripts must have extension `.sh`, must have execute file permissions (`chmod +x <yourscript.sh>`) and be mounted inside of the `/docker-entrypoint-initdb.d` directory. When multiple scripts are present, they will be executed in lexical sort order by name.
+In `setup` mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or `upgrade` mode (`DOCKER_INFLUXDB_INIT_MODE=upgrade`),
+the InfluxDB Docker Hub image supports running custom initialization scripts.
+After the setup process completes, scripts are executed in lexical sort order by name.
 
-As a convenience for script-writers, the image will export a number of variables into the environment before executing any scripts:
+For the container to run scripts, they must:
 
--	`INFLUX_CONFIGS_PATH`: Path to the CLI configs file written by `setup`/`upgrade`
--	`INFLUX_HOST`: URL to the `influxd` instance running setup logic
--	`DOCKER_INFLUXDB_INIT_USER_ID`: ID of the initial admin user created by `setup`/`upgrade`
--	`DOCKER_INFLUXDB_INIT_ORG_ID`: ID of the initial organization created by `setup`/`upgrade`
--	`DOCKER_INFLUXDB_INIT_BUCKET_ID`: ID of the initial bucket created by `setup`/`upgrade`
+- Be mounted in the container's `/docker-entrypoint-initdb.d` directory
+- Be named using the `.sh` file name extension
+- Be executable by the user running the `docker run` command--for example, to allow the current use to execute a script with `docker run`:
+  
+  ```console
+  chmod +x ./scripts/<yourscript.sh>
+  ```
 
-For example, if you wanted to grant write-access to an InfluxDB 1.x client on your initial bucket, you'd first create the file `$PWD/scripts/setup-v1.sh` with contents:
+> #### Grant permissions to mounted files
+>
+> By default, Docker runs containers using the user and group IDs of the user executing the `docker run` command.
+> When files are bind mounted into the container, Docker preserves the user and group ownership from the host system.
+
+The image exports a number of variables into the environment before executing scripts.
+The following variables are available for you to use in your scripts:
+
+- `INFLUX_CONFIGS_PATH`: Path to the `influx` CLI connection configurations file written by `setup`/`upgrade`
+- `INFLUX_HOST`: URL to the `influxd` instance running `setup`/`upgrade`
+- `DOCKER_INFLUXDB_INIT_USER_ID`: ID of the initial admin user created by `setup`/`upgrade`
+- `DOCKER_INFLUXDB_INIT_ORG_ID`: ID of the initial organization created by `setup`/`upgrade`
+- `DOCKER_INFLUXDB_INIT_BUCKET_ID`: ID of the initial bucket created by `setup`/`upgrade`
+
+For example, to grant an InfluxDB 1.x client _write_ permission to your initial bucket, create a `$PWD/scripts/setup-v1.sh` file that contains the following:
 
 ```bash
 #!/bin/bash
@@ -208,265 +163,374 @@ influx v1 auth create \
   --org ${DOCKER_INFLUXDB_INIT_ORG}
 ```
 
-Then you'd run:
+Then, run the following command to start and set up InfluxDB using custom scripts:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v $PWD/data:/var/lib/influxdb2 \
-      -v $PWD/config:/etc/influxdb2 \
-      -v $PWD/scripts:/docker-entrypoint-initdb.d \
-      -e DOCKER_INFLUXDB_INIT_MODE=setup \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      -e V1_DB_NAME=v1-db \
-      -e V1_RP_NAME=v1-rp \
-      -e V1_AUTH_USERNAME=v1-user \
-      -e V1_AUTH_PASSWORD=v1-password \
-      %%IMAGE%%:2.0
+docker run -p 8086:8086 \
+     -v $PWD/data:/var/lib/influxdb2 \
+     -v $PWD/config:/etc/influxdb2 \
+     -v $PWD/scripts:/docker-entrypoint-initdb.d \
+     -e DOCKER_INFLUXDB_INIT_MODE=setup \
+     -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+     -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+     -e DOCKER_INFLUXDB_INIT_ORG=my-org \
+     -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+     -e V1_DB_NAME=v1-db \
+     -e V1_RP_NAME=v1-rp \
+     -e V1_AUTH_USERNAME=v1-user \
+     -e V1_AUTH_PASSWORD=v1-password \
+     %%IMAGE%%:2
 ```
 
-**NOTE:** Custom scripts will not run if an existing boltdb file is found at the configured path (causing `setup` or `upgrade` to be skipped). This behavior allows for the InfluxDB container to reboot post-initialization without encountering errors from non-idempotent script commands.
+> #### Automated setup and upgrade ignored if already setup
+>
+> Automated `setup`, `upgrade`, and custom initialization scripts won't run if an existing `influxd.bolt` boltdb file from a previous setup is found in the configured data directory.
+>
+> This behavior allows for the InfluxDB container to reboot post-setup and avoid overwriting migrated data, `DB is already set up` errors, and errors from non-idempotent script commands.
+
+## Access InfluxDB v2 file system and ports
+
+When starting an InfluxDB container, we recommend the following for easy access to your data, configurations, and InfluxDB v2 instance:
+
+- Publish the container's `8086` port to make the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) accessible from the host system.
+- Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) outside containers.
+
+### Default file system and networking ports
+
+For InfluxDB v2, the InfluxDB Docker Hub image uses the following default ports and file system paths:
+
+- TCP port `8086`: the default port for the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/).
+  To specify a different port or address, use the [`http-bind-address` configuration option](https://docs.influxdata.com/influxdb/v2/reference/config-options/#http-bind-address).
+- `/var/lib/influxdb2/`: the [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout)
+  - `/engine/`: Default InfluxDB [Storage engine path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#engine-path)
+  - `influxd.bolt`: Default [Bolt path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#bolt-path)
+  - `influxd.sqlite`: Default [SQLite path](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/#sqlite-path)
+
+- `/etc/influxdb2`: the [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout)
+  - `/etc/influxdb2/configs`: `influx` CLI connection configurations file
+  - `/etc/influxdb2/influx-configs`: `influx` CLI connection configurations file, _if you run setup from within the container_
+  - Optional: `/etc/influxdb2/config.[yml, json, toml]`: Your customized InfluxDB [configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/) file
+
+### Configure InfluxDB v2 in a container
+
+To customize InfluxDB, specify [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options) in a configuration file, environment variables, or command line flags.
+
+#### Use a configuration file
+
+To customize and mount an InfluxDB configuration file, do the following:
+
+1. If you haven't already, [set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) to initialize an API [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token).
+   You'll need the Operator token in the next step.
+
+2. Run the `influx server-config` CLI command to output the current server configuration to a file in the mounted configuration directory--for example, enter the following command to use the container's `influx` CLI and default Operator token:
+
+   ```sh
+   docker exec -it influxdb2 influx server-config > $PWD/config/config.yml
+   ```
+
+   Replace `$PWD/config/` with the host directory that you mounted at the container's `/etc/influxdb2` InfluxDB configuration directory path.
+
+3. Edit the `config.yml` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
+4. Restart the container.
+
+   ```sh
+   docker restart influxdb2
+   ```
+
+#### Use environment variables and command line flags
+
+To override specific [configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options), use environment variables or command line flags.
+
+- Pass `INFLUXD_` environment variables to Docker to override the configuration file--for example:
+
+  ```sh
+  docker run -p 8086:8086 \
+    -e INFLUXD_STORAGE_WAL_FSYNC_DELAY=15m \
+    influxdb:2 
+  ```
+
+- Pass `influxd` command line flags to override environment variables and the configuration file--for example:
+
+  ```console
+  docker run -p 8086:8086 \
+      %%IMAGE%%:2 --storage-wal-fsync-delay=15m
+  ```
+
+To learn more, see [InfluxDB configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options).
 
 ### Upgrading from InfluxDB 1.x
 
-InfluxDB 2.x provides a 1.x-compatible API, but expects a different storage layout on disk. To bridge this mismatch, the InfluxDB image contains extra functionality to migrate 1.x data and config into 2.x layouts automatically before booting the `influxd` server.
+InfluxDB 2.x provides a [1.x-compatible API](https://docs.influxdata.com/influxdb/v2/reference/api/influxdb-1x/), but expects a different storage layout on disk.
+To account for these differences, the InfluxDB Docker Hub image provides an `upgrade` feature that migrates 1.x data and configuration to 2.x before starting the `influxd` server.
 
-The automated upgrade process bootstraps an initial admin user, organization, and bucket in the system. Additional environment variables are used to configure the setup logic:
+The automated upgrade process creates the following in the InfluxDB v2 container:
 
--	`DOCKER_INFLUXDB_INIT_USERNAME`: The username to set for the system's initial super-user (**Required**).
--	`DOCKER_INFLUXDB_INIT_PASSWORD`: The password to set for the system's inital super-user (**Required**).
--	`DOCKER_INFLUXDB_INIT_ORG`: The name to set for the system's initial organization (**Required**).
--	`DOCKER_INFLUXDB_INIT_BUCKET`: The name to set for the system's initial bucket (**Required**).
--	`DOCKER_INFLUXDB_INIT_RETENTION`: The duration the system's initial bucket should retain data. If not set, the initial bucket will retain data forever.
--	`DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: The authentication token to associate with the system's initial super-user. If not set, a token will be auto-generated by the system.
+- an initial admin user
+- an initial organization
+- an initial bucket
+- InfluxDB v2 data files (the default path is `/var/lib/influxdb2`)
+- InfluxDB v2 configuration files (the default path is `/etc/influxdb2`)
 
-It also requires extra volumes to be mounted into the 2.x container:
+_Mount volumes at both paths to avoid losing data._
 
--	Data from the 1.x instance
--	Custom config from the 1.x instance (if any)
+To run the automated upgrade, specify the following when you start the container:
 
-The upgrade process searches for mounted 1.x data / config in this priority order:
+- InfluxDB v2 initialization environment variables:
 
-1.	A config file referred to by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable
-2.	A data directory referred to by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable
-3.	A config file mounted at `/etc/influxdb/influxdb.conf`
-4.	A data directory mounted at `/var/lib/influxdb`
+  - `DOCKER_INFLUXDB_INIT_MODE=upgrade`
+  - `DOCKER_INFLUXDB_INIT_USERNAME`: A name for the initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+  - `DOCKER_INFLUXDB_INIT_PASSWORD`: A password for the initial admin [user](https://docs.influxdata.com/influxdb/v2/admin/users/)
+  - `DOCKER_INFLUXDB_INIT_ORG`: A name for the initial [organization](https://docs.influxdata.com/influxdb/v2/admin/organizations/)
+  - `DOCKER_INFLUXDB_INIT_BUCKET`: A name for the initial [bucket](https://docs.influxdata.com/influxdb/v2/admin/buckets/)
+  - Optional: `DOCKER_INFLUXDB_INIT_RETENTION`: A [duration](https://docs.influxdata.com/influxdb/v2/reference/glossary/#duration) for the bucket [retention period](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/#bucket-retention-period).
+    Default: `0` (infinite; doesn't delete data)
+  - Optional: `DOCKER_INFLUXDB_INIT_ADMIN_TOKEN`: A value to set for the [Operator token](https://docs.influxdata.com/influxdb/v2/admin/tokens/#operator-token).
+    Default: generates a token.
 
-Finally, the `DOCKER_INFLUXDB_INIT_MODE` environment variable must be set to `upgrade`.
+- 1.x data and configuration paths:
 
-Automated upgrade will generate both data and config files, by default under `/var/lib/influxdb2` and `/etc/influxdb2`. It's recommended to mount volumes at both paths to avoid losing data.
+  - A 1.x data volume, specified by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable or mounted at `/var/lib/influxdb`
+  - Optional: a 1.x custom configuration file, specified by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable or mounted at `/etc/influxdb/influxdb.conf`
 
-**NOTE:** Automated upgrade will not run if an existing boltdb file is found at the configured path. This behavior allows for the InfluxDB container to reboot post-upgrade without overwriting migrated data.
+The upgrade process searches for mounted 1.x data and configuration paths in the following order of precedence:
 
-Find more about the InfluxDB upgrade process [here](https://docs.influxdata.com/influxdb/v2.0/upgrade/v1-to-v2/). See below for examples of common upgrade scenarios.
+1. A configuration file referenced by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG` environment variable
+2. A data directory referenced by the `DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR` environment variable
+3. A configuration file mounted at `/etc/influxdb/influxdb.conf`
+4. A data directory mounted at `/var/lib/influxdb`
 
-#### Upgrade Example - Minimal
+> #### Automated setup and upgrade ignored if already setup
+>
+> Automated `setup`, `upgrade`, and custom initialization scripts won't run if an existing `influxd.bolt` boltdb file from a previous setup is found in the configured data directory.
+>
+> This behavior allows for the InfluxDB container to reboot post-setup and avoid overwriting migrated data, `DB is already set up` errors, and errors from non-idempotent script commands.
+
+#### Upgrade InfluxDB 1.x: default data path and configuration
 
 Assume you've been running a minimal InfluxDB 1.x deployment:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/var/lib/influxdb \
-      %%IMAGE%%:1.8
+docker run -p 8086:8086 \
+    -v influxdb:/var/lib/influxdb \
+    %%IMAGE%%:1.8
 ```
 
-To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container, then run:
+To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container,
+and then run the following command:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/var/lib/influxdb \
-      -v influxdb2:/var/lib/influxdb2 \
-      -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      %%IMAGE%%:2.0
+docker run -p 8086:8086 \
+    -v influxdb:/var/lib/influxdb \
+    -v influxdb2:/var/lib/influxdb2 \
+    -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
+    -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+    -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+    -e DOCKER_INFLUXDB_INIT_ORG=my-org \
+    -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+    %%IMAGE%%:2
 ```
 
-#### Upgrade Example - Custom InfluxDB 1.x Config
+#### Upgrade InfluxDB 1.x: custom configuration
 
-Assume you've been running an InfluxDB 1.x deployment with customized config:
+Assume you've been running an InfluxDB 1.x deployment with customized configuration (`/etc/influxdb/influxdb.conf`):
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/var/lib/influxdb \
-      -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
-      %%IMAGE%%:1.8
+docker run -p 8086:8086 \
+    -v influxdb:/var/lib/influxdb \
+    -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
+    %%IMAGE%%:1.8
 ```
 
-To upgrade this deployment to InfluxDB 2.x, stop the running container, then run:
+To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container,
+and then run the following command:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/var/lib/influxdb \
-      -v influxdb2:/var/lib/influxdb2 \
-      -v influxdb2-config:/etc/influxdb2 \
-      -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
-      -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      %%IMAGE%%:2.0
+docker run -p 8086:8086 \
+    -v influxdb:/var/lib/influxdb \
+    -v influxdb2:/var/lib/influxdb2 \
+    -v influxdb2-config:/etc/influxdb2 \
+    -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
+    -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
+    -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+    -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+    -e DOCKER_INFLUXDB_INIT_ORG=my-org \
+    -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+    %%IMAGE%%:2
 ```
 
-#### Upgrade Example - Custom Paths
+#### Upgrade InfluxDB 1.x: custom data and configuration paths
 
-Assume you've been running an InfluxDB 1.x deployment with data and config mounted at custom paths:
+Assume you've been running an InfluxDB 1.x deployment with data and configuration mounted at custom paths:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/root/influxdb/data \
-      -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
-      %%IMAGE%%:1.8 -config /root/influxdb/influxdb.conf
+docker run -p 8086:8086 \
+    -v influxdb:/root/influxdb/data \
+    -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
+    %%IMAGE%%:1.8 -config /root/influxdb/influxdb.conf
 ```
 
-To upgrade this deployment to InfluxDB 2.x, first decide if you'd like to keep using custom paths, or use the InfluxDB 2.x defaults. If you decide to use the defaults, you'd stop the running InfluxDB 1.x container, then run:
+Before you upgrade to InfluxDB v2, decide whether to keep using your custom paths or to use the InfluxDB v2 defaults.
+
+To use InfluxDB v2 defaults, stop the running InfluxDB 1.x container, and then run the following command:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/root/influxdb/data \
-      -v influxdb2:/var/lib/influxdb2 \
-      -v influxdb2-config:/etc/influxdb2 \
-      -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
-      -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      -e DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG=/root/influxdb/influxdb.conf \
-      %%IMAGE%%:2.0
+docker run -p 8086:8086 \
+    -v influxdb:/root/influxdb/data \
+    -v influxdb2:/var/lib/influxdb2 \
+    -v influxdb2-config:/etc/influxdb2 \
+    -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
+    -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
+    -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+    -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+    -e DOCKER_INFLUXDB_INIT_ORG=my-org \
+    -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+    -e DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG=/root/influxdb/influxdb.conf \
+    %%IMAGE%%:2
 ```
 
-To retain your custom paths, you'd run:
+To use your custom paths instead of InfluxDB v2 default paths, run the following command:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/root/influxdb/data \
-      -v influxdb2:/root/influxdb2/data \
-      -v influxdb2-config:/etc/influxdb2 \
-      -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
-      -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
-      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
-      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
-      -e DOCKER_INFLUXDB_INIT_ORG=my-org \
-      -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
-      -e DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG=/root/influxdb/influxdb.conf \
-      -e DOCKER_INFLUXDB_CONFIG_PATH=/root/influxdb2/config.toml \
-      -e DOCKER_INFLUXDB_BOLT_PATH=/root/influxdb2/influxdb.bolt \
-      -e DOCKER_INFLUXDB_ENGINE_PATH=/root/influxdb2/engine \
-      %%IMAGE%%:2.0
+docker run -p 8086:8086 \
+    -v influxdb:/root/influxdb/data \
+    -v influxdb2:/root/influxdb2/data \
+    -v influxdb2-config:/etc/influxdb2 \
+    -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
+    -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
+    -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+    -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+    -e DOCKER_INFLUXDB_INIT_ORG=my-org \
+    -e DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+    -e DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG=/root/influxdb/influxdb.conf \
+    -e DOCKER_INFLUXDB_CONFIG_PATH=/root/influxdb2/config.toml \
+    -e DOCKER_INFLUXDB_BOLT_PATH=/root/influxdb2/influxdb.bolt \
+    -e DOCKER_INFLUXDB_ENGINE_PATH=/root/influxdb2/engine \
+    %%IMAGE%%:2
 ```
+
+To learn more about the upgrade process, see the [v1-to-v2 upgrade guide](https://docs.influxdata.com/influxdb/v2.0/upgrade/v1-to-v2/).
 
 ### Upgrading from quay.io-hosted InfluxDB 2.x image
 
-Early Docker builds of InfluxDB 2.x were hosted at `quay.io/influxdb/influxdb`. The builds were very bare-bones, containing the `influx` and `influxd` binaries without any default configuration or helper scripts. By default, the `influxd` process stored data under `/root/.influxdbv2`.
+Early Docker builds of InfluxDB 2.x were hosted at `quay.io/influxdb/influxdb` and contained the `influx` and `influxd` binaries without any default configuration or helper scripts.
+By default, the `influxd` process stored data in `/root/.influxdbv2`.
 
-Starting with `v2.0.4`, we've restored our DockerHub build. This build defaults to storing data in `/var/lib/influxdb2`. Upgrading directly from `quay.io/influxdb/influxdb` to `influxdb:2.0.4` without modifying any settings will appear to cause data loss, as the new process won't be able to find your existing data files.
+Starting with `v2.0.4`, we restored the InfluxDB Docker Hub build, which defaults to storing data in `/var/lib/influxdb2`.
+If you upgrade directly from `quay.io/influxdb/influxdb` to `influxdb:2.0.4` using the default settings, InfluxDB won't be able to find your existing data files.
 
-To avoid this problem when migrating from `quay.io/influxdb/influxdb` to `influxdb:2.0`, you can use one of the following approaches.
+To avoid this problem when migrating from `quay.io/influxdb/influxdb` to `influxdb:2.0`, choose one of the following:
 
-#### Change volume mount point
+#### Update the mount to use the InfluxDB default
 
-If you don't mind using the new default path, you can switch the mount-point for the volume containing your data:
+To use the InfluxDB Docker Hub data path, start a container that mounts your data volume into `/var/lib/influxdb2`--for example, if you used the following command to start the InfluxDB quay.io container:
 
 ```console
-# Migrate from this:
-$ docker run -p 8086:8086 \
-      -v $PWD:/root/.influxdbv2 \
-      quay.io/influxdb/influxdb:v2.0.3
-
-# To this:
+# quay.io InfluxDB 2.x container 
 docker run -p 8086:8086 \
-      -v $PWD:/var/lib/influxdb2 \
-      %%IMAGE%%:2.0
+    -v $PWD:/root/.influxdbv2 \
+    quay.io/influxdb/influxdb:v2.0.3
 ```
 
-#### Override default configs
-
-If you'd rather keep your data files in the home directory, you can override the container's default config:
+Use this command to start an InfluxDB v2 Docker Hub container:
 
 ```console
-# Migrate from this:
-$ docker run -p 8086:8086 \
-      -v $PWD:/root/.influxdbv2 \
-      quay.io/influxdb/influxdb:v2.0.3
+# Docker Hub InfluxDB 2.x container
+docker run -p 8086:8086 \
+    -v $PWD:/var/lib/influxdb2 \
+    %%IMAGE%%:2
+```
 
-# To this:
+#### Configure InfluxDB to use the container home directory
+
+To continue using the `/root/.influxdbv2` data path, customize storage path configuration options ([bolt-path](https://docs.influxdata.com/influxdb/v2/reference/config-options/#bolt-path), [engine-path](https://docs.influxdata.com/influxdb/v2/reference/config-options/#engine-path), [sqlite-path](https://docs.influxdata.com/influxdb/v2/reference/config-options/#sqlite-path)) configuration options for your InfluxDB Docker Hub container--for example, if you used the following command to start the InfluxDB quay.io container:
+
+```console
+# quay.io-hosted InfluxDB 2.x
+docker run -p 8086:8086 \
+    -v $PWD:/root/.influxdbv2 \
+    quay.io/influxdb/influxdb:v2.0.3
+```
+
+Use this command to start an InfluxDB v2 Docker Hub container:
+
+```console
 docker run -p 8086:8086 \
       -e INFLUXD_BOLT_PATH=/root/.influxdbv2/influxd.bolt \
       -e INFLUXD_ENGINE_PATH=/root/.influxdbv2/engine \
       -v $PWD:/root/.influxdbv2 \
-      %%IMAGE%%:2.0
+      %%IMAGE%%:2
 ```
 
-See the section about configuration below for more ways to override the data paths.
+# How to use this image for InfluxDB v1
 
-## Using this Image - InfluxDB 1.x
+Use the InfluxDB Docker Hub image to run and set up an [InfluxDB 1.x](https://docs.influxdata.com/influxdb/v1/) container.
 
 ### Running the container
 
-The InfluxDB image exposes a shared volume under `/var/lib/influxdb`, so you can mount a host directory to that point to access persisted container data. A typical invocation of the container might be:
+To start an InfluxDB 1.x container, enter the following command:
 
 ```console
-$ docker run -p 8086:8086 \
-      -v $PWD:/var/lib/influxdb \
-      %%IMAGE%%:1.8
+docker run -p 8086:8086 \
+    -v $PWD:/var/lib/influxdb \
+    %%IMAGE%%:1.8
 ```
 
-Modify `$PWD` to the directory where you want to store data associated with the InfluxDB container.
+The command passes the following arguments:
 
-You can also have Docker control the volume mountpoint by using a named volume.
+- `-p 8086:8086`: Exposes the InfluxDB [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) on host port `8086`.
+- `-v $PWD:/var/lib/influxdb`: Mounts the host's `$PWD` directory to the [InfluxDB data directory](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/) to persist data outside the container.
+
+Replace `$PWD` with the host directory where you want InfluxDB to store data.
+
+_Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/)._
+
+### Networking ports
+
+InfluxDB uses the following networking ports:
+
+- TCP port `8086`: the default port for the [HTTP API](https://docs.influxdata.com/influxdb/v1/tools/api/)
+- TCP port `2003`: the port for the Graphite protocol (if enabled)
+
+Using the `docker run` [`-P, --publish-all` flag](https://docs.docker.com/reference/cli/docker/container/run/#publish-all) exposes the InfluxDB HTTP API to the host.
+
+### Configure InfluxDB v1 in a container
+
+To configure InfluxDB v1 in a container, use a configuration file or environment variables.
+
+#### Use a configuration file
+
+To customize and mount a configuration file, do the following:
+
+1. Output the current server configuration to a file in the mounted configuration directory--for example:
+
+   ```console
+   docker run --rm %%IMAGE%%:1.8 influxd config > influxdb.conf
+   ```
+
+2. Edit the `influxdb.conf` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
+
+   ```console
+   docker run -p 8086:8086 \
+       -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
+       %%IMAGE%%:1.8 -config /etc/influxdb/influxdb.conf
+   ```
+
+   Replace `$PWD` with the host directory where you want to store the configuration file.
+
+#### Use environment variables
+
+Pass [`INFLUXDB_` environment variables](https://docs.influxdata.com/influxdb/v1/administration/config/#environment-variables) to override specific InfluxDB v1 configuration options.
+An environment variable overrides the equivalent option in the configuration file.
 
 ```console
-$ docker run -p 8086:8086 \
-      -v influxdb:/var/lib/influxdb \
-      %%IMAGE%%:1.8
+docker run -p 8086:8086 \
+   -e INFLUXDB_REPORTING_DISABLED=true \
+   -e INFLUXDB_META_DIR=/path/to/metadir \
+   -e INFLUXDB_DATA_QUERY_LOG_ENABLED=false \
+    %%IMAGE%%:1.8
 ```
 
-### Exposed Ports
-
-The following ports are important and are used by InfluxDB.
-
--	8086 HTTP API port
--	2003 Graphite support, if it is enabled
-
-The HTTP API port will be automatically exposed when using `docker run -P`.
-
-### Configuration
-
-InfluxDB can be either configured from a config file or using environment variables. To mount a configuration file and use it with the server, you can use this command:
-
-Generate the default configuration file:
-
-```console
-$ docker run --rm %%IMAGE%%:1.8 influxd config > influxdb.conf
-```
-
-Modify the default configuration, which will now be available under `$PWD`. Then start the InfluxDB container.
-
-```console
-$ docker run -p 8086:8086 \
-      -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
-      %%IMAGE%%:1.8 -config /etc/influxdb/influxdb.conf
-```
-
-Modify `$PWD` to the directory where you want to store the configuration file.
-
-For environment variables, the format is `INFLUXDB_$SECTION_$NAME`. All dashes (`-`) are replaced with underscores (`_`). If the variable isn't in a section, then omit that part.
-
-Examples:
-
-```console
-INFLUXDB_REPORTING_DISABLED=true
-INFLUXDB_META_DIR=/path/to/metadir
-INFLUXDB_DATA_QUERY_LOG_ENABLED=false
-```
-
-Find more about configuring InfluxDB [here](https://docs.influxdata.com/influxdb/v1.8/administration/config/).
+Learn more about [configuring InfluxDB v1](https://docs.influxdata.com/influxdb/v1.8/administration/config/).
 
 ### Graphite
 
@@ -485,13 +549,13 @@ See the [README on GitHub](https://github.com/influxdata/influxdb/blob/master/se
 Creating a DB named mydb:
 
 ```console
-$ curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
+curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
 ```
 
 Inserting into the DB:
 
 ```console
-$ curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
+curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
 Read more about this in the [official documentation](https://docs.influxdata.com/influxdb/latest/guides/writing_data/)
@@ -501,19 +565,19 @@ Read more about this in the [official documentation](https://docs.influxdata.com
 Start the container:
 
 ```console
-$ docker run --name=influxdb -d -p 8086:8086 %%IMAGE%%:1.8
+docker run --name=influxdb -d -p 8086:8086 %%IMAGE%%:1.8
 ```
 
 Run the influx client in this container:
 
 ```console
-$ docker exec -it influxdb influx
+docker exec -it influxdb influx
 ```
 
 Or run the influx client in a separate container:
 
 ```console
-$ docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
+docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
 ```
 
 ### Database Initialization
@@ -575,12 +639,12 @@ If the Docker image finds any files with the extensions `.sh` or `.iql` inside o
 To manually initialize the database and exit, the `/init-influxdb.sh` script can be used directly. It takes the same parameters as the `influxd run` command. As an example:
 
 ```console
-$ docker run --rm \
-      -e INFLUXDB_DB=db0 \
-      -e INFLUXDB_ADMIN_USER=admin -e INFLUXDB_ADMIN_PASSWORD=supersecretpassword \
-      -e INFLUXDB_USER=telegraf -e INFLUXDB_USER_PASSWORD=secretpassword \
-      -v $PWD:/var/lib/influxdb \
-      %%IMAGE%%:1.8 /init-influxdb.sh
+docker run --rm \
+   -e INFLUXDB_DB=db0 \
+   -e INFLUXDB_ADMIN_USER=admin -e INFLUXDB_ADMIN_PASSWORD=supersecretpassword \
+   -e INFLUXDB_USER=telegraf -e INFLUXDB_USER_PASSWORD=secretpassword \
+   -v $PWD:/var/lib/influxdb \
+   %%IMAGE%%:1.8 /init-influxdb.sh
 ```
 
 The above would create the database `db0`, create an admin user with the password `supersecretpassword`, then create the `telegraf` user with your telegraf's secret password. It would then exit and leave behind any files it created in the volume that you mounted.

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -578,9 +578,9 @@ InfluxDB v1 database initialization
 
 The InfluxDB Docker Hub image lets you set initialization options when creating an InfluxDB v1 container.
 
-**WARNING**: We **don't** recommend using these options for production scenarios, but they're useful when running standalone instances for testing.
+The database initialization script is only called when running `influxd`; it isn't executed by any other program.
 
-The database initialization script is only called when running `influxd`.
+**WARNING**: We **don't** recommend using these options for production scenarios, but they're useful when running standalone instances for testing.
 
 ### Environment variables
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -442,10 +442,10 @@ Use this command to start an InfluxDB v2 Docker Hub container:
 
 ```console
 docker run -p 8086:8086 \
-      -e INFLUXD_BOLT_PATH=/root/.influxdbv2/influxd.bolt \
-      -e INFLUXD_ENGINE_PATH=/root/.influxdbv2/engine \
-      -v $PWD:/root/.influxdbv2 \
-      %%IMAGE%%:2
+    -e INFLUXD_BOLT_PATH=/root/.influxdbv2/influxd.bolt \
+    -e INFLUXD_ENGINE_PATH=/root/.influxdbv2/engine \
+    -v $PWD:/root/.influxdbv2 \
+    %%IMAGE%%:2
 ```
 
 How to use this image for InfluxDB v1

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -14,7 +14,7 @@ For more information, visit https://influxdata.com.
 
 ## Start InfluxDB v2 and set up with the UI, CLI, or API
 
-To start an InfluxDB v2 container that you can then set up using the included UI, the `influx` CLI, or the HTTP API, enter the following command:
+To start an InfluxDB v2 container, enter the following command:
 
 ```console
 docker run \
@@ -29,9 +29,9 @@ Replace the following with your own values:
 -	`$PWD/data`: A host directory to mount at the container's [InfluxDB data directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
 -	`$PWD/config`: A host directory to mount at the container's [InfluxDB configuration directory](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) path
 
-After the container starts, the UI and API are accessible at http://localhost:8086 on the host. You're ready to set up an initial admin user, token, and bucket from outside or inside the container--choose one of the following:
+After the container starts, the InfluxDB UI and API are accessible at http://localhost:8086 on the host. You're ready to set up an initial admin user, token, and bucket from outside or inside the container--choose one of the following:
 
--	**Set up InfluxDB from outside the container**:[Set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) from the host or network using the UI, `influx` CLI, or HTTP API.
+-	**Set up InfluxDB from outside the container**: [Set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/) from the host or network using the InfluxDB UI, `influx` CLI, or HTTP API.
 
 -	**Set up InfluxDB from inside the container**: Use `docker exec` to run the `influx` CLI installed in the container--for example:
 
@@ -122,7 +122,7 @@ For the container to run scripts, they must:
 
 > #### Grant permissions to mounted files
 >
-> By default, Docker runs containers using the user and group IDs of the user executing the `docker run` command. When files are bind mounted into the container, Docker preserves the user and group ownership from the host system.
+> By default, Docker runs containers using the user and group IDs of the user executing the `docker run` command. When files are bind-mounted into the container, Docker preserves the user and group ownership from the host system.
 
 The image exports a number of variables into the environment before executing scripts. The following variables are available for you to use in your scripts:
 
@@ -182,7 +182,7 @@ docker run -p 8086:8086 \
 When starting an InfluxDB container, we recommend the following for easy access to your data, configurations, and InfluxDB v2 instance:
 
 -	Publish the container's `8086` port to make the InfluxDB [UI](https://docs.influxdata.com/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](https://docs.influxdata.com/influxdb/v2/reference/api/) accessible from the host system.
--	Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) outside containers.
+-	Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) outside of containers.
 
 ### Default file system and networking ports
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -16,7 +16,7 @@ For more information, visit https://influxdata.com.
 
 To start an InfluxDB v2 container, enter the following command:
 
-```console
+```bash
 docker run \
     -p 8086:8086 \
     -v $PWD/data:/var/lib/influxdb2 \
@@ -35,7 +35,7 @@ After the container starts, the InfluxDB UI and API are accessible at http://loc
 
 -	**Set up InfluxDB from inside the container**: Use `docker exec` to run the `influx` CLI installed in the container--for example:
 
-	```console
+	```bash
 	docker exec influxdb2 influx setup \
 	  --username $USERNAME \
 	  --password $PASSWORD \
@@ -52,7 +52,7 @@ See the [`influx setup` documentation](https://docs.influxdata.com/influxdb/v2/r
 
 To start and set up InfluxDB v2 with a single command, specify `-e DOCKER_INFLUXDB_INIT_MODE=setup` and `-e DOCKER_INFLUXDB_INIT_` environment variables for the initial user, password, bucket, and organization--for example:
 
-```console
+```bash
 docker run -d -p 8086:8086 \
   -v $PWD/data:/var/lib/influxdb2 \
   -v $PWD/config:/etc/influxdb2 \
@@ -88,7 +88,7 @@ In setup mode (`DOCKER_INFLUXDB_INIT_MODE=setup`) or upgrade mode (`DOCKER_INFLU
 
 The following example shows how to pass values for all initial setup options:
 
-```console
+```bash
 docker run -d -p 8086:8086 \
     -v $PWD/data:/var/lib/influxdb2 \
     -v $PWD/config:/etc/influxdb2 \
@@ -116,7 +116,7 @@ For the container to run scripts, they must:
 -	Be named using the `.sh` file name extension
 -	Be executable by the user running the `docker run` command--for example, to allow the current use to execute a script with `docker run`:
 
-	```console
+	```bash
 	chmod +x ./scripts/<yourscript.sh>
 	```
 
@@ -154,7 +154,7 @@ influx v1 auth create \
 
 Then, run the following command to start and set up InfluxDB using custom scripts:
 
-```console
+```bash
 docker run -p 8086:8086 \
      -v $PWD/data:/var/lib/influxdb2 \
      -v $PWD/config:/etc/influxdb2 \
@@ -240,7 +240,7 @@ To override specific [configuration options](https://docs.influxdata.com/influxd
 
 -	Pass `influxd` command line flags to override environment variables and the configuration file--for example:
 
-	```console
+	```bash
 	docker run -p 8086:8086 \
 	  %%IMAGE%%:2 --storage-wal-fsync-delay=15m
 	```
@@ -295,7 +295,7 @@ The upgrade process searches for mounted 1.x data and configuration paths in the
 
 Assume you've been running a minimal InfluxDB 1.x deployment:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/var/lib/influxdb \
     %%IMAGE%%:1.8
@@ -303,7 +303,7 @@ docker run -p 8086:8086 \
 
 To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container, and then run the following command:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/var/lib/influxdb \
     -v influxdb2:/var/lib/influxdb2 \
@@ -319,7 +319,7 @@ docker run -p 8086:8086 \
 
 Assume you've been running an InfluxDB 1.x deployment with customized configuration (`/etc/influxdb/influxdb.conf`):
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/var/lib/influxdb \
     -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
@@ -328,7 +328,7 @@ docker run -p 8086:8086 \
 
 To upgrade this deployment to InfluxDB 2.x, stop the running InfluxDB 1.x container, and then run the following command:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/var/lib/influxdb \
     -v influxdb2:/var/lib/influxdb2 \
@@ -346,7 +346,7 @@ docker run -p 8086:8086 \
 
 Assume you've been running an InfluxDB 1.x deployment with data and configuration mounted at custom paths:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/root/influxdb/data \
     -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
@@ -357,7 +357,7 @@ Before you upgrade to InfluxDB v2, decide whether to keep using your custom path
 
 To use InfluxDB v2 defaults, stop the running InfluxDB 1.x container, and then run the following command:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/root/influxdb/data \
     -v influxdb2:/var/lib/influxdb2 \
@@ -374,7 +374,7 @@ docker run -p 8086:8086 \
 
 To use your custom paths instead of InfluxDB v2 default paths, run the following command:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v influxdb:/root/influxdb/data \
     -v influxdb2:/root/influxdb2/data \
@@ -406,7 +406,7 @@ To avoid this problem when migrating from `quay.io/influxdb/influxdb` to `influx
 
 To use the InfluxDB Docker Hub data path, start a container that mounts your data volume into `/var/lib/influxdb2`--for example, if you used the following command to start the InfluxDB quay.io container:
 
-```console
+```bash
 # quay.io InfluxDB 2.x container 
 docker run -p 8086:8086 \
     -v $PWD:/root/.influxdbv2 \
@@ -415,7 +415,7 @@ docker run -p 8086:8086 \
 
 Use this command to start an InfluxDB v2 Docker Hub container:
 
-```console
+```bash
 # Docker Hub InfluxDB 2.x container
 docker run -p 8086:8086 \
     -v $PWD:/var/lib/influxdb2 \
@@ -426,7 +426,7 @@ docker run -p 8086:8086 \
 
 To continue using the `/root/.influxdbv2` data path, customize storage path configuration options ([bolt-path](https://docs.influxdata.com/influxdb/v2/reference/config-options/#bolt-path), [engine-path](https://docs.influxdata.com/influxdb/v2/reference/config-options/#engine-path), [sqlite-path](https://docs.influxdata.com/influxdb/v2/reference/config-options/#sqlite-path)) configuration options for your InfluxDB Docker Hub container--for example, if you used the following command to start the InfluxDB quay.io container:
 
-```console
+```bash
 # quay.io-hosted InfluxDB 2.x
 docker run -p 8086:8086 \
     -v $PWD:/root/.influxdbv2 \
@@ -435,7 +435,7 @@ docker run -p 8086:8086 \
 
 Use this command to start an InfluxDB v2 Docker Hub container:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -e INFLUXD_BOLT_PATH=/root/.influxdbv2/influxd.bolt \
     -e INFLUXD_ENGINE_PATH=/root/.influxdbv2/engine \
@@ -451,7 +451,7 @@ Use the InfluxDB Docker Hub image to run and set up an [InfluxDB 1.x](https://do
 
 To start an InfluxDB 1.x container, enter the following command:
 
-```console
+```bash
 docker run -p 8086:8086 \
     -v $PWD:/var/lib/influxdb \
     %%IMAGE%%:1.8
@@ -485,13 +485,13 @@ To customize and mount a configuration file, do the following:
 
 1.	Output the current server configuration to a file in the mounted configuration directory--for example:
 
-	```console
+	```bash
 	docker run --rm %%IMAGE%%:1.8 influxd config > influxdb.conf
 	```
 
 2.	Edit the `influxdb.conf` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
 
-	```console
+	```bash
 	docker run -p 8086:8086 \
 	  -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
 	  %%IMAGE%%:1.8 -config /etc/influxdb/influxdb.conf
@@ -503,7 +503,7 @@ To customize and mount a configuration file, do the following:
 
 Pass [`INFLUXDB_` environment variables](https://docs.influxdata.com/influxdb/v1/administration/config/#environment-variables) to override specific InfluxDB v1 configuration options. An environment variable overrides the equivalent option in the configuration file.
 
-```console
+```bash
 docker run -p 8086:8086 \
     -e INFLUXDB_REPORTING_DISABLED=true \
     -e INFLUXDB_META_DIR=/path/to/metadir \
@@ -517,7 +517,7 @@ Learn more about [configuring InfluxDB v1](https://docs.influxdata.com/influxdb/
 
 InfluxDB supports the Graphite line protocol, but the service and ports are not exposed by default. To run InfluxDB with Graphite support enabled, you can either use a configuration file or set the appropriate environment variables. Run InfluxDB with the default Graphite configuration:
 
-```console
+```bash
 docker run -p 8086:8086 -p 2003:2003 \
     -e INFLUXDB_GRAPHITE_ENABLED=true \
     %%IMAGE%%:1.8
@@ -529,13 +529,13 @@ See the [README on GitHub](https://github.com/influxdata/influxdb/blob/master/se
 
 Creating a DB named mydb:
 
-```console
+```bash
 curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
 ```
 
 Inserting into the DB:
 
-```console
+```bash
 curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
@@ -545,19 +545,19 @@ Read more about this in the [official documentation](https://docs.influxdata.com
 
 Start the container:
 
-```console
+```bash
 docker run --name=influxdb -d -p 8086:8086 %%IMAGE%%:1.8
 ```
 
 Run the influx client in this container:
 
-```console
+```bash
 docker exec -it influxdb influx
 ```
 
 Or run the influx client in a separate container:
 
-```console
+```bash
 docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
 ```
 
@@ -623,7 +623,7 @@ If the Docker image finds any files with the extensions `.sh` or `.iql` inside o
 
 To manually initialize an InfluxDB v1 database, use `docker run` to call the `/init-influxdb.sh` script directly. The script takes the same initialization options as the `influxd run` command--for example:
 
-```console
+```bash
 docker run --rm \
     -e INFLUXDB_DB=db0 \
     -e INFLUXDB_ADMIN_USER=admin \

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -19,8 +19,8 @@ To start an InfluxDB v2 container, enter the following command:
 ```bash
 docker run \
     -p 8086:8086 \
-    -v $PWD/data:/var/lib/influxdb2 \
-    -v $PWD/config:/etc/influxdb2 \
+    -v "$PWD/data:/var/lib/influxdb2" \
+    -v "$PWD/config:/etc/influxdb2" \
     %%IMAGE%%:2
 ```
 
@@ -54,8 +54,8 @@ To start and set up InfluxDB v2 with a single command, specify `-e DOCKER_INFLUX
 
 ```bash
 docker run -d -p 8086:8086 \
-  -v $PWD/data:/var/lib/influxdb2 \
-  -v $PWD/config:/etc/influxdb2 \
+  -v "$PWD/data:/var/lib/influxdb2" \
+  -v "$PWD/config:/etc/influxdb2" \
   -e DOCKER_INFLUXDB_INIT_MODE=setup \
   -e DOCKER_INFLUXDB_INIT_USERNAME=<USERNAME> \
   -e DOCKER_INFLUXDB_INIT_PASSWORD=<PASSWORD> \
@@ -90,8 +90,8 @@ The following example shows how to pass values for all initial setup options:
 
 ```bash
 docker run -d -p 8086:8086 \
-    -v $PWD/data:/var/lib/influxdb2 \
-    -v $PWD/config:/etc/influxdb2 \
+    -v "$PWD/data:/var/lib/influxdb2" \
+    -v "$PWD/config:/etc/influxdb2" \
     -e DOCKER_INFLUXDB_INIT_MODE=setup \
     -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
     -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
@@ -156,9 +156,9 @@ Then, run the following command to start and set up InfluxDB using custom script
 
 ```bash
 docker run -p 8086:8086 \
-     -v $PWD/data:/var/lib/influxdb2 \
-     -v $PWD/config:/etc/influxdb2 \
-     -v $PWD/scripts:/docker-entrypoint-initdb.d \
+     -v "$PWD/data:/var/lib/influxdb2" \
+     -v "$PWD/config:/etc/influxdb2" \
+     -v "$PWD/scripts:/docker-entrypoint-initdb.d" \
      -e DOCKER_INFLUXDB_INIT_MODE=setup \
      -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
      -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
@@ -213,8 +213,8 @@ To customize and mount an InfluxDB configuration file, do the following:
 
 2.	Run the `influx server-config` CLI command to output the current server configuration to a file in the mounted configuration directory--for example, enter the following command to use the container's `influx` CLI and default Operator token:
 
-	```sh
-	docker exec -it influxdb2 influx server-config > $PWD/config/config.yml
+	```bash
+	docker exec -it influxdb2 influx server-config > "$PWD/config/config.yml"
 	```
 
 Replace `$PWD/config/` with the host directory that you mounted at the container's `/etc/influxdb2` InfluxDB configuration directory path.
@@ -222,7 +222,7 @@ Replace `$PWD/config/` with the host directory that you mounted at the container
 1.	Edit the `config.yml` file to customize [server configuration options](https://docs.influxdata.com/influxdb/v2/reference/config-options/#configuration-options).
 2.	Restart the container.
 
-	```sh
+	```bash
 	docker restart influxdb2
 	```
 
@@ -232,7 +232,7 @@ To override specific [configuration options](https://docs.influxdata.com/influxd
 
 -	Pass `INFLUXD_` environment variables to Docker to override the configuration file--for example:
 
-	```sh
+	```bash
 	docker run -p 8086:8086 \
 	-e INFLUXD_STORAGE_WAL_FSYNC_DELAY=15m \
 	influxdb:2 
@@ -322,7 +322,7 @@ Assume you've been running an InfluxDB 1.x deployment with customized configurat
 ```bash
 docker run -p 8086:8086 \
     -v influxdb:/var/lib/influxdb \
-    -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
+    -v "$PWD/influxdb.conf:/etc/influxdb/influxdb.conf" \
     %%IMAGE%%:1.8
 ```
 
@@ -333,7 +333,7 @@ docker run -p 8086:8086 \
     -v influxdb:/var/lib/influxdb \
     -v influxdb2:/var/lib/influxdb2 \
     -v influxdb2-config:/etc/influxdb2 \
-    -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf \
+    -v "$PWD/influxdb.conf:/etc/influxdb/influxdb.conf" \
     -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
     -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
     -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
@@ -349,7 +349,7 @@ Assume you've been running an InfluxDB 1.x deployment with data and configuratio
 ```bash
 docker run -p 8086:8086 \
     -v influxdb:/root/influxdb/data \
-    -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
+    -v "$PWD/influxdb.conf:/root/influxdb/influxdb.conf" \
     %%IMAGE%%:1.8 -config /root/influxdb/influxdb.conf
 ```
 
@@ -362,7 +362,7 @@ docker run -p 8086:8086 \
     -v influxdb:/root/influxdb/data \
     -v influxdb2:/var/lib/influxdb2 \
     -v influxdb2-config:/etc/influxdb2 \
-    -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
+    -v "$PWD/influxdb.conf:/root/influxdb/influxdb.conf" \
     -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
     -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
     -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
@@ -379,7 +379,7 @@ docker run -p 8086:8086 \
     -v influxdb:/root/influxdb/data \
     -v influxdb2:/root/influxdb2/data \
     -v influxdb2-config:/etc/influxdb2 \
-    -v $PWD/influxdb.conf:/root/influxdb/influxdb.conf \
+    -v "$PWD/influxdb.conf:/root/influxdb/influxdb.conf" \
     -e DOCKER_INFLUXDB_INIT_MODE=upgrade \
     -e DOCKER_INFLUXDB_INIT_USERNAME=my-user \
     -e DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
@@ -409,7 +409,7 @@ To use the InfluxDB Docker Hub data path, start a container that mounts your dat
 ```bash
 # quay.io InfluxDB 2.x container 
 docker run -p 8086:8086 \
-    -v $PWD:/root/.influxdbv2 \
+    -v "$PWD:/root/.influxdbv2" \
     quay.io/influxdb/influxdb:v2.0.3
 ```
 
@@ -418,7 +418,7 @@ Use this command to start an InfluxDB v2 Docker Hub container:
 ```bash
 # Docker Hub InfluxDB 2.x container
 docker run -p 8086:8086 \
-    -v $PWD:/var/lib/influxdb2 \
+    -v "$PWD:/var/lib/influxdb2" \
     %%IMAGE%%:2
 ```
 
@@ -429,7 +429,7 @@ To continue using the `/root/.influxdbv2` data path, customize storage path conf
 ```bash
 # quay.io-hosted InfluxDB 2.x
 docker run -p 8086:8086 \
-    -v $PWD:/root/.influxdbv2 \
+    -v "$PWD:/root/.influxdbv2" \
     quay.io/influxdb/influxdb:v2.0.3
 ```
 
@@ -439,7 +439,7 @@ Use this command to start an InfluxDB v2 Docker Hub container:
 docker run -p 8086:8086 \
     -e INFLUXD_BOLT_PATH=/root/.influxdbv2/influxd.bolt \
     -e INFLUXD_ENGINE_PATH=/root/.influxdbv2/engine \
-    -v $PWD:/root/.influxdbv2 \
+    -v "$PWD:/root/.influxdbv2" \
     %%IMAGE%%:2
 ```
 
@@ -453,7 +453,7 @@ To start an InfluxDB 1.x container, enter the following command:
 
 ```bash
 docker run -p 8086:8086 \
-    -v $PWD:/var/lib/influxdb \
+    -v "$PWD:/var/lib/influxdb" \
     %%IMAGE%%:1.8
 ```
 
@@ -493,7 +493,7 @@ To customize and mount a configuration file, do the following:
 
 	```bash
 	docker run -p 8086:8086 \
-	  -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
+	  -v "$PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro" \
 	  %%IMAGE%%:1.8 -config /etc/influxdb/influxdb.conf
 	```
 
@@ -630,7 +630,7 @@ docker run --rm \
     -e INFLUXDB_ADMIN_PASSWORD=supersecretpassword \
     -e INFLUXDB_USER=telegraf -e \
     -e INFLUXDB_USER_PASSWORD=secretpassword \
-    -v $PWD:/var/lib/influxdb \
+    -v "$PWD:/var/lib/influxdb" \
     %%IMAGE%%:1.8 /init-influxdb.sh
 ```
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -576,11 +576,13 @@ docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
 InfluxDB v1 database initialization
 -----------------------------------
 
+### Not recommended for production
+
+We **don't** recommend using initialization options for InfluxDB v1 production scenarios, but they're useful when running standalone instances for testing.
+
 The InfluxDB Docker Hub image lets you set initialization options when creating an InfluxDB v1 container.
 
 The database initialization script is only called when running `influxd`; it isn't executed by any other program.
-
-**WARNING**: We **don't** recommend using these options for production scenarios, but they're useful when running standalone instances for testing.
 
 ### Environment variables
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -524,9 +524,9 @@ An environment variable overrides the equivalent option in the configuration fil
 
 ```console
 docker run -p 8086:8086 \
-   -e INFLUXDB_REPORTING_DISABLED=true \
-   -e INFLUXDB_META_DIR=/path/to/metadir \
-   -e INFLUXDB_DATA_QUERY_LOG_ENABLED=false \
+    -e INFLUXDB_REPORTING_DISABLED=true \
+    -e INFLUXDB_META_DIR=/path/to/metadir \
+    -e INFLUXDB_DATA_QUERY_LOG_ENABLED=false \
     %%IMAGE%%:1.8
 ```
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -9,8 +9,8 @@ For more information, visit https://influxdata.com.
 
 %%LOGO%%
 
-How to use this image for InfluxDB OSS v2
-=========================================
+How to use this image for InfluxDB v2
+=====================================
 
 **Quick start**: See the guide to [Install InfluxDB v2 for Docker](https://docs.influxdata.com/influxdb/v2/install/?t=Docker) and get started using InfluxDB v2.
 
@@ -453,7 +453,8 @@ How to use this image for InfluxDB v1
 
 Use the InfluxDB Docker Hub image to run and set up an [InfluxDB 1.x](https://docs.influxdata.com/influxdb/v1/) container.
 
-### Running the container
+Running the container
+---------------------
 
 To start an InfluxDB 1.x container, enter the following command:
 
@@ -472,7 +473,8 @@ Replace `$PWD` with the host directory where you want InfluxDB to store data.
 
 *Use Docker [Volumes](https://docs.docker.com/storage/volumes/) or [Bind mounts](https://docs.docker.com/storage/bind-mounts/) to persist InfluxDB [data and configuration directories](https://docs.influxdata.com/influxdb/v1/concepts/file-system-layout/).*
 
-### Networking ports
+Networking ports
+----------------
 
 InfluxDB uses the following networking ports:
 
@@ -481,11 +483,12 @@ InfluxDB uses the following networking ports:
 
 Using the `docker run` [`-P, --publish-all` flag](https://docs.docker.com/reference/cli/docker/container/run/#publish-all) exposes the InfluxDB HTTP API to the host.
 
-### Configure InfluxDB v1 in a container
+Configure InfluxDB v1 in a container
+------------------------------------
 
 To configure InfluxDB v1 in a container, use a configuration file or environment variables.
 
-#### Use a configuration file
+### Use a configuration file
 
 To customize and mount a configuration file, do the following:
 
@@ -505,7 +508,7 @@ To customize and mount a configuration file, do the following:
 
 	Replace `$PWD` with the host directory where you want to store the configuration file.
 
-#### Use environment variables
+### Use environment variables
 
 Pass [`INFLUXDB_` environment variables](https://docs.influxdata.com/influxdb/v1/administration/config/#environment-variables) to override specific InfluxDB v1 configuration options. An environment variable overrides the equivalent option in the configuration file.
 
@@ -519,7 +522,8 @@ docker run -p 8086:8086 \
 
 Learn more about [configuring InfluxDB v1](https://docs.influxdata.com/influxdb/v1.8/administration/config/).
 
-### Graphite
+Graphite
+--------
 
 InfluxDB supports the Graphite line protocol, but the service and ports are not exposed by default. To run InfluxDB with Graphite support enabled, you can either use a configuration file or set the appropriate environment variables. Run InfluxDB with the default Graphite configuration:
 
@@ -531,7 +535,8 @@ docker run -p 8086:8086 -p 2003:2003 \
 
 See the [README on GitHub](https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md) for more detailed documentation to set up the Graphite service. In order to take advantage of graphite templates, you should use a configuration file by outputting a default configuration file using the steps above and modifying the `[[graphite]]` section.
 
-### HTTP API
+InfluxDB v1 HTTP API
+--------------------
 
 Creating a DB named mydb:
 
@@ -547,7 +552,8 @@ curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_sho
 
 Read more about this in the [official documentation](https://docs.influxdata.com/influxdb/latest/guides/writing_data/)
 
-### CLI / SHELL
+CLI / SHELL
+-----------
 
 Start the container:
 
@@ -567,61 +573,62 @@ Or run the influx client in a separate container:
 docker run --rm --link=influxdb -it %%IMAGE%%:1.8 influx -host influxdb
 ```
 
-### Database Initialization
+Database Initialization
+-----------------------
 
 The InfluxDB image contains some extra functionality for initializing a database. These options are not suggested for production, but are quite useful when running standalone instances for testing.
 
 The database initialization script will only be called when running `influxd`. It will not be executed when running any other program.
 
-#### Environment Variables
+### Environment Variables
 
 The InfluxDB image uses several environment variables to automatically configure certain parts of the server. They may significantly aid you in using this image.
 
-##### INFLUXDB_DB
+#### INFLUXDB_DB
 
 Automatically initializes a database with the name of this environment variable.
 
-##### INFLUXDB_HTTP_AUTH_ENABLED
+#### INFLUXDB_HTTP_AUTH_ENABLED
 
 Enables authentication. Either this must be set or `auth-enabled = true` must be set within the configuration file for any authentication related options below to work.
 
-##### INFLUXDB_ADMIN_USER
+#### INFLUXDB_ADMIN_USER
 
 The name of the admin user to be created. If this is unset, no admin user is created.
 
-##### INFLUXDB_ADMIN_PASSWORD
+#### INFLUXDB_ADMIN_PASSWORD
 
 The password for the admin user configured with `INFLUXDB_ADMIN_USER`. If this is unset, a random password is generated and printed to standard out.
 
-##### INFLUXDB_USER
+#### INFLUXDB_USER
 
 The name of a user to be created with no privileges. If `INFLUXDB_DB` is set, this user will be granted read and write permissions for that database.
 
-##### INFLUXDB_USER_PASSWORD
+#### INFLUXDB_USER_PASSWORD
 
 The password for the user configured with `INFLUXDB_USER`. If this is unset, a random password is generated and printed to standard out.
 
-##### INFLUXDB_READ_USER
+#### INFLUXDB_READ_USER
 
 The name of a user to be created with read privileges on `INFLUXDB_DB`. If `INFLUXDB_DB` is not set, this user will have no granted permissions.
 
-##### INFLUXDB_READ_USER_PASSWORD
+#### INFLUXDB_READ_USER_PASSWORD
 
 The password for the user configured with `INFLUXDB_READ_USER`. If this is unset, a random password is generated and printed to standard out.
 
-##### INFLUXDB_WRITE_USER
+#### INFLUXDB_WRITE_USER
 
 The name of a user to be created with write privileges on `INFLUXDB_DB`. If `INFLUXDB_DB` is not set, this user will have no granted permissions.
 
-##### INFLUXDB_WRITE_USER_PASSWORD
+#### INFLUXDB_WRITE_USER_PASSWORD
 
 The password for the user configured with `INFLUXDB_WRITE_USER`. If this is unset, a random password is generated and printed to standard out.
 
-#### Initialization Files
+### Initialization Files
 
 If the Docker image finds any files with the extensions `.sh` or `.iql` inside of the `/docker-entrypoint-initdb.d` folder, it will execute them. The order they are executed in is determined by the shell. This is usually alphabetical order.
 
-#### Manually Initializing the Database
+### Manually Initializing the Database
 
 To manually initialize the database and exit, the `/init-influxdb.sh` script can be used directly. It takes the same parameters as the `influxd run` command. As an example:
 

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -640,4 +640,4 @@ The command creates the following:
 -	an admin user `admin` with the password `supersecretpassword`
 -	a `telegraf` user with the password `secretpassword`
 
-The `-rm` flag causes Docker to exit and delete the container after the script runs. The data and configuration files created during initialization remain in the mounted volume (the host's `$PWD` directory).
+The `--rm` flag causes Docker to exit and delete the container after the script runs. The data and configuration files created during initialization remain in the mounted volume (the host's `$PWD` directory).

--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -630,9 +630,9 @@ The password for the user configured with `INFLUXDB_WRITE_USER`. If this is unse
 
 If the Docker image finds any files with the extensions `.sh` or `.iql` inside of the `/docker-entrypoint-initdb.d` folder, it will execute them. The order they are executed in is determined by the shell. This is usually alphabetical order.
 
-### Manually Initializing the Database
+### Manually Initialize InfluxDB v1
 
-To manually initialize the database and exit, the `/init-influxdb.sh` script can be used directly. It takes the same parameters as the `influxd run` command. As an example:
+To manually initialize an InfluxDB v1 database, use `docker run` to call the `/init-influxdb.sh` script directly. The script takes the same initialization options as the `influxd run` command--for example:
 
 ```console
 docker run --rm \
@@ -645,4 +645,10 @@ docker run --rm \
     %%IMAGE%%:1.8 /init-influxdb.sh
 ```
 
-The above would create the database `db0`, create an admin user with the password `supersecretpassword`, then create the `telegraf` user with your telegraf's secret password. It would then exit and leave behind any files it created in the volume that you mounted.
+The command creates the following:
+
+-	a database named `db0`
+-	an admin user `admin` with the password `supersecretpassword`
+-	a `telegraf` user with the password `secretpassword`
+
+The `-rm` flag causes Docker to exit and delete the container after the script runs. The data and configuration files created during initialization remain in the mounted volume (the host's `$PWD` directory).

--- a/influxdb/variant-data.md
+++ b/influxdb/variant-data.md
@@ -1,7 +1,7 @@
 `%%IMAGE%%:data`
 ----------------
 
-*Using this image for [InfluxDB (v1) Enterprise](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file) requires a valid InfluxData [license key](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file).*
+*Using this image for [InfluxDB Enterprise](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file) requires a valid InfluxData [license key](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file).*
 
 This image contains the enterprise data node package for clustering. It supports all of the same options as the InfluxDB 1.x OSS image, but it needs port 8088 to be exposed to the meta nodes.
 

--- a/influxdb/variant-data.md
+++ b/influxdb/variant-data.md
@@ -1,5 +1,4 @@
-`%%IMAGE%%:data`
-----------------
+## `%%IMAGE%%:data`
 
 *Using this image for [InfluxDB Enterprise](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file) requires a valid InfluxData [license key](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file).*
 

--- a/influxdb/variant-data.md
+++ b/influxdb/variant-data.md
@@ -1,7 +1,7 @@
 `%%IMAGE%%:data`
 ----------------
 
-*This image requires a valid license key from InfluxData.* Please visit our [products page](https://www.influxdata.com/products/) to learn more.
+*Using this image for [InfluxDB (v1) Enterprise](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file) requires a valid InfluxData [license key](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/#license-key-or-file).*
 
 This image contains the enterprise data node package for clustering. It supports all of the same options as the InfluxDB 1.x OSS image, but it needs port 8088 to be exposed to the meta nodes.
 

--- a/influxdb/variant-data.md
+++ b/influxdb/variant-data.md
@@ -1,4 +1,5 @@
-## `%%IMAGE%%:data`
+`%%IMAGE%%:data`
+----------------
 
 *This image requires a valid license key from InfluxData.* Please visit our [products page](https://www.influxdata.com/products/) to learn more.
 

--- a/influxdb/variant-meta.md
+++ b/influxdb/variant-meta.md
@@ -1,4 +1,5 @@
-## `%%IMAGE%%:meta`
+`%%IMAGE%%:meta`
+----------------
 
 *This image requires a valid license key from InfluxData.* Please visit our [products page](https://www.influxdata.com/products/) to learn more.
 
@@ -11,7 +12,7 @@ This image contains the enterprise meta node package for clustering. It is meant
 The license key can be specified using either an environment variable or by overriding the configuration file. If you specify the license key directly, the container needs to be able to access the InfluxData portal.
 
 ```console
-$ docker run -p 8089:8089 -p 8091:8091 \
+docker run -p 8089:8089 -p 8091:8091 \
       -e INFLUXDB_ENTERPRISE_LICENSE_KEY=<license-key>
       %%IMAGE%%:meta
 ```
@@ -23,21 +24,21 @@ The examples below will use docker's built-in networking capability. If you use 
 First, create a docker network:
 
 ```console
-$ docker network create influxdb
+docker network create influxdb
 ```
 
 Start three meta nodes. This is the suggested number of meta nodes. We do not recommend running more or less. If you choose to run more or less, be sure that the number of meta nodes is odd. The hostname must be set on each container to the address that will be used to access the meta node. When using docker networks, the hostname should be made the same as the name of the container.
 
 ```console
-$ docker run -d --name=influxdb-meta-0 --network=influxdb \
+docker run -d --name=influxdb-meta-0 --network=influxdb \
       -h influxdb-meta-0 \
       -e INFLUXDB_ENTERPRISE_LICENSE_KEY=<license-key> \
       %%IMAGE%%:meta
-$ docker run -d --name=influxdb-meta-1 --network=influxdb \
+docker run -d --name=influxdb-meta-1 --network=influxdb \
       -h influxdb-meta-1 \
       -e INFLUXDB_ENTERPRISE_LICENSE_KEY=<license-key> \
       %%IMAGE%%:meta
-$ docker run -d --name=influxdb-meta-2 --network=influxdb \
+docker run -d --name=influxdb-meta-2 --network=influxdb \
       -h influxdb-meta-2 \
       -e INFLUXDB_ENTERPRISE_LICENSE_KEY=<license-key> \
       %%IMAGE%%:meta
@@ -48,16 +49,16 @@ When setting the hostname, you can use `-h <hostname>` or you can directly set t
 After starting the meta nodes, you need to tell them about each other. Choose one of the meta nodes and run `influxd-ctl` in the container.
 
 ```console
-$ docker exec influxdb-meta-0 \
+docker exec influxdb-meta-0 \
       influxd-ctl add-meta influxdb-meta-1:8091
-$ docker exec influxdb-meta-0 \
+docker exec influxdb-meta-0 \
       influxd-ctl add-meta influxdb-meta-2:8091
 ```
 
 Or you can just start a single meta node. If you setup a single meta node, you do not need to use `influxd-ctl add-meta`.
 
 ```console
-$ docker run -d --name=influxdb-meta --network=influxdb \
+docker run -d --name=influxdb-meta --network=influxdb \
       -h influxdb-meta \
       -e INFLUXDB_ENTERPRISE_LICENSE_KEY=<license-key> \
       %%IMAGE%%:meta -single-server
@@ -68,7 +69,7 @@ $ docker run -d --name=influxdb-meta --network=influxdb \
 Start the data nodes using `%%IMAGE%%:data` with similar command line arguments to the meta nodes. You can start as many data nodes as are allowed by your license.
 
 ```console
-$ docker run -d --name=influxdb-data-0 --network=influxdb \
+docker run -d --name=influxdb-data-0 --network=influxdb \
       -h influxdb-data-0 \
       -e INFLUXDB_LICENSE_KEY=<license-key> \
       %%IMAGE%%:data
@@ -77,7 +78,7 @@ $ docker run -d --name=influxdb-data-0 --network=influxdb \
 You can add `-p 8086:8086` to expose the http port to the host machine. After starting the container, choose one of the meta nodes and add the data node to it.
 
 ```console
-$ docker exec influxdb-meta-0 \
+docker exec influxdb-meta-0 \
       influxd-ctl add-data influxdb-data-0:8088
 ```
 
@@ -94,13 +95,13 @@ InfluxDB Meta can be either configured from a config file or using environment v
 Generate the default configuration file:
 
 ```console
-$ docker run --rm %%IMAGE%%:meta influxd-meta config > influxdb-meta.conf
+docker run --rm %%IMAGE%%:meta influxd-meta config > influxdb-meta.conf
 ```
 
 Modify the default configuration, which will now be available under `$PWD`. Then start the InfluxDB Meta container.
 
 ```console
-$ docker run \
+docker run \
       -v $PWD/influxdb-meta.conf:/etc/influxdb/influxdb-meta.conf:ro \
       %%IMAGE%% -config /etc/influxdb/influxdb-meta.conf
 ```

--- a/influxdb/variant-meta.md
+++ b/influxdb/variant-meta.md
@@ -1,5 +1,4 @@
-`%%IMAGE%%:meta`
-----------------
+## `%%IMAGE%%:meta`
 
 *This image requires a valid license key from InfluxData.* Please visit our [products page](https://www.influxdata.com/products/) to learn more.
 
@@ -118,4 +117,4 @@ INFLUXDB_META_DIR=/path/to/metadir
 INFLUXDB_ENTERPRISE_REGISTRATION_ENABLED=true
 ```
 
-Find more about configuring InfluxDB Meta [here](http://docs.influxdata.com/enterprise_influxdb/latest/production_installation/meta_node_installation/).
+For more information, see how to [Install InfluxDB Enterprise meta nodes](https://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/meta_node_installation/).


### PR DESCRIPTION

This PR revises the image description, product names, and procedures and code samples for using the InfluxDB Docker Hub image for InfluxDB v2.

- Updates description to be consistent with marketing and documentation
- Add specificity for product/version naming ("InfluxDB v2")
- Promote automated setup and other Docker-specific aspects
- Replace deprecated `influxd print-config` with `influx server-config` and note the Operator token requirement
- Use the version `2` tag in code samples
- Use canonical `/influxdb/v2` in Docs links
- Rely on `docs.influxdata.com` for Quick Start guide and InfluxDB features not specific to Docker
- Add a section to define ports and file system
