### PR TITLE
fix(README): Fix indent problem for environments keyword

### DIFF
--- a/odoo/content.md
+++ b/odoo/content.md
@@ -132,9 +132,9 @@ services:
     ports:
       - "8069:8069"
     environment:
-    - HOST=mydb
-    - USER=odoo
-    - PASSWORD=myodoo
+      - HOST=mydb
+      - USER=odoo
+      - PASSWORD=myodoo
   mydb:
     image: postgres:15
     environment:


### PR DESCRIPTION
As I use docker-compose.yml example, I saw an indentation problem.

Is that OK?