### PR TITLE
Fix typos in dind-rootless sed expressions

### DIFF
--- a/docker/variant-rootless.md
+++ b/docker/variant-rootless.md
@@ -23,8 +23,8 @@ To run with a different UID/GID than the one baked into the image, modify `/etc/
 FROM %%IMAGE%%:dind-rootless
 USER root
 RUN set -eux; \
-	sed -i -e 's/^rootless:1000:1000:/rootless:1234:5678:/' /etc/passwd; \
-	sed -i -e 's/^rootless:1000:/:5678:/' /etc/group; \
+	sed -i -e 's/^rootless:x:1000:1000:/rootless:x:1234:5678:/' /etc/passwd; \
+	sed -i -e 's/^rootless:x:1000:/rootless:x:5678:/' /etc/group; \
 	chown -R rootless ~rootless
 USER rootless
 ```


### PR DESCRIPTION
Verified properly this time:

```console
$ cat Dockerfile
FROM docker:dind-rootless
USER root
RUN set -eux; \
	sed -i -e 's/^rootless:x:1000:1000:/rootless:x:1234:5678:/' /etc/passwd; \
	sed -i -e 's/^rootless:x:1000:/rootless:x:5678:/' /etc/group; \
	chown -R rootless ~rootless
USER rootless

$ docker buildx build --pull --tag tianon/dind1234 .
...
#6 exporting to image
#6 exporting layers done
#6 writing image sha256:114395aef97f155e9d229b3b2328e2149ae689b18f115cb6e3900ed469c7fdad done
#6 naming to docker.io/tianon/dind1234 done
#6 DONE 0.0s

$ docker run -dit --rm --name dind --privileged tianon/dind1234
508c64a236d9ef97f6e533128ab1ea16928f79f354286d45483b96039094cc41

$ docker logs --tail=2 dind
INFO[2025-03-03T20:55:39.874459873Z] API listen on /run/user/1234/docker.sock     
INFO[2025-03-03T20:55:39.874496567Z] API listen on [::]:2376                      

$ docker exec -it dind docker-entrypoint.sh docker run --rm hello-world
Unable to find image 'hello-world:latest' locally
latest: Pulling from library/hello-world
e6590344b1a5: Pull complete 
Digest: sha256:bfbb0cc14f13f9ed1ae86abc2b9f11181dc50d779807ed3a3c5e55a6936dbdd5
Status: Downloaded newer image for hello-world:latest

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (amd64)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/

$ docker top dind o uid,comm,pid
UID                 COMMAND             PID
1234                rootlesskit         112943
1234                exe                 113077
1234                vpnkit              113093
1234                docker-init         113107
1234                dockerd             113111
1234                containerd          113128
```

Follow-up to https://github.com/docker-library/docs/pull/2546
Updates https://github.com/docker-library/docker/issues/528