### PR TITLE
Update examples from "ruby:3.0" to "ruby:3.3"

### DIFF
--- a/ruby/content.md
+++ b/ruby/content.md
@@ -11,7 +11,7 @@ Ruby is a dynamic, reflective, object-oriented, general-purpose, open-source pro
 ## Create a `Dockerfile` in your Ruby app project
 
 ```dockerfile
-FROM %%IMAGE%%:3.0
+FROM %%IMAGE%%:3.3
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
@@ -40,7 +40,7 @@ $ docker run -it --name my-running-script my-ruby-app
 The above example `Dockerfile` expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
 
 ```console
-$ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app %%IMAGE%%:3.0 bundle install
+$ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app %%IMAGE%%:3.3 bundle install
 ```
 
 ## Run a single Ruby script
@@ -48,7 +48,7 @@ $ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app %%IMAGE%%:3.0 bundle in
 For many simple, single file projects, you may find it inconvenient to write a complete `Dockerfile`. In such cases, you can run a Ruby script by using the Ruby Docker image directly:
 
 ```console
-$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:3.0 ruby your-daemon-or-script.rb
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:3.3 ruby your-daemon-or-script.rb
 ```
 
 ## Encoding

--- a/ruby/content.md
+++ b/ruby/content.md
@@ -59,6 +59,6 @@ By default, Ruby inherits the locale of the environment in which it is run. For 
 
 This image sets several environment variables which change the behavior of Bundler and Gem for running a single application within a container (especially in such a way that the development sources of the application can be bind-mounted inside a container and not have `.bundle` from the host interfere with the proper functionality of the container).
 
-The environment variables we set are canonically listed in the above-linked `Dockerfiles`, but some of them include `GEM_HOME`, `BUNDLE_PATH`, `BUNDLE_BIN`, `BUNDLE_SILENCE_ROOT_WARNING`, and `BUNDLE_APP_CONFIG`.
+The environment variables we set are canonically listed in the above-linked `Dockerfiles`, but some of them include `GEM_HOME`, `BUNDLE_SILENCE_ROOT_WARNING`, and `BUNDLE_APP_CONFIG`.
 
 If these cause issues for your use case (running multiple Ruby applications in a single container, for example), setting them to the empty string *should* be sufficient for undoing their behavior.


### PR DESCRIPTION
Previous: https://github.com/docker-library/docs/pull/2051

3.0 images are not build/updated anymore

-------

In a separate commit, I've dropped mentions of evn variables that were once set but aren't anymore. See https://github.com/docker-library/ruby/pull/209 and https://github.com/docker-library/ruby/pull/306