### PR TITLE
docs: update readme to indicate the port binding

### DIFF
--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -102,14 +102,6 @@ To run a cluster with the Data Center Edition, please refer to Installing SonarQ
 
 ## Configuration
 
-### Port binding
-
-By default, the image will use port 9000
-
-```console
-docker container run --name sonarqube-custom -p 9000:9000 sonarqube:10.6.0-community
-```
-
 ### Database
 
 By default, the image will use an embedded H2 database that is not suited for production.
@@ -139,7 +131,7 @@ For upgrade instructions, see Upgrading from the Docker Image on the [Upgrade th
 In some environments, it may make more sense to prepare a custom image containing your configuration. A `Dockerfile` to achieve this may be as simple as:
 
 ```dockerfile
-FROM sonarqube:10.6.0-community
+FROM sonarqube:8.9-community
 COPY sonar-custom-plugin-1.0.jar /opt/sonarqube/extensions/
 ```
 

--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -102,6 +102,14 @@ To run a cluster with the Data Center Edition, please refer to Installing SonarQ
 
 ## Configuration
 
+### Port binding
+
+By default, the image will use port 9000
+
+```console
+docker container run --name sonarqube-custom -p 9000:9000 sonarqube:10.6.0-community
+```
+
 ### Database
 
 By default, the image will use an embedded H2 database that is not suited for production.
@@ -131,7 +139,7 @@ For upgrade instructions, see Upgrading from the Docker Image on the [Upgrade th
 In some environments, it may make more sense to prepare a custom image containing your configuration. A `Dockerfile` to achieve this may be as simple as:
 
 ```dockerfile
-FROM sonarqube:8.9-community
+FROM sonarqube:10.6.0-community
 COPY sonar-custom-plugin-1.0.jar /opt/sonarqube/extensions/
 ```
 

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -59,9 +59,9 @@ Set up a database by following the "Installing the Database" section of https://
 
 We recommend creating volumes for the following directories:
 
-- `/opt/sonarqube/data`: data files, such as the embedded H2 database and Elasticsearch indexes
-- `/opt/sonarqube/logs`: contains SonarQube logs about access, web process, CE process, Elasticsearch logs
-- `/opt/sonarqube/extensions`: for 3rd party plugins
+-	`/opt/sonarqube/data`: data files, such as the embedded H2 database and Elasticsearch indexes
+-	`/opt/sonarqube/logs`: contains SonarQube logs about access, web process, CE process, Elasticsearch logs
+-	`/opt/sonarqube/extensions`: for 3rd party plugins
 
 > **Warning:** You cannot use the same volumes on multiple instances of SonarQube.
 

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -37,6 +37,14 @@ To run a cluster with the Data Center Edition, please refer to Installing SonarQ
 
 ## Configuration
 
+### Port binding
+
+By default, the server running within the container will listen on port 9000. You can expose the container port 9000 to the host port 9000 with the `-p 9000:9000` argument to `docker container run`, like the command below:
+
+```console
+docker container run --name sonarqube-custom -p 9000:9000 sonarqube:10.6-community
+```
+
 ### Database
 
 By default, the image will use an embedded H2 database that is not suited for production.
@@ -49,9 +57,9 @@ Set up a database by following the "Installing the Database" section of https://
 
 We recommend creating volumes for the following directories:
 
--	`/opt/sonarqube/data`: data files, such as the embedded H2 database and Elasticsearch indexes
--	`/opt/sonarqube/logs`: contains SonarQube logs about access, web process, CE process, Elasticsearch logs
--	`/opt/sonarqube/extensions`: for 3rd party plugins
+- `/opt/sonarqube/data`: data files, such as the embedded H2 database and Elasticsearch indexes
+- `/opt/sonarqube/logs`: contains SonarQube logs about access, web process, CE process, Elasticsearch logs
+- `/opt/sonarqube/extensions`: for 3rd party plugins
 
 > **Warning:** You cannot use the same volumes on multiple instances of SonarQube.
 
@@ -66,7 +74,7 @@ For upgrade instructions, see Upgrading from the Docker Image on the [Upgrade th
 In some environments, it may make more sense to prepare a custom image containing your configuration. A `Dockerfile` to achieve this may be as simple as:
 
 ```dockerfile
-FROM sonarqube:8.9-community
+FROM sonarqube:10.6-community
 COPY sonar-custom-plugin-1.0.jar /opt/sonarqube/extensions/
 ```
 
@@ -74,7 +82,7 @@ You could then build and try the image with something like:
 
 ```console
 $ docker build --tag=sonarqube-custom .
-$ docker run -ti sonarqube-custom
+$ docker container run -ti sonarqube-custom
 ```
 
 ### Avoid hard termination of SonarQube

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -84,7 +84,7 @@ You could then build and try the image with something like:
 
 ```console
 $ docker build --tag=sonarqube-custom .
-$ docker container run -ti sonarqube-custom
+$ docker run -ti sonarqube-custom
 ```
 
 ### Avoid hard termination of SonarQube

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -39,7 +39,7 @@ To run a cluster with the Data Center Edition, please refer to Installing SonarQ
 
 ### Port binding
 
-By default, the server running within the container will listen on port 9000. You can expose the container port 9000 to the host port 9000 with the `-p 9000:9000` argument to `docker container run`, like the command below:
+By default, the server running within the container will listen on port 9000. You can expose the container port 9000 to the host port 9000 with the `-p 9000:9000` argument to `docker run`, like the command below:
 
 ```console
 docker container run --name sonarqube-custom -p 9000:9000 sonarqube:10.6-community

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -42,7 +42,7 @@ To run a cluster with the Data Center Edition, please refer to Installing SonarQ
 By default, the server running within the container will listen on port 9000. You can expose the container port 9000 to the host port 9000 with the `-p 9000:9000` argument to `docker run`, like the command below:
 
 ```console
-docker container run --name sonarqube-custom -p 9000:9000 sonarqube:10.6-community
+docker run --name sonarqube-custom -p 9000:9000 %%IMAGE%%:10.6-community
 ```
 
 You can then browse to `http://localhost:9000` or `http://host-ip:9000` in your web browser to access the SonarQube web interface.

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -45,6 +45,8 @@ By default, the server running within the container will listen on port 9000. Yo
 docker container run --name sonarqube-custom -p 9000:9000 sonarqube:10.6-community
 ```
 
+You can then browse to `http://localhost:9000` or `http://host-ip:9000` in your web browser to access the SonarQube web interface.
+
 ### Database
 
 By default, the image will use an embedded H2 database that is not suited for production.

--- a/sonarqube/content.md
+++ b/sonarqube/content.md
@@ -76,7 +76,7 @@ For upgrade instructions, see Upgrading from the Docker Image on the [Upgrade th
 In some environments, it may make more sense to prepare a custom image containing your configuration. A `Dockerfile` to achieve this may be as simple as:
 
 ```dockerfile
-FROM sonarqube:10.6-community
+FROM %%IMAGE%%:10.6-community
 COPY sonar-custom-plugin-1.0.jar /opt/sonarqube/extensions/
 ```
 


### PR DESCRIPTION
In order to make it easier for developers who want to run SonarQube in a container, I think it is worth indicating the port binding when running the docker run command.

Our exemple are using the tag 10.6.0-community