### PR TITLE
fix: remove obsolete docker compose file version

### DIFF
--- a/wordpress/stack.yml
+++ b/wordpress/stack.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
 
   wordpress:


### PR DESCRIPTION
Based on [this reference](https://docs.docker.com/reference/compose-file/version-and-name/), there is no need to compose file version.