### PR TITLE
docs(ubuntu): close Mantic and backfill Noble and Oracular

### DIFF
--- a/ubuntu/content.md
+++ b/ubuntu/content.md
@@ -34,5 +34,5 @@ The tarballs published by Canonical, referenced by `dist-*` tags in https://git.
 
 -	[Focal](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/focal/ubuntu-oci)
 -	[Jammy](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/jammy/ubuntu-oci)
--	[Lunar](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/lunar/ubuntu-oci)
--	[Mantic](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/mantic/ubuntu-oci)
+-	[Noble](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/noble/ubuntu-oci)
+-	[Oracular](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/oracular/ubuntu-oci)


### PR DESCRIPTION
Update the docs to remove releases that have reached EOL, and to add Noble and Oracular