### PR TITLE
Add Docker Hub categories

### DIFF
--- a/.ci/check-metadata.sh
+++ b/.ci/check-metadata.sh
@@ -6,4 +6,4 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")/.."
 # metadata.sh takes directories with a 'metadata.json' in them
 # metadata.json is expected in every repo
 # "." so that the canonical source metadata.json is checked too
-./metadata.sh -d -c */ .
+./metadata.sh */ .

--- a/.ci/check-metadata.sh
+++ b/.ci/check-metadata.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")/.."
+
+# metadata.sh takes directories with a 'metadata.json' in them
+# metadata.json is expected in every repo
+# "." so that the canonical source metadata.json is checked too
+./metadata.sh -d -c */ .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,8 @@ jobs:
           fetch-depth: 0
       - run: .ci/check-pr-no-readme.sh
     if: ${{ github.event_name == 'pull_request' }}
+  metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: .ci/check-metadata.sh

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This file should contain a link to the maintainers of the Dockerfile.
 
 ## `metadata.json`
 
-This file contains data about the repo for Docker Hub. The minimum file is defined below. `./metadata.sh [repo-name]` must be used to correctly format it (use `-w` to apply its suggested format changes). Only three sorted unique Docker Hub categories are allowed. `metadata.json` in the root contains the list of categories to choose from.
+This file contains data about the repo for Docker Hub. The minimum file is defined below. `./metadata.sh [repo-name]` must be used to correctly format it (use `-w` to apply its suggested format changes). Only three sorted unique Docker Hub categories are allowed. `metadata.json` in the root contains the list of categories to choose from. See descriptions for the categories on the [Docker docs site](https://docs.docker.com/docker-hub/repos/categories/).
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This file should contain a link to the maintainers of the Dockerfile.
 
 ## `metadata.json`
 
-This file contains data about the repo for Docker Hub. The minimum file is defined below. `./metadata.sh [repo-name]` must be used to correctly format it (use `-f` to apply its suggested changes). There is a limit to the number of Docker Hub categories allowed; run with `-c` to check the limit and categories. `metadata.json` in the root contains the list of categories to choose from.
+This file contains data about the repo for Docker Hub. The minimum file is defined below. `./metadata.sh [repo-name]` must be used to correctly format it (use `-w` to apply its suggested format changes). Only three sorted unique Docker Hub categories are allowed. `metadata.json` in the root contains the list of categories to choose from.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ After opening your Pull Request the changes will be checked by an automated `mar
 -	Create a `license.md` (required)
 -	Create a `maintainer.md` (required)
 -	Create a `github-repo` (required)
+-	Create a `metadata.json` (required)
 -	Add a `logo.png` (recommended)
 
 Optionally:
@@ -127,6 +128,18 @@ The image is automatically scaled to a 120 pixel square for the top of the Docke
 ## `maintainer.md`
 
 This file should contain a link to the maintainers of the Dockerfile.
+
+## `metadata.json`
+
+This file contains data about the repo for Docker Hub. The minimum file is defined below. `./metadata.sh [repo-name]` must be used to correctly format it (use `-f` to apply its suggested changes). There is a limit to the number of Docker Hub categories allowed; run with `-c` to check the limit and categories. `metadata.json` in the root contains the list of categories to choose from.
+
+```json
+{
+    "hub": {
+         "categories": []
+    }
+}
+```
 
 ## `README-short.txt`
 

--- a/adminer/metadata.json
+++ b/adminer/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/aerospike/metadata.json
+++ b/aerospike/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/almalinux/metadata.json
+++ b/almalinux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/alpine/metadata.json
+++ b/alpine/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/alt/metadata.json
+++ b/alt/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/amazoncorretto/metadata.json
+++ b/amazoncorretto/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/amazonlinux/metadata.json
+++ b/amazonlinux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/api-firewall/metadata.json
+++ b/api-firewall/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "security"
+    ]
+  }
+}

--- a/api-firewall/metadata.json
+++ b/api-firewall/metadata.json
@@ -1,7 +1,7 @@
 {
   "hub": {
     "categories": [
-      "security"
+      "api-management"
     ]
   }
 }

--- a/arangodb/metadata.json
+++ b/arangodb/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/archlinux/metadata.json
+++ b/archlinux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/backdrop/metadata.json
+++ b/backdrop/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/bash/metadata.json
+++ b/bash/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/bonita/metadata.json
+++ b/bonita/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/buildpack-deps/metadata.json
+++ b/buildpack-deps/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/busybox/metadata.json
+++ b/busybox/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/caddy/metadata.json
+++ b/caddy/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/cassandra/metadata.json
+++ b/cassandra/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/centos/metadata.json
+++ b/centos/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/chronograf/metadata.json
+++ b/chronograf/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/cirros/metadata.json
+++ b/cirros/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/clearlinux/metadata.json
+++ b/clearlinux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/clefos/metadata.json
+++ b/clefos/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/clojure/metadata.json
+++ b/clojure/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/composer/metadata.json
+++ b/composer/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/consul/metadata.json
+++ b/consul/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/convertigo/metadata.json
+++ b/convertigo/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/couchbase/metadata.json
+++ b/couchbase/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/couchdb/metadata.json
+++ b/couchdb/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/crate/metadata.json
+++ b/crate/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/dart/metadata.json
+++ b/dart/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/debian/metadata.json
+++ b/debian/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/docker/metadata.json
+++ b/docker/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/drupal/metadata.json
+++ b/drupal/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/drupal/metadata.json
+++ b/drupal/metadata.json
@@ -1,7 +1,7 @@
 {
   "hub": {
     "categories": [
-      "languages-and-frameworks"
+      "content-management-system"
     ]
   }
 }

--- a/eclipse-mosquitto/metadata.json
+++ b/eclipse-mosquitto/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "message-queues"
+    ]
+  }
+}

--- a/eclipse-temurin/metadata.json
+++ b/eclipse-temurin/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/eggdrop/metadata.json
+++ b/eggdrop/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/elasticsearch/metadata.json
+++ b/elasticsearch/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/elixir/metadata.json
+++ b/elixir/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/emqx/metadata.json
+++ b/emqx/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "message-queues"
+    ]
+  }
+}

--- a/erlang/metadata.json
+++ b/erlang/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/express-gateway/metadata.json
+++ b/express-gateway/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/fedora/metadata.json
+++ b/fedora/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/flink/metadata.json
+++ b/flink/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "data-science"
+    ]
+  }
+}

--- a/fluentd/metadata.json
+++ b/fluentd/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/friendica/metadata.json
+++ b/friendica/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/gazebo/metadata.json
+++ b/gazebo/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/gcc/metadata.json
+++ b/gcc/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/geonetwork/metadata.json
+++ b/geonetwork/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "data-science"
+    ]
+  }
+}

--- a/get-categories.sh
+++ b/get-categories.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+workdir="$(readlink -f "$BASH_SOURCE")"
+workdir="$(dirname "$workdir")"
+
+jsonFile='metadata.json'
+canonicalMetadataFile="$workdir/$jsonFile"
+
+allCategories="$(curl -fsSL https://hub.docker.com/v2/categories)"
+export allCategories
+
+# add categories slugs to canonicalMetadataFile without losing other keys there
+json="$(
+	jq --sort-keys '
+		(env.allCategories | fromjson) as $allCategories
+		| .hub.categories = ( [ $allCategories[].slug ] | sort )
+	' "$canonicalMetadataFile"
+)"
+
+echo "$json" | tee "$canonicalMetadataFile"

--- a/get-categories.sh
+++ b/get-categories.sh
@@ -7,15 +7,10 @@ workdir="$(dirname "$workdir")"
 jsonFile='metadata.json'
 canonicalMetadataFile="$workdir/$jsonFile"
 
-allCategories="$(curl -fsSL https://hub.docker.com/v2/categories)"
-export allCategories
-
 # add categories slugs to canonicalMetadataFile without losing other keys there
-json="$(
-	jq --sort-keys '
-		(env.allCategories | fromjson) as $allCategories
-		| .hub.categories = ( [ $allCategories[].slug ] | sort )
-	' "$canonicalMetadataFile"
-)"
-
-echo "$json" | tee "$canonicalMetadataFile"
+curl -fsSL https://hub.docker.com/v2/categories | jq -s --sort-keys '
+	.[0] as $allCategories
+	| .[1]
+	| .hub.categories = ( [ $allCategories[].slug ] | sort )
+' - "$canonicalMetadataFile" | tee "$canonicalMetadataFile.new"
+mv "$canonicalMetadataFile.new" "$canonicalMetadataFile"

--- a/ghost/metadata.json
+++ b/ghost/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/golang/metadata.json
+++ b/golang/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/gradle/metadata.json
+++ b/gradle/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/groovy/metadata.json
+++ b/groovy/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/haproxy/metadata.json
+++ b/haproxy/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/haskell/metadata.json
+++ b/haskell/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/haxe/metadata.json
+++ b/haxe/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/hello-world/metadata.json
+++ b/hello-world/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/hitch/metadata.json
+++ b/hitch/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/httpd/metadata.json
+++ b/httpd/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/hylang/metadata.json
+++ b/hylang/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/ibm-semeru-runtimes/metadata.json
+++ b/ibm-semeru-runtimes/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/ibmjava/metadata.json
+++ b/ibmjava/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/influxdb/metadata.json
+++ b/influxdb/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/irssi/metadata.json
+++ b/irssi/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/jetty/metadata.json
+++ b/jetty/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/jobber/metadata.json
+++ b/jobber/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/joomla/metadata.json
+++ b/joomla/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/jruby/metadata.json
+++ b/jruby/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/julia/metadata.json
+++ b/julia/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/kapacitor/metadata.json
+++ b/kapacitor/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/kibana/metadata.json
+++ b/kibana/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/kong/metadata.json
+++ b/kong/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "api-management"
+    ]
+  }
+}

--- a/lightstreamer/metadata.json
+++ b/lightstreamer/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "message-queues"
+    ]
+  }
+}

--- a/liquibase/metadata.json
+++ b/liquibase/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/logstash/metadata.json
+++ b/logstash/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/mageia/metadata.json
+++ b/mageia/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/mariadb/metadata.json
+++ b/mariadb/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/matomo/metadata.json
+++ b/matomo/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/maven/metadata.json
+++ b/maven/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/mediawiki/metadata.json
+++ b/mediawiki/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/memcached/metadata.json
+++ b/memcached/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,22 @@
+{
+  "hub": {
+    "categories": [
+      "api-management",
+      "content-management-system",
+      "data-science",
+      "databases-and-storage",
+      "developer-tools",
+      "integration-and-delivery",
+      "internet-of-things",
+      "languages-and-frameworks",
+      "machine-learning-and-ai",
+      "message-queues",
+      "monitoring-and-observability",
+      "networking",
+      "operating-systems",
+      "security",
+      "web-analytics",
+      "web-servers"
+    ]
+  }
+}

--- a/metadata.sh
+++ b/metadata.sh
@@ -14,38 +14,31 @@ self="$(basename "$0")"
 usage() {
 	cat <<EOUSAGE
 
-usage: $self [--categories] [--diff] [--write] repo [...]
+usage: $self [--write] repo [...]
    ie: $self debian
-       $self -d */
-       $self -dc python
+       $self -w python
 
-This script checks a repo's metadata.json and checks categories, diffs, or formats it.
+This script checks a givens repo's metadata.json. It checks formating (providing a diff), checks categories, and can write the formatting changes.
 
--c, --categories    Check that the categories are from the valid set of categories and that there are no more than $maxCategories. Exits non-zero if there are too many categories or they are unkown.
--d, --diff          Check formatting of the '[repo]/metadata.json' and print a diff. Default action if no flags are supplied. Exits non-zero if there is a difference.
 -h, --help          Print this help output and exit.
--w, --write         Apply the formatting that the '-d' flag would output.
+-w, --write         Apply json formatting (run without to see the diff that would be applied).
 
-Arguments are the list of repos with a 'metadata.json' in them. 'metadata.json' is expected in every repo
+Arguments are the list of repos with a 'metadata.json' in them. 'metadata.json' is expected in every repo.
 '.' can also be passed to check the format of the canonical './metadata.json' at
 the root of the repo, but the max categories of '-c' is skipped for it.
 EOUSAGE
 }
 
 # arg handling
-opts="$(getopt -o 'cdhw' --long 'categories,diff,help,write' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'hw' --long 'help,write' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
-categories=
-diff=
 write=
 
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
-		--categories | -c) categories=1 ;;
-		--diff | -d) diff=1 ;;
 		--help | -h) usage && exit 0 ;;
 		--write | -w) write=1 ;;
 		--) break ;;
@@ -59,11 +52,6 @@ while true; do
 	esac
 done
 
-# default to print diff
-if [ -z "$diff" ] && [ -z "$categories" ] && [ -z "$write" ]; then
-	diff=1
-fi
-
 repos=( "$@" )
 if [ "${#repos[@]}" -eq 0 ]; then
 	repos=( */ )
@@ -73,60 +61,41 @@ repos=( "${repos[@]%/}" )
 failures=0
 for repo in "${repos[@]}"; do
 	repoFile="$repo/$jsonFile"
-	if [ ! -e "$repoFile" ]; then
-		echo >&2 "error: $repoFile does not exist"
+	if [ ! -s "$repoFile" ]; then
+		echo >&2 "error: $repoFile does not exist or is empty"
 		(( failures++ )) || :
 		continue
 	fi
 
-	if [ -n "$diff" ] || [ -n "$write" ]; then
-		# sort object keys and pretty print with jq as our "cannonical json"
-		# sort categories array, no duplicates
-		if ! repoFileJson="$(jq --sort-keys '.hub.categories |= unique' "$repoFile")"; then
-			echo >&2 "error parsing '$repoFile'; invalid JSON?"
+	# sort object keys and pretty print with jq as our "cannonical json"
+	# sort categories array, no duplicates
+	if ! repoFileJson="$(jq -s --sort-keys '.[0] | .hub.categories |= unique' "$repoFile")"; then
+		echo >&2 "error parsing '$repoFile'; invalid JSON?"
+		(( failures++ )) || :
+		continue
+	fi
+	if ! filediff="$(diff -u "$repoFile" <(cat <<<"$repoFileJson"))"; then
+		cat <<<"$filediff"
+		if [ -n "$write" ]; then
+			cat <<<"$repoFileJson" > "$repoFile"
+		else
 			(( failures++ )) || :
-			continue
-		fi
-		if ! filediff="$(diff -u "$repoFile" <(cat <<<"$repoFileJson"))"; then
-			if [ -n "$diff" ]; then
-				cat <<<"$filediff"
-				[ -n "write" ] || (( failures++ )) || :
-			fi
-			if [ -n "$write" ]; then
-				cat <<<"$repoFileJson" > "$repoFile"
-			fi
 		fi
 	fi
 
 	# TODO also check for required keys and/or types?
-	if [ -n "$categories" ]; then
-		# the canonicalMetadataFile doesn't have too many categories since it is the source of categories
-		# all other metadata.json files must not be more than maxCategories
-		if [ "$repoFile" != "$canonicalMetadataFile" ]; then
-			if tooManyCategories="$(jq --raw-output '
-				.hub.categories
-				| length
-				| if . > (env.maxCategories | tonumber) then
-					.
-				else empty end
-			' "$repoFile")"; then
-				if [ -n "$tooManyCategories" ]; then
-					echo >&2 "error: $repoFile: too many categories: $tooManyCategories (max $maxCategories)"
-					(( failures++ )) || :
-				fi
-			else
-				echo >&2 "error parsing '$repoFile'; invalid JSON?"
-				(( failures++ )) || :
-				continue
-			fi
-
-		fi
-		# check for categories that aren't in the canonical set
-		if extraCategories="$(jq -c --slurpfile canonical "$canonicalMetadataFile" '
-			.hub.categories - $canonical[0].hub.categories
+	# the canonicalMetadataFile doesn't have too many categories since it is the source of categories
+	# all other metadata.json files must not be more than maxCategories
+	if [ "$repoFile" != "$canonicalMetadataFile" ]; then
+		if tooManyCategories="$(jq --raw-output '
+			.hub.categories
+			| length
+			| if . > (env.maxCategories | tonumber) then
+				.
+			else empty end
 		' "$repoFile")"; then
-			if [ "$extraCategories" != '[]' ]; then
-				echo >&2 "error: $repoFile: unkown categories: $extraCategories"
+			if [ -n "$tooManyCategories" ]; then
+				echo >&2 "error: $repoFile: too many categories: $tooManyCategories (max $maxCategories)"
 				(( failures++ )) || :
 			fi
 		else
@@ -134,6 +103,20 @@ for repo in "${repos[@]}"; do
 			(( failures++ )) || :
 			continue
 		fi
+	fi
+
+	# check for categories that aren't in the canonical set
+	if extraCategories="$(jq -c --slurpfile canonical "$canonicalMetadataFile" '
+		.hub.categories - $canonical[0].hub.categories
+	' "$repoFile")"; then
+		if [ "$extraCategories" != '[]' ]; then
+			echo >&2 "error: $repoFile: unkown categories: $extraCategories"
+			(( failures++ )) || :
+		fi
+	else
+		echo >&2 "error parsing '$repoFile'; invalid JSON?"
+		(( failures++ )) || :
+		continue
 	fi
 done
 

--- a/metadata.sh
+++ b/metadata.sh
@@ -3,28 +3,28 @@ set -Eeuo pipefail
 
 workdir="$(readlink -f "$BASH_SOURCE")"
 workdir="$(dirname "$workdir")"
-#cd "$workdir"
+cd "$workdir"
 
 jsonFile='metadata.json'
-canonicalMetadataFile="$workdir/$jsonFile"
-maxCategories=3
+canonicalMetadataFile="./$jsonFile"
+export maxCategories=3
 
 self="$(basename "$0")"
 
 usage() {
 	cat <<EOUSAGE
 
-usage: $self [--categories] [--diff] [--fmt] repo [...]
+usage: $self [--categories] [--diff] [--write] repo [...]
    ie: $self debian
        $self -d */
        $self -dc python
 
 This script checks a repo's metadata.json and checks categories, diffs, or formats it.
 
--c, --categories      Check that the categories are from the valid set of categories and that there are no more than $maxCategories. Exits non-zero if there are too many categories or they are unkown.
--d, --diff            Check formatting of the '[repo]/metadata.json' and print a diff. Default action if no flags are supplied. Exits non-zero if there is a difference.
--f, --fmt, --format   Apply the formatting that the '-d' flag would output.
--h, --help            Print this help output and exit.
+-c, --categories    Check that the categories are from the valid set of categories and that there are no more than $maxCategories. Exits non-zero if there are too many categories or they are unkown.
+-d, --diff          Check formatting of the '[repo]/metadata.json' and print a diff. Default action if no flags are supplied. Exits non-zero if there is a difference.
+-h, --help          Print this help output and exit.
+-w, --write         Apply the formatting that the '-d' flag would output.
 
 Arguments are the list of repos with a 'metadata.json' in them. 'metadata.json' is expected in every repo
 '.' can also be passed to check the format of the canonical './metadata.json' at
@@ -33,21 +33,21 @@ EOUSAGE
 }
 
 # arg handling
-opts="$(getopt -o 'cdfh' --long 'categories,diff,fmt,format,help' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'cdhw' --long 'categories,diff,help,write' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
 categories=
 diff=
-fmt=
+write=
 
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
-		--categories|-c) categories=1 ;;
-		--diff|-d) diff=1 ;;
-		--fmt|--format|-f) fmt=1 ;;
-		--help|-h) usage && exit 0 ;;
+		--categories | -c) categories=1 ;;
+		--diff | -d) diff=1 ;;
+		--help | -h) usage && exit 0 ;;
+		--write | -w) write=1 ;;
 		--) break ;;
 		*)
 			{
@@ -60,7 +60,7 @@ while true; do
 done
 
 # default to print diff
-if [ -z "$diff" ] && [ -z "$categories" ] && [ -z "$fmt" ]; then
+if [ -z "$diff" ] && [ -z "$categories" ] && [ -z "$write" ]; then
 	diff=1
 fi
 
@@ -70,37 +70,30 @@ if [ "${#repos[@]}" -eq 0 ]; then
 fi
 repos=( "${repos[@]%/}" )
 
-canonicalMetadataFileJson="$(cat "$canonicalMetadataFile")"
-export canonicalMetadataFileJson
-
-failure=
+failures=0
 for repo in "${repos[@]}"; do
-	repoFile="$workdir/$repo/$jsonFile"
-	if [ ! -f "$repoFile" ]; then
-		failure=1
-		echo "error file does not exist: $repo/$jsonFile"
+	repoFile="$repo/$jsonFile"
+	if [ ! -e "$repoFile" ]; then
+		echo >&2 "error: $repoFile does not exist"
+		(( failures++ )) || :
 		continue
 	fi
-	repoFile="$(readlink -f "$repoFile")"
 
-	if [ -n "$diff" ] || [ -n "$fmt" ]; then
+	if [ -n "$diff" ] || [ -n "$write" ]; then
 		# sort object keys and pretty print with jq as our "cannonical json"
-		# sort categories array
-		if ! repoFilejson="$(jq --sort-keys '.hub.categories |= sort' "$repoFile")"; then
-			echo "error $repo/$jsonFile improper json"
-			failure=1
+		# sort categories array, no duplicates
+		if ! repoFileJson="$(jq --sort-keys '.hub.categories |= unique' "$repoFile")"; then
+			echo >&2 "error parsing '$repoFile'; invalid JSON?"
+			(( failures++ )) || :
 			continue
 		fi
-		if ! filediff="$(diff -u "$repoFile" <(echo "$repoFilejson"))"; then
+		if ! filediff="$(diff -u "$repoFile" <(cat <<<"$repoFileJson"))"; then
 			if [ -n "$diff" ]; then
-				echo >&2 "$repoFile"
-				# skip diff headers
-				echo "$filediff" | tail -n +3
-				failure=1
+				cat <<<"$filediff"
+				[ -n "write" ] || (( failures++ )) || :
 			fi
-			if [ -n "$fmt" ]; then
-				# TODO should fmt + categories remove invalid or categories over max?
-				echo "$repoFilejson" > "$repoFile"
+			if [ -n "$write" ]; then
+				cat <<<"$repoFileJson" > "$repoFile"
 			fi
 		fi
 	fi
@@ -109,32 +102,39 @@ for repo in "${repos[@]}"; do
 	if [ -n "$categories" ]; then
 		# the canonicalMetadataFile doesn't have too many categories since it is the source of categories
 		# all other metadata.json files must not be more than maxCategories
-		if [ "$canonicalMetadataFile" != "$repoFile" ]; then
-			tooManyCategories="$(jq --raw-output '
+		if [ "$repoFile" != "$canonicalMetadataFile" ]; then
+			if tooManyCategories="$(jq --raw-output '
 				.hub.categories
-				| if length > '"$maxCategories"' then
-					length
+				| length
+				| if . > (env.maxCategories | tonumber) then
+					.
 				else empty end
-			' "$repoFile")"
-			if [ -n "$tooManyCategories" ]; then
-				echo >&2 "$repo, error too many Docker Hub categories: $tooManyCategories, max $maxCategories"
-				failure=1
+			' "$repoFile")"; then
+				if [ -n "$tooManyCategories" ]; then
+					echo >&2 "error: $repoFile: too many categories: $tooManyCategories (max $maxCategories)"
+					(( failures++ )) || :
+				fi
+			else
+				echo >&2 "error parsing '$repoFile'; invalid JSON?"
+				(( failures++ )) || :
+				continue
 			fi
+
 		fi
 		# check for categories that aren't in the canonical set
-		extraCategories="$(jq -c '
-			(env.canonicalMetadataFileJson | fromjson | .hub.categories) as $canonicalCategories
-			| .hub.categories
-			| map(. as $cat | select($canonicalCategories | index($cat) < 0))
-			| if length > 0 then . else empty end
-		' "$repoFile")"
-		if [ -n "$extraCategories" ]; then
-			echo >&2 "$repo, error unkown categories: $extraCategories"
-			failure=1
+		if extraCategories="$(jq -c --slurpfile canonical "$canonicalMetadataFile" '
+			.hub.categories - $canonical[0].hub.categories
+		' "$repoFile")"; then
+			if [ "$extraCategories" != '[]' ]; then
+				echo >&2 "error: $repoFile: unkown categories: $extraCategories"
+				(( failures++ )) || :
+			fi
+		else
+			echo >&2 "error parsing '$repoFile'; invalid JSON?"
+			(( failures++ )) || :
+			continue
 		fi
 	fi
 done
 
-if [ "$failure" ]; then
-	exit 1
-fi
+exit "$failures"

--- a/metadata.sh
+++ b/metadata.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+workdir="$(readlink -f "$BASH_SOURCE")"
+workdir="$(dirname "$workdir")"
+#cd "$workdir"
+
+jsonFile='metadata.json'
+canonicalMetadataFile="$workdir/$jsonFile"
+maxCategories=3
+
+self="$(basename "$0")"
+
+usage() {
+	cat <<EOUSAGE
+
+usage: $self [--categories] [--diff] [--fmt] repo [...]
+   ie: $self debian
+       $self -d */
+       $self -dc python
+
+This script checks a repo's metadata.json and checks categories, diffs, or formats it.
+
+-c, --categories      Check that the categories are from the valid set of categories and that there are no more than $maxCategories. Exits non-zero if there are too many categories or they are unkown.
+-d, --diff            Check formatting of the '[repo]/metadata.json' and print a diff. Default action if no flags are supplied. Exits non-zero if there is a difference.
+-f, --fmt, --format   Apply the formatting that the '-d' flag would output.
+-h, --help            Print this help output and exit.
+
+Arguments are the list of repos with a 'metadata.json' in them. 'metadata.json' is expected in every repo
+'.' can also be passed to check the format of the canonical './metadata.json' at
+the root of the repo, but the max categories of '-c' is skipped for it.
+EOUSAGE
+}
+
+# arg handling
+opts="$(getopt -o 'cdfh' --long 'categories,diff,fmt,format,help' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+categories=
+diff=
+fmt=
+
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+		--categories|-c) categories=1 ;;
+		--diff|-d) diff=1 ;;
+		--fmt|--format|-f) fmt=1 ;;
+		--help|-h) usage && exit 0 ;;
+		--) break ;;
+		*)
+			{
+				echo "error: unknown flag: $flag"
+				usage
+			} >&2
+			exit 1
+			;;
+	esac
+done
+
+# default to print diff
+if [ -z "$diff" ] && [ -z "$categories" ] && [ -z "$fmt" ]; then
+	diff=1
+fi
+
+repos=( "$@" )
+if [ "${#repos[@]}" -eq 0 ]; then
+	repos=( */ )
+fi
+repos=( "${repos[@]%/}" )
+
+canonicalMetadataFileJson="$(cat "$canonicalMetadataFile")"
+export canonicalMetadataFileJson
+
+failure=
+for repo in "${repos[@]}"; do
+	repoFile="$workdir/$repo/$jsonFile"
+	if [ ! -f "$repoFile" ]; then
+		failure=1
+		echo "error file does not exist: $repo/$jsonFile"
+		continue
+	fi
+	repoFile="$(readlink -f "$repoFile")"
+
+	if [ -n "$diff" ] || [ -n "$fmt" ]; then
+		# sort object keys and pretty print with jq as our "cannonical json"
+		# sort categories array
+		if ! repoFilejson="$(jq --sort-keys '.hub.categories |= sort' "$repoFile")"; then
+			echo "error $repo/$jsonFile improper json"
+			failure=1
+			continue
+		fi
+		if ! filediff="$(diff -u "$repoFile" <(echo "$repoFilejson"))"; then
+			if [ -n "$diff" ]; then
+				echo >&2 "$repoFile"
+				# skip diff headers
+				echo "$filediff" | tail -n +3
+				failure=1
+			fi
+			if [ -n "$fmt" ]; then
+				# TODO should fmt + categories remove invalid or categories over max?
+				echo "$repoFilejson" > "$repoFile"
+			fi
+		fi
+	fi
+
+	# TODO also check for required keys and/or types?
+	if [ -n "$categories" ]; then
+		# the canonicalMetadataFile doesn't have too many categories since it is the source of categories
+		# all other metadata.json files must not be more than maxCategories
+		if [ "$canonicalMetadataFile" != "$repoFile" ]; then
+			tooManyCategories="$(jq --raw-output '
+				.hub.categories
+				| if length > '"$maxCategories"' then
+					length
+				else empty end
+			' "$repoFile")"
+			if [ -n "$tooManyCategories" ]; then
+				echo >&2 "$repo, error too many Docker Hub categories: $tooManyCategories, max $maxCategories"
+				failure=1
+			fi
+		fi
+		# check for categories that aren't in the canonical set
+		extraCategories="$(jq -c '
+			(env.canonicalMetadataFileJson | fromjson | .hub.categories) as $canonicalCategories
+			| .hub.categories
+			| map(. as $cat | select($canonicalCategories | index($cat) < 0))
+			| if length > 0 then . else empty end
+		' "$repoFile")"
+		if [ -n "$extraCategories" ]; then
+			echo >&2 "$repo, error unkown categories: $extraCategories"
+			failure=1
+		fi
+	fi
+done
+
+if [ "$failure" ]; then
+	exit 1
+fi

--- a/metadata.sh
+++ b/metadata.sh
@@ -14,8 +14,8 @@ self="$(basename "$0")"
 usage() {
 	cat <<EOUSAGE
 
-usage: $self [--write] repo [...]
-   ie: $self debian
+usage: $self [--write] REPO[...]
+   eg: $self debian
        $self -w python
 
 This script checks a givens repo's metadata.json. It checks formating (providing a diff), checks categories, and can write the formatting changes.
@@ -35,7 +35,7 @@ eval set -- "$opts"
 
 write=
 
-while true; do
+while :; do
 	flag="$1"
 	shift
 	case "$flag" in

--- a/mongo-express/metadata.json
+++ b/mongo-express/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/mongo/metadata.json
+++ b/mongo/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/monica/metadata.json
+++ b/monica/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/mono/metadata.json
+++ b/mono/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/mysql/metadata.json
+++ b/mysql/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/nats-streaming/metadata.json
+++ b/nats-streaming/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/nats/metadata.json
+++ b/nats/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "message-queues"
+    ]
+  }
+}

--- a/neo4j/metadata.json
+++ b/neo4j/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/neurodebian/metadata.json
+++ b/neurodebian/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "data-science"
+    ]
+  }
+}

--- a/nextcloud/metadata.json
+++ b/nextcloud/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/nginx/metadata.json
+++ b/nginx/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/node/metadata.json
+++ b/node/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/notary/metadata.json
+++ b/notary/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "security"
+    ]
+  }
+}

--- a/odoo/metadata.json
+++ b/odoo/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/open-liberty/metadata.json
+++ b/open-liberty/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/open-liberty/metadata.json
+++ b/open-liberty/metadata.json
@@ -1,7 +1,7 @@
 {
   "hub": {
     "categories": [
-      "operating-systems"
+      "web-servers"
     ]
   }
 }

--- a/openjdk/metadata.json
+++ b/openjdk/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/oraclelinux/metadata.json
+++ b/oraclelinux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/orientdb/metadata.json
+++ b/orientdb/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/percona/metadata.json
+++ b/percona/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/perl/metadata.json
+++ b/perl/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/photon/metadata.json
+++ b/photon/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/php-zendserver/metadata.json
+++ b/php-zendserver/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/php/metadata.json
+++ b/php/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/phpmyadmin/metadata.json
+++ b/phpmyadmin/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/plone/metadata.json
+++ b/plone/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/postfixadmin/metadata.json
+++ b/postfixadmin/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "developer-tools"
+    ]
+  }
+}

--- a/postgres/metadata.json
+++ b/postgres/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/push.pl
+++ b/push.pl
@@ -8,6 +8,7 @@ use File::Basename qw(basename fileparse);
 use File::Temp;
 use Getopt::Long;
 use Mojo::File;
+use Mojo::JSON qw(decode_json);
 use Mojo::UserAgent;
 use Mojo::Util qw(decode encode trim url_escape);
 
@@ -211,6 +212,32 @@ while (my $repo = shift) { # 'library/hylang', 'tianon/perl', etc
 	my $repoDetails = $repoTx->res->json;
 	$repoDetails->{description} //= '';
 	$repoDetails->{full_description} //= '';
+	$repoDetails->{categories} //= [];
+	my @repoCategories = sort map { $_->{slug} } @{$repoDetails->{categories}};
+	
+	# read local categories from metadata.json
+	my $repoMetadataBytes = Mojo::File->new($repoName . '/metadata.json')->slurp;
+	my $repoMetadataJson = decode_json $repoMetadataBytes;
+	my @localRepoCategories = sort @{$repoMetadataJson->{hub}{categories}};
+	
+	# check if the local categories differ in length or items from the remote
+	my $needCat = @localRepoCategories != @repoCategories;
+	if (! $needCat) {
+		foreach my $i (0..@localRepoCategories) {
+			last if ! defined $repoCategories[$i]; # length difference already covered, so we can bail
+			if ($localRepoCategories[$i] ne $repoCategories[$i]) {
+				$needCat = 1;
+				last;
+			}
+		}
+	}
+	if ($needCat) {
+		say 'updating ' . $repoName . ' categories';
+		my $catsPatch = $ua->patch($repoUrl . 'categories/' => { %$authorizationHeader, Accept => 'application/json' } => json => [
+				map { { slug => $_ => name => 'All those moments will be lost in time, like tears in rain... Time to die.' } } @{$repoMetadataJson->{hub}{categories}}
+			]);
+		die 'patch to categories failed: ' . $catsPatch->res->text unless $catsPatch->res->is_success;
+	}
 	
 	my $hubShort = prompt_for_edit($repoDetails->{description}, $repoName . '/README-short.txt');
 	my $hubLong = prompt_for_edit($repoDetails->{full_description}, $repoName . '/README.md', $hubLengthLimit);

--- a/push.pl
+++ b/push.pl
@@ -213,17 +213,17 @@ while (my $repo = shift) { # 'library/hylang', 'tianon/perl', etc
 	$repoDetails->{description} //= '';
 	$repoDetails->{full_description} //= '';
 	$repoDetails->{categories} //= [];
-	my @repoCategories = sort map { $_->{slug} } @{$repoDetails->{categories}};
+	my @repoCategories = sort map { $_->{slug} } @{ $repoDetails->{categories} };
 	
 	# read local categories from metadata.json
 	my $repoMetadataBytes = Mojo::File->new($repoName . '/metadata.json')->slurp;
 	my $repoMetadataJson = decode_json $repoMetadataBytes;
-	my @localRepoCategories = sort @{$repoMetadataJson->{hub}{categories}};
+	my @localRepoCategories = sort @{ $repoMetadataJson->{hub}{categories} };
 	
 	# check if the local categories differ in length or items from the remote
 	my $needCat = @localRepoCategories != @repoCategories;
 	if (! $needCat) {
-		foreach my $i (0..@localRepoCategories) {
+		foreach my $i (0 .. @localRepoCategories) {
 			last if ! defined $repoCategories[$i]; # length difference already covered, so we can bail
 			if ($localRepoCategories[$i] ne $repoCategories[$i]) {
 				$needCat = 1;
@@ -234,7 +234,10 @@ while (my $repo = shift) { # 'library/hylang', 'tianon/perl', etc
 	if ($needCat) {
 		say 'updating ' . $repoName . ' categories';
 		my $catsPatch = $ua->patch($repoUrl . 'categories/' => { %$authorizationHeader, Accept => 'application/json' } => json => [
-				map { { slug => $_ => name => 'All those moments will be lost in time, like tears in rain... Time to die.' } } @{$repoMetadataJson->{hub}{categories}}
+				map { {
+					slug => $_,
+					name => 'All those moments will be lost in time, like tears in rain... Time to die.',
+				} } @{ $repoMetadataJson->{hub}{categories} }
 			]);
 		die 'patch to categories failed: ' . $catsPatch->res->text unless $catsPatch->res->is_success;
 	}

--- a/pypy/metadata.json
+++ b/pypy/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/python/metadata.json
+++ b/python/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/r-base/metadata.json
+++ b/r-base/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/rabbitmq/metadata.json
+++ b/rabbitmq/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "message-queues"
+    ]
+  }
+}

--- a/rakudo-star/metadata.json
+++ b/rakudo-star/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/redis/metadata.json
+++ b/redis/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/redmine/metadata.json
+++ b/redmine/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/registry/metadata.json
+++ b/registry/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/rethinkdb/metadata.json
+++ b/rethinkdb/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/rocket.chat/metadata.json
+++ b/rocket.chat/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/rockylinux/metadata.json
+++ b/rockylinux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/ros/metadata.json
+++ b/ros/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/ruby/metadata.json
+++ b/ruby/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/rust/metadata.json
+++ b/rust/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/sapmachine/metadata.json
+++ b/sapmachine/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/satosa/metadata.json
+++ b/satosa/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "security"
+    ]
+  }
+}

--- a/satosa/metadata.json
+++ b/satosa/metadata.json
@@ -1,7 +1,7 @@
 {
   "hub": {
     "categories": [
-      "security"
+      "api-management"
     ]
   }
 }

--- a/scratch/metadata.json
+++ b/scratch/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/silverpeas/metadata.json
+++ b/silverpeas/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/sl/metadata.json
+++ b/sl/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/solr/metadata.json
+++ b/solr/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "databases-and-storage"
+    ]
+  }
+}

--- a/sonarqube/metadata.json
+++ b/sonarqube/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "integration-and-delivery"
+    ]
+  }
+}

--- a/spark/metadata.json
+++ b/spark/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "machine-learning-and-ai"
+    ]
+  }
+}

--- a/spark/metadata.json
+++ b/spark/metadata.json
@@ -1,7 +1,7 @@
 {
   "hub": {
     "categories": [
-      "machine-learning-and-ai"
+      "data-science"
     ]
   }
 }

--- a/spiped/metadata.json
+++ b/spiped/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "security"
+    ]
+  }
+}

--- a/storm/metadata.json
+++ b/storm/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "data-science"
+    ]
+  }
+}

--- a/swift/metadata.json
+++ b/swift/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/swipl/metadata.json
+++ b/swipl/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "languages-and-frameworks"
+    ]
+  }
+}

--- a/teamspeak/metadata.json
+++ b/teamspeak/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/telegraf/metadata.json
+++ b/telegraf/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "monitoring-and-observability"
+    ]
+  }
+}

--- a/tomcat/metadata.json
+++ b/tomcat/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/tomee/metadata.json
+++ b/tomee/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/traefik/metadata.json
+++ b/traefik/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "networking"
+    ]
+  }
+}

--- a/ubuntu/metadata.json
+++ b/ubuntu/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "operating-systems"
+    ]
+  }
+}

--- a/unit/metadata.json
+++ b/unit/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/varnish/metadata.json
+++ b/varnish/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/vault/metadata.json
+++ b/vault/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/vault/metadata.json
+++ b/vault/metadata.json
@@ -1,5 +1,7 @@
 {
   "hub": {
-    "categories": []
+    "categories": [
+      "security"
+    ]
   }
 }

--- a/websphere-liberty/metadata.json
+++ b/websphere-liberty/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "web-servers"
+    ]
+  }
+}

--- a/wordpress/metadata.json
+++ b/wordpress/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/xwiki/metadata.json
+++ b/xwiki/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/yourls/metadata.json
+++ b/yourls/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system"
+    ]
+  }
+}

--- a/znc/metadata.json
+++ b/znc/metadata.json
@@ -1,0 +1,5 @@
+{
+  "hub": {
+    "categories": []
+  }
+}

--- a/zookeeper/metadata.json
+++ b/zookeeper/metadata.json
@@ -1,0 +1,7 @@
+{
+  "hub": {
+    "categories": [
+      "message-queues"
+    ]
+  }
+}

--- a/zookeeper/metadata.json
+++ b/zookeeper/metadata.json
@@ -1,7 +1,7 @@
 {
   "hub": {
     "categories": [
-      "message-queues"
+      "databases-and-storage"
     ]
   }
 }


### PR DESCRIPTION
Docker Hub allows owners to set categories for their repos (https://docs.docker.com/docker-hub/repos/categories/), so let's allow our image maintainers in DOI to do it. Categories are not yet visible to users.

To our image maintainers: these initial categories are based on some rough google searching of the contained software and `content.md`, we apologize for any that are inaccurate. Docker Hub currently allows setting up to 3, so if you'd like to add more, just add them to the list in `[repo]/metadata.json`.