### PR TITLE
Update README.md

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -337,7 +337,7 @@ initdb: could not look up effective user ID 1000: user does not exist
 
 The four easiest ways to get around this:
 
-1.	on host machine, use the matching UID:GID that the container installs for postgres user/group. This being 999:999 for Debian based containers and 70:70 for Alpine based containers.
+1.	on the host, use the same UID:GID that the container defines for postgres user/group. These are 999:999 for Debian based containers and 70:70 for Alpine based containers.
 
 2.	allow the image to use [the `nss_wrapper` library](https://cwrap.org/nss_wrapper.html) to "fake" `/etc/passwd` contents for you (see [docker-library/postgres#448](https://github.com/docker-library/postgres/pull/448) for more details)
 


### PR DESCRIPTION
Add the simplest solution to this issue as #1.

Why the same UID:GID was not used for both Alpine and Debian containers is silly.. but either way people can choose to use locally the same UID:GID which the container uses internally to avoid this issue in a much easier way than the other proposed solutions.