### PR TITLE
Update Redis repository URL to the Correct URL

### DIFF
--- a/redis/github-repo
+++ b/redis/github-repo
@@ -1,1 +1,1 @@
-https://github.com/docker-library/redis
+https://github.com/redis/docker-library-redis


### PR DESCRIPTION
This PR updates the `git-repo` URL to the updated location of the Redis URL.