### PR TITLE
Update chronograf and kapacitor: Specify how to run as root

### DIFF
--- a/chronograf/content.md
+++ b/chronograf/content.md
@@ -60,6 +60,12 @@ $ docker run -p 8888:8888 \
 
 Try combining this with Telegraf to get dashboards for your infrastructure within minutes!
 
+#### Running as root
+
+Starting in v1.10.5, Chronograf no longer run as the root user by default. If a
+user wants to revert this change they can set `CHRONOGRAF_AS_ROOT=true` as an
+environment variable.
+
 ## Official Documentation
 
 See the [official docs](https://docs.influxdata.com/chronograf/latest/) for information on creating visualizations.

--- a/chronograf/content.md
+++ b/chronograf/content.md
@@ -62,9 +62,7 @@ Try combining this with Telegraf to get dashboards for your infrastructure withi
 
 #### Running as root
 
-Starting in v1.10.5, Chronograf no longer run as the root user by default. If a
-user wants to revert this change they can set `CHRONOGRAF_AS_ROOT=true` as an
-environment variable.
+Starting in v1.10.5, Chronograf no longer run as the root user by default. If a user wants to revert this change they can set `CHRONOGRAF_AS_ROOT=true` as an environment variable.
 
 ## Official Documentation
 

--- a/kapacitor/content.md
+++ b/kapacitor/content.md
@@ -69,9 +69,7 @@ Find more about configuring Kapacitor [here](https://docs.influxdata.com/kapacit
 
 #### Running as root
 
-Starting in v1.7.4, Kapacitor no longer run as the root user by default. If a
-user wants to revert this change they can set `KAPACITOR_AS_ROOT=true` as an
-environment variable.
+Starting in v1.7.4, Kapacitor no longer run as the root user by default. If a user wants to revert this change they can set `KAPACITOR_AS_ROOT=true` as an environment variable.
 
 ### Exposed Ports
 

--- a/kapacitor/content.md
+++ b/kapacitor/content.md
@@ -67,6 +67,12 @@ KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
 
 Find more about configuring Kapacitor [here](https://docs.influxdata.com/kapacitor/latest/introduction/installation/)
 
+#### Running as root
+
+Starting in v1.7.4, Kapacitor no longer run as the root user by default. If a
+user wants to revert this change they can set `KAPACITOR_AS_ROOT=true` as an
+environment variable.
+
 ### Exposed Ports
 
 -	9092 TCP -- HTTP API endpoint


### PR DESCRIPTION
In a recent release we stopped running as the root user, but provided users a way to change this if they wanted to via an env variable. This adds this variable to the docs.