### PR TITLE
Update docs for Caddy image with a fix to its reload feature

### DIFF
--- a/caddy/content.md
+++ b/caddy/content.md
@@ -123,7 +123,7 @@ See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for more details.
 
 ### Docker Compose example
 
-If you prefer to use `docker compose` to run your stack, here's a sample service definition which goes in a file named `compose.yaml`. 
+If you prefer to use `docker compose` to run your stack, here's a sample service definition which goes in a file named `compose.yaml`.
 
 ```yaml
 services:

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -123,7 +123,7 @@ See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for more details.
 
 ### Docker Compose example
 
-If you prefer to use `docker-compose` to run your stack, here's a sample service definition which goes into your `compose.yaml`. 
+If you prefer to use `docker compose` to run your stack, here's a sample service definition which goes in a file named `compose.yaml`. 
 
 ```yaml
 services:

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -46,7 +46,7 @@ $ docker run -d -p 80:80 \
 
 #### ⚠️ Do not mount the Caddyfile directly at `/etc/caddy/Caddyfile`
 
-This effectively disables Caddy's graceful reload feature in many cases depending on the way you apply changes to the file as discussed in [this issue](https://github.com/caddyserver/caddy/issues/5735#issuecomment-1675896585).
+If vim or another editor is used that changes the inode of the edited file, the changes will only be applied within the container when the container is recreated , which is explained in detail in this [Medium article](https://medium.com/@jonsbun/why-need-to-be-careful-when-mounting-single-files-into-a-docker-container-4f929340834). When using such an editor, Caddy's graceful reload functionality might not work as expected, as described in [this issue](https://github.com/caddyserver/caddy/issues/5735#issuecomment-1675896585).
 
 ### Automatic TLS with the Caddy image
 

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -35,7 +35,7 @@ $ curl http://localhost/
 hello world
 ```
 
-To override the default [`Caddyfile`](https://github.com/caddyserver/dist/blob/master/config/Caddyfile), you can create one in the subfolder `caddyfile` at `$PWD/caddyfile/Caddyfile` and mount this folder at `/etc/caddy`:
+To override the default [`Caddyfile`](https://github.com/caddyserver/dist/blob/master/config/Caddyfile), you can create one in the subfolder `conf` at `$PWD/conf/Caddyfile` and mount this folder at `/etc/caddy`:
 
 ```console
 $ docker run -d -p 80:80 \

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -150,4 +150,4 @@ volumes:
 
 Defining the data volume as [`external`](https://docs.docker.com/compose/compose-file/compose-file-v3/#external) makes sure `docker-compose down` does not delete the volume. You may need to create it manually using `docker volume create [project-name]_caddy_data`.
 
-Graceful reloads can then be conducted via `docker compose exec --workdir /etc/caddy caddy caddy reload`.
+Graceful reloads can then be conducted via `docker compose exec -w /etc/caddy caddy caddy reload`.

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -144,10 +144,7 @@ services:
 
 volumes:
   caddy_data:
-    external: true
   caddy_config:
 ```
-
-Defining the data volume as [`external`](https://docs.docker.com/compose/compose-file/compose-file-v3/#external) makes sure `docker-compose down` does not delete the volume. You may need to create it manually using `docker volume create [project-name]_caddy_data`.
 
 Graceful reloads can then be conducted via `docker compose exec -w /etc/caddy caddy caddy reload`.

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -46,7 +46,7 @@ $ docker run -d -p 80:80 \
 
 #### ⚠️ Do not mount the Caddyfile directly at `/etc/caddy/Caddyfile`
 
-If vim or another editor is used that changes the inode of the edited file, the changes will only be applied within the container when the container is recreated , which is explained in detail in this [Medium article](https://medium.com/@jonsbun/why-need-to-be-careful-when-mounting-single-files-into-a-docker-container-4f929340834). When using such an editor, Caddy's graceful reload functionality might not work as expected, as described in [this issue](https://github.com/caddyserver/caddy/issues/5735#issuecomment-1675896585).
+If vim or another editor is used that changes the inode of the edited file, the changes will only be applied within the container when the container is recreated, which is explained in detail in this [Medium article](https://medium.com/@jonsbun/why-need-to-be-careful-when-mounting-single-files-into-a-docker-container-4f929340834). When using such an editor, Caddy's graceful reload functionality might not work as expected, as described in [this issue](https://github.com/caddyserver/caddy/issues/5735#issuecomment-1675896585).
 
 ### Automatic TLS with the Caddy image
 

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -39,7 +39,7 @@ To override the default [`Caddyfile`](https://github.com/caddyserver/dist/blob/m
 
 ```console
 $ docker run -d -p 80:80 \
-    -v $PWD/caddyfile:/etc/caddy \
+    -v $PWD/conf:/etc/caddy \
     -v caddy_data:/data \
     %%IMAGE%%
 ```

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -123,7 +123,7 @@ See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for more details.
 
 ### Docker Compose example
 
-If you prefer to use `docker compose` to run your stack, here's a sample service definition which goes in a file named `compose.yaml`.
+If you prefer to use `docker compose` to run your stack, here's a sample service definition which goes in a file named `compose.yaml`. The configuration assumes you put a custom Caddyfile into `$PWD/conf` as described [above](#basic-usage).
 
 ```yaml
 services:
@@ -137,7 +137,7 @@ services:
       - "443:443"
       - "443:443/udp"
     volumes:
-      - $PWD/caddyfile:/etc/caddy
+      - $PWD/conf:/etc/caddy
       - $PWD/site:/srv
       - caddy_data:/data
       - caddy_config:/config

--- a/caddy/content.md
+++ b/caddy/content.md
@@ -35,14 +35,18 @@ $ curl http://localhost/
 hello world
 ```
 
-To override the default [`Caddyfile`](https://github.com/caddyserver/dist/blob/master/config/Caddyfile), you can mount a new one at `/etc/caddy/Caddyfile`:
+To override the default [`Caddyfile`](https://github.com/caddyserver/dist/blob/master/config/Caddyfile), you can create one in the subfolder `caddyfile` at `$PWD/caddyfile/Caddyfile` and mount this folder at `/etc/caddy`:
 
 ```console
 $ docker run -d -p 80:80 \
-    -v $PWD/Caddyfile:/etc/caddy/Caddyfile \
+    -v $PWD/caddyfile:/etc/caddy \
     -v caddy_data:/data \
     %%IMAGE%%
 ```
+
+#### ⚠️ Do not mount the Caddyfile directly at `/etc/caddy/Caddyfile`
+
+This effectively disables Caddy's graceful reload feature in many cases depending on the way you apply changes to the file as discussed in [this issue](https://github.com/caddyserver/caddy/issues/5735#issuecomment-1675896585).
 
 ### Automatic TLS with the Caddy image
 
@@ -119,11 +123,9 @@ See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for more details.
 
 ### Docker Compose example
 
-If you prefer to use `docker-compose` to run your stack, here's a sample service definition.
+If you prefer to use `docker-compose` to run your stack, here's a sample service definition which goes into your `compose.yaml`. 
 
 ```yaml
-version: "3.7"
-
 services:
   caddy:
     image: %%IMAGE%%:<version>
@@ -135,7 +137,7 @@ services:
       - "443:443"
       - "443:443/udp"
     volumes:
-      - $PWD/Caddyfile:/etc/caddy/Caddyfile
+      - $PWD/caddyfile:/etc/caddy
       - $PWD/site:/srv
       - caddy_data:/data
       - caddy_config:/config
@@ -147,3 +149,5 @@ volumes:
 ```
 
 Defining the data volume as [`external`](https://docs.docker.com/compose/compose-file/compose-file-v3/#external) makes sure `docker-compose down` does not delete the volume. You may need to create it manually using `docker volume create [project-name]_caddy_data`.
+
+Graceful reloads can then be conducted via `docker compose exec --workdir /etc/caddy caddy caddy reload`.


### PR DESCRIPTION
Last August unexpected behaviour of the graceful reload feature was discussed in this [upstream issue](https://github.com/caddyserver/caddy/issues/5735) and a fix proposed alongside the suggestion to add that fix to the docs. This has not yet happened but should be solved by this PR.

This is my first contribution here, so if there is anything I should address to finalize this PR, I ask you kindly to let me know.

This one resolves #1858 as well.