### PR TITLE
Joomla Update

### DIFF
--- a/joomla/content.md
+++ b/joomla/content.md
@@ -9,31 +9,45 @@ Joomla is a free and open-source content management system (CMS) for publishing 
 # How to use this image
 
 ```console
-$ docker run --name some-%%REPO%% --link some-mysql:mysql -d %%IMAGE%%
+$ docker run --name some-%%REPO%% --network some-network -d %%IMAGE%%
 ```
 
-The following environment variables are also honored for configuring your Joomla instance:
+The following environment variables are honored for configuring your Joomla instance:
 
--	`-e JOOMLA_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
--	`-e JOOMLA_DB_USER=...` (defaults to "root")
--	`-e JOOMLA_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
--	`-e JOOMLA_DB_NAME=...` (defaults to "joomla")
+- `-e JOOMLA_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
+- `-e JOOMLA_DB_USER=...` (defaults to "root")
+- `-e JOOMLA_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
+- `-e JOOMLA_DB_PASSWORD_FILE=...` (path to a file containing the database password)
+- `-e JOOMLA_DB_NAME=...` (defaults to "joomla")
+- `-e JOOMLA_DB_TYPE=...` (defaults to "mysqli" options: mysqli, pgsql)
 
 If the `JOOMLA_DB_NAME` specified does not already exist on the given MySQL server, it will be created automatically upon startup of the `%%REPO%%` container, provided that the `JOOMLA_DB_USER` specified has the necessary permissions to create it.
+
+The following environment variables are also honored for configuring auto deployment (skip the browser setup) for your Joomla instance:
+
+- `-e JOOMLA_SITE_NAME=...` (name of the Joomla site)
+- `-e JOOMLA_ADMIN_USER=...` (full name of the Joomla administrator)
+- `-e JOOMLA_ADMIN_USERNAME=...` (username of the Joomla administrator)
+- `-e JOOMLA_ADMIN_PASSWORD=...` (password of the Joomla administrator)
+- `-e JOOMLA_ADMIN_EMAIL=...` (email address of the Joomla administrator)
+- `-e JOOMLA_EXTENSIONS_URLS=...` (semicolon-separated list of URLs to install Joomla extensions from)
+- `-e JOOMLA_EXTENSIONS_PATHS=...` (semicolon-separated list of file paths to install Joomla extensions from)
+- `-e JOOMLA_SMTP_HOST=...` (SMTP host for outgoing email)
+- `-e JOOMLA_SMTP_HOST_PORT=...` (SMTP port for outgoing email)
 
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 
 ```console
-$ docker run --name some-%%REPO%% --link some-mysql:mysql -p 8080:80 -d %%IMAGE%%
+$ docker run --name some-%%REPO%% --network joomla-network -p 8080:80 -d %%IMAGE%%
 ```
 
 Then, access it via `http://localhost:8080` or `http://host-ip:8080` in a browser.
 
-If you'd like to use an external database instead of a linked `mysql` container, specify the hostname and port with `JOOMLA_DB_HOST` along with the password in `JOOMLA_DB_PASSWORD` and the username in `JOOMLA_DB_USER` (if it is something other than `root`):
+If you'd like to use an external database instead of a MySQL container, specify the hostname and port with `JOOMLA_DB_HOST` along with the password in `JOOMLA_DB_PASSWORD` and the username in `JOOMLA_DB_USER` (if it is something other than `root`):
 
 ```console
-$ docker run --name some-%%REPO%% -e JOOMLA_DB_HOST=10.1.2.3:3306 \
-    -e JOOMLA_DB_USER=... -e JOOMLA_DB_PASSWORD=... -d %%REPO%%
+$ docker run --name some-%%REPO%% --network joomla-network -e JOOMLA_DB_HOST=10.1.2.3:3306 \
+    -e JOOMLA_DB_USER=... -e JOOMLA_DB_PASSWORD=... -d %%IMAGE%%
 ```
 
 ## %%STACK%%
@@ -44,7 +58,7 @@ Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml
 
 This image does not provide any additional PHP extensions or other libraries, even if they are required by popular plugins. There are an infinite number of possible plugins, and they potentially require any extension PHP supports. Including every PHP extension that exists would dramatically increase the image size.
 
-If you need additional PHP extensions, you'll need to create your own image `FROM` this one. The [documentation of the `php` image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) explains how to compile additional extensions. Additionally, the [`%%REPO%%` Dockerfile](https://github.com/joomla/docker-joomla/blob/966275ada2148e343a68c8c03870f11cc7f5b89c/apache/Dockerfile#L7-L11) has an example of doing this.
+If you need additional PHP extensions, you'll need to create your own image `FROM` this one. The [documentation of the `php` image](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) explains how to compile additional extensions. Additionally, the [`%%REPO%%` Dockerfile](https://github.com/joomla-docker/docker-joomla/blob/360f6bd96c80f72b020d2d9c8aae9daa6bca2887/5.1/php8.3/apache/Dockerfile#L51-L64) has an example of doing this.
 
 The following Docker Hub features can help with the task of keeping your dependent images up-to-date:
 

--- a/joomla/content.md
+++ b/joomla/content.md
@@ -14,26 +14,26 @@ $ docker run --name some-%%REPO%% --network some-network -d %%IMAGE%%
 
 The following environment variables are honored for configuring your Joomla instance:
 
-- `-e JOOMLA_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
-- `-e JOOMLA_DB_USER=...` (defaults to "root")
-- `-e JOOMLA_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
-- `-e JOOMLA_DB_PASSWORD_FILE=...` (path to a file containing the database password)
-- `-e JOOMLA_DB_NAME=...` (defaults to "joomla")
-- `-e JOOMLA_DB_TYPE=...` (defaults to "mysqli" options: mysqli, pgsql)
+-	`-e JOOMLA_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
+-	`-e JOOMLA_DB_USER=...` (defaults to "root")
+-	`-e JOOMLA_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
+-	`-e JOOMLA_DB_PASSWORD_FILE=...` (path to a file containing the database password)
+-	`-e JOOMLA_DB_NAME=...` (defaults to "joomla")
+-	`-e JOOMLA_DB_TYPE=...` (defaults to "mysqli" options: mysqli, pgsql)
 
 If the `JOOMLA_DB_NAME` specified does not already exist on the given MySQL server, it will be created automatically upon startup of the `%%REPO%%` container, provided that the `JOOMLA_DB_USER` specified has the necessary permissions to create it.
 
 The following environment variables are also honored for configuring auto deployment (skip the browser setup) for your Joomla instance:
 
-- `-e JOOMLA_SITE_NAME=...` (name of the Joomla site)
-- `-e JOOMLA_ADMIN_USER=...` (full name of the Joomla administrator)
-- `-e JOOMLA_ADMIN_USERNAME=...` (username of the Joomla administrator)
-- `-e JOOMLA_ADMIN_PASSWORD=...` (password of the Joomla administrator)
-- `-e JOOMLA_ADMIN_EMAIL=...` (email address of the Joomla administrator)
-- `-e JOOMLA_EXTENSIONS_URLS=...` (semicolon-separated list of URLs to install Joomla extensions from)
-- `-e JOOMLA_EXTENSIONS_PATHS=...` (semicolon-separated list of file paths to install Joomla extensions from)
-- `-e JOOMLA_SMTP_HOST=...` (SMTP host for outgoing email)
-- `-e JOOMLA_SMTP_HOST_PORT=...` (SMTP port for outgoing email)
+-	`-e JOOMLA_SITE_NAME=...` (name of the Joomla site)
+-	`-e JOOMLA_ADMIN_USER=...` (full name of the Joomla administrator)
+-	`-e JOOMLA_ADMIN_USERNAME=...` (username of the Joomla administrator)
+-	`-e JOOMLA_ADMIN_PASSWORD=...` (password of the Joomla administrator)
+-	`-e JOOMLA_ADMIN_EMAIL=...` (email address of the Joomla administrator)
+-	`-e JOOMLA_EXTENSIONS_URLS=...` (semicolon-separated list of URLs to install Joomla extensions from)
+-	`-e JOOMLA_EXTENSIONS_PATHS=...` (semicolon-separated list of file paths to install Joomla extensions from)
+-	`-e JOOMLA_SMTP_HOST=...` (SMTP host for outgoing email)
+-	`-e JOOMLA_SMTP_HOST_PORT=...` (SMTP port for outgoing email)
 
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 

--- a/joomla/content.md
+++ b/joomla/content.md
@@ -38,7 +38,7 @@ The following environment variables are also honored for configuring auto deploy
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used:
 
 ```console
-$ docker run --name some-%%REPO%% --network joomla-network -p 8080:80 -d %%IMAGE%%
+$ docker run --name some-%%REPO%% --network some-network -p 8080:80 -d %%IMAGE%%
 ```
 
 Then, access it via `http://localhost:8080` or `http://host-ip:8080` in a browser.
@@ -46,7 +46,7 @@ Then, access it via `http://localhost:8080` or `http://host-ip:8080` in a browse
 If you'd like to use an external database instead of a MySQL container, specify the hostname and port with `JOOMLA_DB_HOST` along with the password in `JOOMLA_DB_PASSWORD` and the username in `JOOMLA_DB_USER` (if it is something other than `root`):
 
 ```console
-$ docker run --name some-%%REPO%% --network joomla-network -e JOOMLA_DB_HOST=10.1.2.3:3306 \
+$ docker run --name some-%%REPO%% --network some-network -e JOOMLA_DB_HOST=10.1.2.3:3306 \
     -e JOOMLA_DB_USER=... -e JOOMLA_DB_PASSWORD=... -d %%IMAGE%%
 ```
 

--- a/joomla/github-repo
+++ b/joomla/github-repo
@@ -1,1 +1,1 @@
-https://github.com/joomla/docker-joomla
+https://github.com/joomla-docker/docker-joomla

--- a/joomla/stack.yml
+++ b/joomla/stack.yml
@@ -1,19 +1,29 @@
-version: '3.1'
-
 services:
+
   joomla:
     image: joomla
     restart: always
-    links:
-      - joomladb:mysql
     ports:
       - 8080:80
     environment:
-      JOOMLA_DB_HOST: joomladb
-      JOOMLA_DB_PASSWORD: example
+      JOOMLA_DB_HOST: db
+      JOOMLA_DB_USER: joomla
+      JOOMLA_DB_PASSWORD: examplepass
+      JOOMLA_DB_NAME: joomla_db
+    volumes:
+      - joomla:/var/www/html
 
-  joomladb:
+  db:
     image: mysql:8.0
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: joomla_db
+      MYSQL_USER: joomla
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  joomla:
+  db:

--- a/joomla/stack.yml
+++ b/joomla/stack.yml
@@ -10,8 +10,15 @@ services:
       JOOMLA_DB_USER: joomla
       JOOMLA_DB_PASSWORD: examplepass
       JOOMLA_DB_NAME: joomla_db
+      JOOMLA_SITE_NAME: Joomla
+      JOOMLA_ADMIN_USER: Joomla Hero
+      JOOMLA_ADMIN_USERNAME: joomla
+      JOOMLA_ADMIN_PASSWORD: joomla@secured
+      JOOMLA_ADMIN_EMAIL: joomla@example.com
     volumes:
-      - joomla:/var/www/html
+      - joomla_data:/var/www/html
+    networks:
+      - joomla_network
 
   db:
     image: mysql:8.0
@@ -22,8 +29,13 @@ services:
       MYSQL_PASSWORD: examplepass
       MYSQL_RANDOM_ROOT_PASSWORD: '1'
     volumes:
-      - db:/var/lib/mysql
+      - db_data:/var/lib/mysql
+    networks:
+      - joomla_network
 
 volumes:
-  joomla:
-  db:
+  joomla_data:
+  db_data:
+
+networks:
+  joomla_network:


### PR DESCRIPTION
Update Joomla Docker documentation to improve clarity and enhance configuration options

- Changed container network configuration to use Docker networks instead of linking containers.
- Introduced new environment variables for database configuration:
  - `JOOMLA_DB_PASSWORD_FILE`: Path to a file containing the database password.
  - `JOOMLA_DB_TYPE`: Database type with options for "mysqli" and "pgsql".
- Added environment variables for auto-deployment configuration:
  - `JOOMLA_SITE_NAME`, `JOOMLA_ADMIN_USER`, `JOOMLA_ADMIN_USERNAME`, `JOOMLA_ADMIN_PASSWORD`, `JOOMLA_ADMIN_EMAIL`
  - `JOOMLA_EXTENSIONS_URLS`, `JOOMLA_EXTENSIONS_PATHS`
  - `JOOMLA_SMTP_HOST`, `JOOMLA_SMTP_HOST_PORT`
- Updated port mapping instructions to reflect the new network setup.
- Corrected the Dockerfile reference link for adding additional PHP extensions.

These changes improve the setup process, provide more flexible configuration options, and correct outdated references.
