### PR TITLE
Correct IBM Semeru Tag info in Example 

### DIFF
--- a/ibm-semeru-runtimes/content.md
+++ b/ibm-semeru-runtimes/content.md
@@ -11,7 +11,7 @@ The IBM Semeru Runtimes are free production-ready open source binaries built wit
 To run a pre-built japp.jar file with the latest OpenJDK 11, use the following Dockerfile:
 
 ```dockerfile
-FROM %%IMAGE%%:11
+FROM %%IMAGE%%:open-11-jdk
 RUN mkdir /opt/app
 COPY japp.jar /opt/app
 CMD ["java", "-jar", "/opt/app/japp.jar"]
@@ -32,6 +32,6 @@ If you are using a distribution that we don't provide an image for you can copy 
 # Example
 FROM <base image>
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=%%IMAGE%%:11 $JAVA_HOME $JAVA_HOME
+COPY --from=%%IMAGE%%:open-11-jdk $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ```


### PR DESCRIPTION
The example in https://hub.docker.com/_/ibm-semeru-runtimes has incorrect tag, which is corrected as part of this update.  