### PR TITLE
Fix broken link to index.ros.org for documentation home page

### DIFF
--- a/ros/README.md
+++ b/ros/README.md
@@ -332,7 +332,7 @@ services:
 
 ## ROS 2
 
-[Index](https://index.ros.org/doc/ros2/): ROS 2 Documentation  
+[Documentation](https://docs.ros.org/): ROS 2 Documentation
 [Design](https://design.ros2.org/): ROS 2 Design Articles
 
 ## ROS 1


### PR DESCRIPTION
Fixes: https://github.com/ros-infrastructure/rosindex/issues/456