### PR TITLE
Officially deprecate `php-zendserver` image

### DIFF
--- a/php-zendserver/README-short.txt
+++ b/php-zendserver/README-short.txt
@@ -1,1 +1,1 @@
-Zend Server - the integrated PHP application platform for mobile and web apps.
+DEPRECATED; Zend Server - the integrated PHP application platform for mobile and web apps.

--- a/php-zendserver/deprecated.md
+++ b/php-zendserver/deprecated.md
@@ -1,0 +1,1 @@
+This image is not actively maintained (and [has not been for years](https://github.com/docker-library/official-images/issues?q=label%3Alibrary%2Fphp-zendserver)). It is highly recommended for users to seek out alternatives.


### PR DESCRIPTION
Quoting https://github.com/docker-library/official-images/pull/16941#issuecomment-2195225594:

> it's been three years since this image has had any meaningful updates (https://github.com/docker-library/official-images/pull/10276)

Closes https://github.com/docker-library/official-images/pull/16941
Closes https://github.com/docker-library/official-images/pull/17016