### PR TITLE
Add `adminer` deprecation notice

### DIFF
--- a/adminer/README-short.txt
+++ b/adminer/README-short.txt
@@ -1,1 +1,1 @@
-Database management in a single PHP file.
+DEPRECATED; Database management in a single PHP file.

--- a/adminer/deprecated.md
+++ b/adminer/deprecated.md
@@ -1,0 +1,5 @@
+Adminer is [no longer maintained (upstream)](https://www.youtube.com/watch?v=OrOtiu_nfHE&lc=Ugy8pAL8wgAL3_iKkzZ4AaABAg.9pj_kQ2rkuw9pp813OyHha):
+
+> I've stopped working on it but maybe I'll return to it some day.
+
+See also [TimWolla/docker-adminer#147](https://github.com/TimWolla/docker-adminer/issues/147). Users are strongly encouraged to seek alternatives.


### PR DESCRIPTION
See https://www.youtube.com/watch?v=OrOtiu_nfHE&lc=Ugy8pAL8wgAL3_iKkzZ4AaABAg.9pj_kQ2rkuw9pp813OyHha (youtube comment), https://github.com/TimWolla/docker-adminer/issues/147, and https://github.com/vrana/adminer -- upstream is not actively maintained (and has not been for years now).  We should reflect/document that status accurately on Docker Hub.