### PR TITLE
Deprecate `mono` image (due to maintainer inactivity)

### DIFF
--- a/mono/README-short.txt
+++ b/mono/README-short.txt
@@ -1,1 +1,1 @@
-Mono is an open source implementation of Microsoft's .NET Framework
+DEPRECATED; Mono is an open source implementation of Microsoft's .NET Framework

--- a/mono/deprecated.md
+++ b/mono/deprecated.md
@@ -1,0 +1,1 @@
+This image is deprecated due to maintainer inactivity (last updated Jun 2022; [docker-library/official-images#12682](https://github.com/docker-library/official-images/pull/12682)).


### PR DESCRIPTION
- https://github.com/docker-library/official-images/pull/12682#issuecomment-1875991681
- https://github.com/docker-library/official-images/pull/17091#issuecomment-2201099734

:disappointed:

(This is easy to revert if y'all want to revive the image! :heart:)