### PR TITLE
Update content.md

### DIFF
--- a/aerospike/content.md
+++ b/aerospike/content.md
@@ -169,7 +169,7 @@ For more, see [How do I get a 2 nodes Aerospike cluster running quickly in Docke
 
 ## Image Versions
 
-These images are based on [ubuntu:22.04](https://hub.docker.com/_/ubuntu).
+These images are based on [ubuntu:24.04](https://hub.docker.com/_/ubuntu).
 
 ### ee-[version]
 


### PR DESCRIPTION
Starting on Aerospike 7.2.0.1 release, ubuntu 24.04 is used as base image.