### PR TITLE
docs: update deprecated/outdated compose syntax and filenames

### DIFF
--- a/backdrop/content.md
+++ b/backdrop/content.md
@@ -44,9 +44,9 @@ $ docker run --name some-%%REPO%% \
   -d %%REPO%%
 ```
 
-## ... via [`docker-compose`](https://github.com/docker/compose)
+## ... via [Docker Compose](https://github.com/docker/compose)
 
-Example `docker-compose.yml` for `%%REPO%%`:
+Example `compose.yaml` for `%%REPO%%`:
 
 ```yaml
 %%REPO%%:
@@ -65,7 +65,7 @@ db:
     MYSQL_DATABASE: %%REPO%%
 ```
 
-Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
+Run `docker compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
 
 ## Adding additional libraries / extensions
 

--- a/bonita/content.md
+++ b/bonita/content.md
@@ -38,7 +38,7 @@ This image is built from the following [GitHub repository](https://github.com/Bo
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 -	Replace `<hostname>` with the one used in the licence generation command
 -	leave double `$$` untouched

--- a/cassandra/content.md
+++ b/cassandra/content.md
@@ -114,4 +114,4 @@ The `-v /my/own/datadir:/var/lib/cassandra` part of the command mounts the `/my/
 
 ## No connections until Cassandra init completes
 
-If there is no database initialized when the container starts, then a default database will be created. While this is the expected behavior, this means that it will not accept incoming connections until such initialization completes. This may cause issues when using automation tools, such as `docker-compose`, which start several containers simultaneously.
+If there is no database initialized when the container starts, then a default database will be created. While this is the expected behavior, this means that it will not accept incoming connections until such initialization completes. This may cause issues when using automation tools, such as Docker Compose, which start several containers simultaneously.

--- a/convertigo/content.md
+++ b/convertigo/content.md
@@ -275,13 +275,13 @@ The default `ENABLE_JDWP_DEBUG` value is **false** and can be defined this way:
 $ docker run -d –name C8O -e ENABLE_JDWP_DEBUG=true -p 28080:28080 %%IMAGE%%
 ```
 
-## Pre configurated Docker compose stack
+## Pre-configurated Docker Compose file
 
-You can use this [stack](https://github.com/convertigo/docker/blob/master/compose/mbaas/docker-compose.yml) to run a complete Convertigo Low Code server with FullSync repository and MySQL analytics in a few command lines.
+You can use [this Docker Compose file](https://github.com/convertigo/docker/blob/master/compose/mbaas/docker-compose.yml) to run a complete Convertigo Low Code server with FullSync repository and MySQL analytics in a few command lines.
 
 ```console
 $ mkdir c8oMBaaS
 $ cd c8oMBaaS
 $ wget https://raw.githubusercontent.com/convertigo/docker/master/compose/mbaas/docker-compose.yml
-$ docker-compose up -d
+$ docker compose up -d
 ```

--- a/drupal/content.md
+++ b/drupal/content.md
@@ -100,7 +100,7 @@ $ docker run --name some-%%REPO%% --network some-network -d \
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate). When installing select `postgres` as database with the following parameters: `dbname=postgres` `user=postgres` `pass=example` `hostname=postgres`
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate). When installing select `postgres` as database with the following parameters: `dbname=postgres` `user=postgres` `pass=example` `hostname=postgres`
 
 ## Adding additional libraries / extensions
 

--- a/eggdrop/content.md
+++ b/eggdrop/content.md
@@ -104,13 +104,13 @@ to your docker run command line.
 
 ## Common Errors
 
-# docker-compose.yml
+# compose.yaml
 
-A docker-compose.yml example is hosted at https://github.com/eggheads/eggdrop-docker/blob/master/docker-compose.yml . A common error creating your own docker-compose.yml file from scratch is not adding
+A `docker-compose.yml` example is hosted at https://github.com/eggheads/eggdrop-docker/blob/master/docker-compose.yml. A common error creating your own Docker Compose file from scratch is not adding:
 
 	stdin_open: true
 
-to the docker-compose.yml file. Without it, Eggdrop will give you an "END OF FILE ON TERMINAL" error and not start.
+Without it, Eggdrop will give you an "END OF FILE ON TERMINAL" error and not start.
 
 ## Troubleshooting / Support
 

--- a/emqx/content.md
+++ b/emqx/content.md
@@ -62,53 +62,51 @@ If not specified, EMQX determines its node name based on the running environment
 
 EMQX supports a variety of clustering methods, see our [documentation](https://docs.emqx.com/en/emqx/latest/deploy/cluster/create-cluster.html) for details.
 
-Let's create a static node list cluster from docker-compose.
+Let's create a static node list cluster from Docker Compose.
 
--	Create `docker-compose.yaml`:
+-	Create `compose.yaml`:
 
 ```yaml
-  version: '3'
+services:
+  emqx1:
+    image: %%IMAGE%%:latest
+    environment:
+    - "EMQX_NODE__NAME=emqx@node1.emqx.io"
+    - "EMQX_CLUSTER__DISCOVERY_STRATEGY=static"
+    - "EMQX_CLUSTER__STATIC__SEEDS=[emqx@node1.emqx.io, emqx@node2.emqx.io]"
+    networks:
+      emqx-bridge:
+        aliases:
+        - node1.emqx.io
 
-  services:
-    emqx1:
-      image: %%IMAGE%%:latest
-      environment:
-      - "EMQX_NODE__NAME=emqx@node1.emqx.io"
-      - "EMQX_CLUSTER__DISCOVERY_STRATEGY=static"
-      - "EMQX_CLUSTER__STATIC__SEEDS=[emqx@node1.emqx.io, emqx@node2.emqx.io]"
-      networks:
-        emqx-bridge:
-          aliases:
-          - node1.emqx.io
+  emqx2:
+    image: %%IMAGE%%:latest
+    environment:
+    - "EMQX_NODE__NAME=emqx@node2.emqx.io"
+    - "EMQX_CLUSTER__DISCOVERY_STRATEGY=static"
+    - "EMQX_CLUSTER__STATIC__SEEDS=[emqx@node1.emqx.io, emqx@node2.emqx.io]"
+    networks:
+      emqx-bridge:
+        aliases:
+        - node2.emqx.io
 
-    emqx2:
-      image: %%IMAGE%%:latest
-      environment:
-      - "EMQX_NODE__NAME=emqx@node2.emqx.io"
-      - "EMQX_CLUSTER__DISCOVERY_STRATEGY=static"
-      - "EMQX_CLUSTER__STATIC__SEEDS=[emqx@node1.emqx.io, emqx@node2.emqx.io]"
-      networks:
-        emqx-bridge:
-          aliases:
-          - node2.emqx.io
-
-  networks:
-    emqx-bridge:
-      driver: bridge
+networks:
+  emqx-bridge:
+    driver: bridge
 ```
 
--	Start the docker-compose cluster
+-	Start the Docker Compose services
 
 ```bash
-  docker-compose -p my_emqx up -d
+docker compose -p my_emqx up -d
 ```
 
 -	View cluster
 
 ```bash
-  $ docker exec -it my_emqx_emqx1_1 sh -c "emqx ctl cluster status"
-  Cluster status: #{running_nodes => ['emqx@node1.emqx.io','emqx@node2.emqx.io'],
-                    stopped_nodes => []}
+$ docker exec -it my_emqx_emqx1_1 sh -c "emqx ctl cluster status"
+Cluster status: #{running_nodes => ['emqx@node1.emqx.io','emqx@node2.emqx.io'],
+                  stopped_nodes => []}
 ```
 
 ### Persistence
@@ -120,7 +118,7 @@ If you want to persist the EMQX docker container, you need to keep the following
 
 Since data in these folders are partially stored under the `/opt/emqx/data/mnesia/${node_name}`, the user also needs to reuse the same node name to see the previous state. To make this work, one needs to set the host part of `EMQX_NODE__NAME` to something static that does not change when you restart or recreate the container. It could be container name, hostname or loopback IP address `127.0.0.1` if you only have one node.
 
-In if you use docker-compose, the configuration would look something like this:
+In if you use Docker Compose, the configuration would look something like this:
 
 ```YAML
 volumes:

--- a/friendica/content.md
+++ b/friendica/content.md
@@ -28,13 +28,13 @@ Now you can access the Friendica installation wizard at http://localhost:8080/ f
 
 ## Using the fpm image
 
-To use the fpm image you need an additional web server that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases you might want use another container or your host as proxy. If you use your host you can address your Friendica container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `docker-compose` file). In both cases you don't want to map the fpm port to you host.
+To use the fpm image you need an additional web server that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases you might want use another container or your host as proxy. If you use your host you can address your Friendica container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `compose.yaml` file). In both cases you don't want to map the fpm port to you host.
 
 ```console
 $ docker run -d %%IMAGE%%:fpm
 ```
 
-As the fastCGI-Process is not capable of serving static files (style sheets, images, ...) the webserver needs access to these files. This can be achieved with the `volumes-from` option. You can find more information in the docker-compose section.
+As the fastCGI-Process is not capable of serving static files (style sheets, images, ...) the webserver needs access to these files. This can be achieved with the `volumes-from` option. You can find more information in the Docker Compose section.
 
 ## Background tasks
 
@@ -159,8 +159,6 @@ The Friendica image supports auto configuration via environment variables. You c
 As an alternative to passing sensitive information via environment variables, _FILE may be appended to the previously listed environment variables, causing the initialization script to load the values for those variables from files present in the container. In particular, this can be used to load passwords from Docker secrets stored in /run/secrets/<secret_name> files. For example:
 
 ```yaml
-version: '3.2'
-
 services:
   db:
     image: mariadb
@@ -220,9 +218,9 @@ Currently, this is only supported for `FRIENDICA_ADMIN_MAIL`, `MYSQL_DATABASE`, 
 
 You have to pull the latest image from the hub (`docker pull %%IMAGE%%`). The stable branch gets checked at every startup and will get updated if no installation was found or a new image is used.
 
-# Running this image with docker-compose
+# Running this image with Docker Compose
 
-The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples what you have to look for.
+The easiest way to get a fully featured and functional setup is using a `compose.yaml` file. There are too many different possibilities to setup your system, so here are only some examples what you have to look for.
 
 At first make sure you have chosen the right base image (fpm or apache) and added the features you wanted (see below). In every case you want to add a database container and docker volumes to get easy access to your persistent data. When you want your server reachable from the internet adding HTTPS-encryption is mandatory! See below for more information.
 
@@ -233,8 +231,6 @@ This version will use the apache image and add a mariaDB container. The volumes 
 Make sure to set the variable `MYSQL_PASSWORD` before run this setup.
 
 ```yaml
-version: '2'
-
 services:
   db:
     image: mariadb
@@ -268,7 +264,7 @@ volumes:
   friendica:
 ```
 
-Then run `docker-compose up -d`, now you can access Friendica at http://localhost:8080/ from your system.
+Then run `docker compose up -d`, now you can access Friendica at http://localhost:8080/ from your system.
 
 ## Base version - FPM
 
@@ -281,11 +277,9 @@ As this setup does **not include encryption** it should to be run behind a proxy
 Prerequisites for this example:
 
 -	Make sure to set the variable `MYSQL_PASSWORD` and `MYSQL_USER` before you run the setup.
--	Create a `nginx.conf` in the same directory as the docker-compose.yml file (take it from [example](https://github.com/friendica/docker/tree/master/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/fpm/web/nginx.conf))
+-	Create a `nginx.conf` in the same directory as the `compose.yaml` file (take it from [example](https://github.com/friendica/docker/tree/master/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/fpm/web/nginx.conf))
 
 ```yaml
-version: '2'
-
 services:
   db:
     image: mariadb
@@ -333,7 +327,7 @@ networks:
   proxy-tier:
 ```
 
-Then run `docker-compose up -d`, now you can access Friendica at http://localhost:8080/ from your system.
+Then run `docker compose up -d`, now you can access Friendica at http://localhost:8080/ from your system.
 
 # Special settings for DEV/RC images
 

--- a/geonetwork/content.md
+++ b/geonetwork/content.md
@@ -164,7 +164,7 @@ docker run --name some-%%REPO%% -d -p 8080:8080  -e GN_CONFIG_PROPERTIES="-Dgeon
 
 ### %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080/geonetwork`, `http://localhost:8080/geonetwork`, or `http://host-ip:8080/geonetwork` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080/geonetwork`, `http://localhost:8080/geonetwork`, or `http://host-ip:8080/geonetwork` (as appropriate).
 
 ### Default credentials
 

--- a/ghost/content.md
+++ b/ghost/content.md
@@ -44,7 +44,7 @@ $ docker run -d \
 	%%IMAGE%%:alpine
 ```
 
-Note: `database__connection__filename` is only valid in development mode and is the location for the SQLite database file. If using development mode, it should be set to a writeable path within a persistent folder (bind mount or volume). It is not available in production mode because an external MySQL server is required (see the `docker-compose` example below).
+Note: `database__connection__filename` is only valid in development mode and is the location for the SQLite database file. If using development mode, it should be set to a writeable path within a persistent folder (bind mount or volume). It is not available in production mode because an external MySQL server is required (see the Docker Compose example below).
 
 ### Docker Volume
 
@@ -91,4 +91,4 @@ The following example demonstrates some of the necessary configuration for runni
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).

--- a/joomla/content.md
+++ b/joomla/content.md
@@ -52,7 +52,7 @@ $ docker run --name some-%%REPO%% --network some-network -e JOOMLA_DB_HOST=10.1.
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 ## Adding additional libraries / extensions
 

--- a/matomo/content.md
+++ b/matomo/content.md
@@ -54,9 +54,9 @@ The PHP memory limit can be configured with the following environment variable:
 
 -	`PHP_MEMORY_LIMIT`
 
-## Docker-compose examples and log import instructions
+## Docker Compose examples and log import instructions
 
-A minimal set-up using docker-compose is available in the [.examples folder](%%GITHUB-REPO%%/tree/master/.examples).
+A minimal set-up using Docker Compose is available in the [.examples folder](%%GITHUB-REPO%%/tree/master/.examples).
 
 If you want to use the import logs script, you can then run the following container as needed, in order to execute the python import logs script:
 

--- a/mediawiki/content.md
+++ b/mediawiki/content.md
@@ -48,7 +48,7 @@ $ docker run --rm %%IMAGE%% tar -cC /var/www/html/sites . | tar -xC /path/on/hos
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 ## Adding additional libraries / extensions
 

--- a/monica/content.md
+++ b/monica/content.md
@@ -30,7 +30,7 @@ docker run --name some-%%REPO%% -d -p 9000:9000 %%IMAGE%%:fpm
 
 ### Using an external database
 
-You'll need to setup an external database. Monica currently support MySQL/MariaDB database. You can also link a database container, e. g. `--link my-mysql:db`, and then use `db` as the database host on setup. More info is in the docker-compose section.
+You'll need to setup an external database. Monica currently support MySQL/MariaDB database. You can also link a database container, e. g. `--link my-mysql:db`, and then use `db` as the database host on setup. More info is in the Docker Compose section.
 
 ### Persistent data storage
 
@@ -52,21 +52,21 @@ Like every Laravel application, the `php artisan` command is very usefull for Mo
 docker exec CONTAINER_ID php artisan COMMAND
 ```
 
-or for docker-compose
+Or for Docker Compose:
 
 ```console
-docker-compose exec %%REPO%% php artisan COMMAND
+docker compose exec %%REPO%% php artisan COMMAND
 ```
 
-where `%%REPO%%` is the name of the service in your `docker-compose.yml` file.
+where `%%REPO%%` is the name of the service in your `compose.yaml` file.
 
 ## Configuration using environment variables
 
 The Monica image will use environment variables to setup the application. See [Monica documentation](https://github.com/monicahq/monica/blob/4.x/.env.example) for common used variables you should setup.
 
-## Running the image with docker-compose
+## Running the image with Docker Compose
 
-See some examples of docker-compose possibilities in the [example section](%%GITHUB-REPO%%/blob/main/.examples).
+See some examples of Docker Compose possibilities in the [example section](%%GITHUB-REPO%%/blob/main/.examples).
 
 ---
 
@@ -76,11 +76,9 @@ This version will use the apache image and add a mysql container. The volumes ar
 
 Make sure to pass in values for `APP_KEY` variable before you run this setup.
 
-1.	Create a `docker-compose.yml` file
+1.	Create a `compose.yaml` file
 
 	```yaml
-	version: "3.9"
-
 	services:
 	  app:
 	    image: monica
@@ -120,7 +118,7 @@ Make sure to pass in values for `APP_KEY` variable before you run this setup.
 3.	Run
 
 	```console
-	docker-compose up -d
+	docker compose up -d
 	```
 
 	Wait until all migrations are done and then access Monica at http://localhost:8080/ from your host system. If this looks ok, add your first user account.
@@ -128,7 +126,7 @@ Make sure to pass in values for `APP_KEY` variable before you run this setup.
 4.	Run this command once:
 
 	```console
-	docker-compose exec app php artisan setup:production
+	docker compose exec app php artisan setup:production
 	```
 
 ### FPM version
@@ -143,13 +141,11 @@ When using FPM image, you will need another container with a webserver to proxy 
 	curl -sSL https://raw.githubusercontent.com/monicahq/docker/main/.examples/full/web/Dockerfile -o web/Dockerfile
 	```
 
-	The `web` container image should be pre-build before each deploy with: `docker-compose build`.
+	The `web` container image should be pre-build before each deploy with: `docker compose build`.
 
-2.	Create a `docker-compose.yml` file
+2.	Create a `compose.yaml` file
 
 	```yaml
-	version: "3.9"
-
 	services:
 	  app:
 	    image: monica:fpm
@@ -197,7 +193,7 @@ When using FPM image, you will need another container with a webserver to proxy 
 4.	Run
 
 	```console
-	docker-compose up -d
+	docker compose up -d
 	```
 
 	Wait until all migrations are done and then access Monica at http://localhost:8080/ from your host system. If this looks ok, add your first user account.
@@ -205,7 +201,7 @@ When using FPM image, you will need another container with a webserver to proxy 
 5.	Run this command once:
 
 	```console
-	docker-compose exec app php artisan setup:production
+	docker compose exec app php artisan setup:production
 	```
 
 ## Make Monica available from the internet
@@ -218,4 +214,4 @@ One way to expose your Monica instance is to use a proxy webserver from your hos
 
 ### Using a proxy webserver container
 
-See some examples of docker-compose possibilities in the [example section](%%GITHUB-REPO%%/blob/main/.examples) to show how to a proxy webserver with ssl capabilities.
+See some examples of Docker Compose possibilities in the [example section](%%GITHUB-REPO%%/blob/main/.examples) to show how to a proxy webserver with ssl capabilities.

--- a/mysql/content.md
+++ b/mysql/content.md
@@ -38,7 +38,7 @@ More information about the MySQL command line client can be found in the [MySQL 
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 ## Container shell access and viewing MySQL logs
 
@@ -152,7 +152,7 @@ The `-v /my/own/datadir:/var/lib/mysql` part of the command mounts the `/my/own/
 
 ## No connections until MySQL init completes
 
-If there is no database initialized when the container starts, then a default database will be created. While this is the expected behavior, this means that it will not accept incoming connections until such initialization completes. This may cause issues when using automation tools, such as `docker-compose`, which start several containers simultaneously.
+If there is no database initialized when the container starts, then a default database will be created. While this is the expected behavior, this means that it will not accept incoming connections until such initialization completes. This may cause issues when using automation tools, such as Docker Compose, which start several containers simultaneously.
 
 If the application you're trying to connect to MySQL does not handle MySQL downtime or waiting for MySQL to start gracefully, then putting a connect-retry loop before the service starts might be necessary. For an example of such an implementation in the official images, see [WordPress](https://github.com/docker-library/wordpress/blob/1b48b4bccd7adb0f7ea1431c7b470a40e186f3da/docker-entrypoint.sh#L195-L235) or [Bonita](https://github.com/docker-library/docs/blob/9660a0cccb87d8db842f33bc0578d769caaf3ba9/bonita/stack.yml#L28-L44).
 

--- a/nextcloud/content.md
+++ b/nextcloud/content.md
@@ -26,13 +26,13 @@ Now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 ## Using the fpm image
 
-To use the fpm image, you need an additional web server, such as [nginx](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html), that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases, you might want to use another container or your host as proxy. If you use your host you can address your Nextcloud container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `docker-compose` file). In both cases you don't want to map the fpm port to your host.
+To use the fpm image, you need an additional web server, such as [nginx](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html), that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases, you might want to use another container or your host as proxy. If you use your host you can address your Nextcloud container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `compose.yaml` file). In both cases you don't want to map the fpm port to your host.
 
 ```console
 $ docker run -d %%IMAGE%%:fpm
 ```
 
-As the fastCGI-Process is not capable of serving static files (style sheets, images, ...), the webserver needs access to these files. This can be achieved with the `volumes-from` option. You can find more information in the [docker-compose section](#running-this-image-with-docker-compose).
+As the fastCGI-Process is not capable of serving static files (style sheets, images, ...), the webserver needs access to these files. This can be achieved with the `volumes-from` option. You can find more information in the [Docker Compose section](#running-this-image-with-docker-compose).
 
 ## Using an external database
 
@@ -274,9 +274,9 @@ Check the [Nexcloud documentation](https://docs.nextcloud.com/server/latest/admi
 
 Keep in mind that once set, removing these environment variables won't remove these values from the configuration file, due to how Nextcloud merges configuration files together.
 
-# Running this image with docker-compose
+# Running this image with Docker Compose
 
-The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
+The easiest way to get a fully featured and functional setup is using a `compose.yaml` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
 
 At first, make sure you have chosen the right base image (fpm or apache) and added features you wanted (see below). In every case, you would want to add a database container and docker volumes to get easy access to your persistent data. When you want to have your server reachable from the internet, adding HTTPS-encryption is mandatory! See below for more information.
 
@@ -287,8 +287,6 @@ This version will use the apache image and add a mariaDB container. The volumes 
 Make sure to pass in values for `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` variables before you run this setup.
 
 ```yaml
-version: '2'
-
 volumes:
   nextcloud:
   db:
@@ -322,7 +320,7 @@ services:
       - MYSQL_HOST=db
 ```
 
-Then run `docker-compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
+Then run `docker compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 ## Base version - FPM
 
@@ -333,8 +331,6 @@ As this setup does **not include encryption**, it should be run behind a proxy.
 Make sure to pass in values for `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` variables before you run this setup.
 
 ```yaml
-version: '2'
-
 volumes:
   nextcloud:
   db:
@@ -378,7 +374,7 @@ services:
       - app
 ```
 
-Then run `docker-compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
+Then run `docker compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 # Docker Secrets
 
@@ -460,7 +456,7 @@ In our [examples](https://github.com/nextcloud/docker/tree/master/.examples) sec
 
 # First use
 
-When you first access your Nextcloud, the setup wizard will appear and ask you to choose an administrator account username, password and the database connection. For the database use `db` as host and `nextcloud` as table and user name. Also enter the password you chose in your `docker-compose.yml` file.
+When you first access your Nextcloud, the setup wizard will appear and ask you to choose an administrator account username, password and the database connection. For the database use `db` as host and `nextcloud` as table and user name. Also enter the password you chose in your `compose.yaml` file.
 
 # Update to a newer version
 
@@ -479,11 +475,11 @@ $ docker run <OPTIONS> -d %%IMAGE%%
 
 Beware that you have to run the same command with the options that you used to initially start your Nextcloud. That includes volumes, port mapping.
 
-When using docker-compose your compose file takes care of your configuration, so you just have to run:
+When using Docker Compose, your `compose.yaml` file takes care of your configuration, so you just have to run:
 
 ```console
-$ docker-compose pull
-$ docker-compose up -d
+$ docker compose pull
+$ docker compose up -d
 ```
 
 # Adding Features
@@ -498,7 +494,7 @@ RUN ...
 
 The [examples folder](https://github.com/nextcloud/docker/blob/master/.examples) gives a few examples on how to add certain functionalities, like including the cron job, smb-support or imap-authentication.
 
-If you use your own Dockerfile, you need to configure your docker-compose file accordingly. Switch out the `image` option with `build`. You have to specify the path to your Dockerfile. (in the example it's in the same directory next to the docker-compose file)
+If you use your own Dockerfile, you need to configure your `compose.yaml` file accordingly. Switch out the `image` option with `build`. You have to specify the path to your Dockerfile. (in the example it's in the same directory next to the `compose.yaml` file)
 
 ```yaml
   app:
@@ -531,11 +527,11 @@ docker build -t your-name --pull .
 docker run -d your-name
 ```
 
-or for docker-compose:
+Or for Docker Compose:
 
 ```console
-docker-compose build --pull
-docker-compose up -d
+docker compose build --pull
+docker compose up -d
 ```
 
 The `--pull` option tells docker to look for new versions of the base image. Then the build instructions inside your `Dockerfile` are run on top of the new image.
@@ -544,7 +540,7 @@ The `--pull` option tells docker to look for new versions of the base image. The
 
 You're already using Nextcloud and want to switch to docker? Great! Here are some things to look out for:
 
-1.	Define your whole Nextcloud infrastructure in a `docker-compose` file and run it with `docker-compose up -d` to get the base installation, volumes and database. Work from there.
+1.	Define your whole Nextcloud infrastructure in a `compose.yaml` file and run it with `docker compose up -d` to get the base installation, volumes and database. Work from there.
 
 2.	Restore your database from a mysqldump (nextcloud\_db\_1 is the name of your db container)
 
@@ -552,16 +548,16 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 		```console
 		docker cp ./database.dmp nextcloud_db_1:/dmp
-		docker-compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
-		docker-compose exec db rm /dmp
+		docker compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
+		docker compose exec db rm /dmp
 		```
 
 	-	To import from a PostgreSQL dump use to following commands
 
 		```console
 		docker cp ./database.dmp nextcloud_db_1:/dmp
-		docker-compose exec db sh -c "psql -U USER --set ON_ERROR_STOP=on nextcloud < /dmp"
-		docker-compose exec db rm /dmp
+		docker compose exec db sh -c "psql -U USER --set ON_ERROR_STOP=on nextcloud < /dmp"
+		docker compose exec db rm /dmp
 		```
 
 3.	Edit your config.php
@@ -619,11 +615,11 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 	```console
 	docker cp ./data/ nextcloud_app_1:/var/www/html/
-	docker-compose exec app chown -R www-data:www-data /var/www/html/data
+	docker compose exec app chown -R www-data:www-data /var/www/html/data
 	docker cp ./theming/ nextcloud_app_1:/var/www/html/
-	docker-compose exec app chown -R www-data:www-data /var/www/html/theming
+	docker compose exec app chown -R www-data:www-data /var/www/html/theming
 	docker cp ./config/config.php nextcloud_app_1:/var/www/html/config
-	docker-compose exec app chown -R www-data:www-data /var/www/html/config
+	docker compose exec app chown -R www-data:www-data /var/www/html/config
 	```
 
 	If you want to preserve the metadata of your files like timestamps, copy the data directly on the host to the named volume using plain `cp` like this:
@@ -636,7 +632,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 	```console
 	docker cp ./custom_apps/ nextcloud_data:/var/www/html/
-	docker-compose exec app chown -R www-data:www-data /var/www/html/custom_apps
+	docker compose exec app chown -R www-data:www-data /var/www/html/custom_apps
 	```
 
 # Questions / Issues

--- a/percona/content.md
+++ b/percona/content.md
@@ -40,7 +40,7 @@ More information about the MySQL command line client can be found in the [MySQL 
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 ## Container shell access and viewing MySQL logs
 
@@ -172,7 +172,7 @@ The `-v /my/own/datadir:/var/lib/mysql` part of the command mounts the `/my/own/
 
 ## No connections until MySQL init completes
 
-If there is no database initialized when the container starts, then a default database will be created. While this is the expected behavior, this means that it will not accept incoming connections until such initialization completes. This may cause issues when using automation tools, such as `docker-compose`, which start several containers simultaneously.
+If there is no database initialized when the container starts, then a default database will be created. While this is the expected behavior, this means that it will not accept incoming connections until such initialization completes. This may cause issues when using automation tools, such as Docker Compose, which start several containers simultaneously.
 
 If the application you're trying to connect to MySQL does not handle MySQL downtime or waiting for MySQL to start gracefully, then a putting a connect-retry loop before the service starts might be necessary. For an example of such an implementation in the official images, see [WordPress](https://github.com/docker-library/wordpress/blob/1b48b4bccd7adb0f7ea1431c7b470a40e186f3da/docker-entrypoint.sh#L195-L235) or [Bonita](https://github.com/docker-library/docs/blob/9660a0cccb87d8db842f33bc0578d769caaf3ba9/bonita/stack.yml#L28-L44).
 

--- a/phpmyadmin/content.md
+++ b/phpmyadmin/content.md
@@ -62,7 +62,7 @@ You can use arbitrary servers by adding the environment variable `PMA_ARBITRARY=
 docker run --name phpmyadmin -d -e PMA_ARBITRARY=1 -p 8080:80 %%IMAGE%%
 ```
 
-## Usage with docker-compose and arbitrary server
+## Usage with Docker Compose and arbitrary server
 
 This will run phpMyAdmin with the arbitrary server option - allowing you to specify any MySQL/MariaDB server on the login page.
 

--- a/storm/content.md
+++ b/storm/content.md
@@ -54,7 +54,7 @@ $ docker run -it -v $(pwd)/topology.jar:/topology.jar %%IMAGE%% storm jar /topol
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml storm` (or `docker-compose -f stack.yml up`) and wait for it to initialize completely. The Nimbus will be available at `http://swarm-ip:6627`, `http://localhost:6627`, or `http://host-ip:6627` (as appropriate).
+Run `docker stack deploy -c stack.yml storm` (or `docker compose -f stack.yml up`) and wait for it to initialize completely. The Nimbus will be available at `http://swarm-ip:6627`, `http://localhost:6627`, or `http://host-ip:6627` (as appropriate).
 
 ## Configuration
 


### PR DESCRIPTION
Not an exhaustive update (didn't want to touch the `stack.yml` stuff yet, could do in a follow-up) but updated references to old `docker-compose` binary and changed the filename from `docker-compose.yml` to `compose.yaml`, where it made sense to do so.