### PR TITLE
Update short description of websphere-liberty and open-liberty

### DIFF
--- a/open-liberty/README-short.txt
+++ b/open-liberty/README-short.txt
@@ -1,1 +1,1 @@
-Open Liberty multi-architecture images based on Ubuntu 18.04
+Open Liberty multi-architecture images based on Ubuntu

--- a/websphere-liberty/README-short.txt
+++ b/websphere-liberty/README-short.txt
@@ -1,1 +1,1 @@
-WebSphere Liberty multi-architecture images based on Ubuntu 18.04
+WebSphere Liberty multi-architecture images based on Ubuntu


### PR DESCRIPTION
The reference to Ubuntu 18.04 in the short description of websphere-liberty and open-liberty is outdated, hence remove it.