### PR TITLE
Add PHP PIE for installing extensions to docs

### DIFF
--- a/php/content.md
+++ b/php/content.md
@@ -78,8 +78,14 @@ The latest recommended way of installing PHP extensions is through [PIE](https:/
 ```dockerfile
 FROM %%IMAGE%%:8.2-cli
 
-# Install PIE here (see https://github.com/php/pie/blob/main/docs/usage.md)
+# Install PIE here; e.g. through using Docker
+RUN export DEBIAN_FRONTEND="noninteractive"; \
+    set -eux; \
+    apt-get update; apt-get install -y --no-install-recommends unzip; \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
+# Use PIE to install extensions
 RUN pie install phpredis/phpredis:^6.1 \
 	&& pie install xdebug/xdebug:^3.4
 ```


### PR DESCRIPTION
Based on the discussion in https://github.com/docker-library/php/issues/1554, PHP PIE is not likely to be included as part of the official PHP image. However, as it aims to replace PECL as the official way for installing PHP extensions, consumers of the PHP image should probably be informed on using this tool.

## To Do/Discuss
- [x] Decide on whether or not to suggest an explicit way of installing PIE in the example, or just leave the reference to the docs as I did now
  - In particular the core extension `zip` is required, so installation is not entirely trivial
- [ ] Check whether adding the deprecation notice for PECL is not a bit too eager
- [x] Pending what happens with https://github.com/php/pie/issues/157, adding something like `rm -rf ~/.composer ~/.pie` to the suggested installation steps might be relevant to reduce the size of the built image
- [ ] Wait for further upstream to become more stable
  - See also https://github.com/php/pie/blob/main/docs/supported-extensions.md for a list of supported extensions
