### PR TITLE
Add newlines between tag groups so they get better line-spacing

### DIFF
--- a/.template-helpers/generate-dockerfile-links-partial.sh
+++ b/.template-helpers/generate-dockerfile-links-partial.sh
@@ -13,7 +13,7 @@ if [ -z "${BASHBREW_LIBRARY:-}" ]; then
 	repo="https://github.com/docker-library/official-images/raw/master/library/$repo"
 fi
 
-if [ -n "$ARCH_SPECIFIC_DOCS" ] && archTags="$(bashbrew cat --format '{{ range .Entries }}{{ if .HasArchitecture arch }}{{ .Tags | first }}{{ "\n" }}{{ end }}{{ end }}' "$repo")" && [ -z "$archTags" ]; then
+if [ -n "$ARCH_SPECIFIC_DOCS" ] && archTags="$(bashbrew list --uniq --arch-filter "$repo")" && [ -z "$archTags" ]; then
 	echo "**WARNING:** THIS IMAGE *IS NOT SUPPORTED* ON THE \`$BASHBREW_ARCH\` ARCHITECTURE"
 	exit
 fi

--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -33,16 +33,14 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 	{{- $url = $url | ternary $url (hasPrefix "https://git.launchpad.net/" $repoUrlBase | ternary (print $repoUrlBase "/tree/" $dockerfilePath "?h=" ($e.ArchGitFetch $arch) "&id=" $gitCommit) "") -}}
 	{{- /* TODO decide what to do (if anything) about other non-GitHub repos with respect to URL */ -}}
 
-	{{- if $i -}}
-		{{- "\n" -}}
-	{{- end -}}
-
 	- {{- "\t" -}}
 	{{- if $url -}} [ {{- end -}}
 	` {{- $e.Tags | join "`, `" -}} `
 	{{- if $url -}} ]( {{- $url -}} ) {{- end -}}
+
+	{{- "\n" -}}
 {{- end -}}
-{{- "\n\n" -}}
+{{- "\n" -}}
 
 {{- if (len $sharedTagGroups) -}}
 	{{- "## Shared Tags\n\n" -}}

--- a/.template-helpers/generate-dockerfile-links-partial.tmpl
+++ b/.template-helpers/generate-dockerfile-links-partial.tmpl
@@ -38,9 +38,8 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 	` {{- $e.Tags | join "`, `" -}} `
 	{{- if $url -}} ]( {{- $url -}} ) {{- end -}}
 
-	{{- "\n" -}}
+	{{- "\n\n" -}}
 {{- end -}}
-{{- "\n" -}}
 
 {{- if (len $sharedTagGroups) -}}
 	{{- "## Shared Tags\n\n" -}}
@@ -51,7 +50,7 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 		{{- if (len $entries) -}}
 			{{- "-\t`" -}}
 			{{ .SharedTags | join "`, `" }}
-			{{- "`:\n" -}}
+			{{- "`:\n\n" -}}
 
 			{{- range $i, $e := $entries -}}
 				{{- $arch := $archSpecific | ternary arch ($e.HasArchitecture arch | ternary arch ($e.Architectures | first)) -}}
@@ -79,6 +78,7 @@ This template defines the "Supported tags and Dockerfile links" portion of an im
 
 				{{- "\n" -}}
 			{{- end -}}
+			{{- "\n" -}}
 		{{- end -}}
 	{{- end -}}
 	{{- "\n" -}}


### PR DESCRIPTION
Especially with Docker Hub's new stylesheets, the tag listing is *really* compressed and hard to scan/read, especially on the really extreme examples like `tomcat`.

This adjusts the line-spacing such that they should have a little more breathing room overall.