### PR TITLE
fix: typo on version name

### DIFF
--- a/eclipse-temurin/content.md
+++ b/eclipse-temurin/content.md
@@ -54,7 +54,7 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 ### Creating a JRE using jlink
 
-On OpenJDK 11+, a JRE can be generated using `jlink`, see the following Dockerfile:
+On OpenJDK 21+, a JRE can be generated using `jlink`, see the following Dockerfile:
 
 ```dockerfile
 # Example of custom Java runtime using jlink in a multi-stage container build


### PR DESCRIPTION
The examples are showing JDK version 21 but the description text above states JDK version 11