### PR TITLE
Reset mongo express basic auth

### DIFF
--- a/mongo/stack.yml
+++ b/mongo/stack.yml
@@ -19,3 +19,4 @@ services:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
       ME_CONFIG_MONGODB_ADMINPASSWORD: example
       ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
+      ME_CONFIG_BASICAUTH: false


### PR DESCRIPTION
ME_CONFIG_BASICAUTH=false is no longer the default value following https://github.com/mongo-express/mongo-express-docker/commit/ec6ee123c1ecd59a7662680bec407e0913a0321e#diff-8d7a21b017921bb88eaf71656b7b5767203db16e8126fc1e5ad2a9ba0bc542f5R29

If we don't set it to `false`, mongo express will prompt for a basic auth username and password. But such credentials don't exist in `stack.yml`.