### PR TITLE
Update `push.pl` runtime to Perl 5.39 and Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.30-buster
+FROM perl:5.39-bookworm
 
 RUN set -eux; \
 	apt-get update; \


### PR DESCRIPTION
(verified successful/working while testing https://github.com/docker-library/docs/pull/2465)