### PR TITLE
Officially deprecate ClefOS

### DIFF
--- a/clefos/README-short.txt
+++ b/clefos/README-short.txt
@@ -1,1 +1,1 @@
-The official build of ClefOS.
+DEPRECATED; The official build of ClefOS.

--- a/clefos/deprecated.md
+++ b/clefos/deprecated.md
@@ -1,0 +1,1 @@
+With [the EOL of CentOS 7 (June 30, 2024)](https://www.redhat.com/en/topics/linux/centos-linux-eol), this image/project is [officially deprecated](https://github.com/docker-library/official-images/pull/7964#issuecomment-2253636315). Please adjust your usage accordingly.


### PR DESCRIPTION
cc @nealef for a vibe and wording check :heart:

(I'm honestly kind of sad to see it go, because it was fun and even sometimes helpful for catching bugs/assumptions to have a DOI that _didn't_ support `amd64`, but alas - end of an era :smile:)

Refs https://github.com/docker-library/official-images/pull/7964#issuecomment-2253636315