### PR TITLE
Update MariaDB Readme with port binding information and remove double space

### DIFF
--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -76,8 +76,8 @@ The intent is also to maintain high compatibility with MySQL, ensuring a library
 ![logo](https://raw.githubusercontent.com/docker-library/docs/554e4b9aaac2e266b9ab31e9a312cb6f96d69286/mariadb/logo.png)
 
 # How to use this image
-
-The mariadb has a number of tags, and of note is `latest`, as the latest stable version, and `lts`, as the last long term support release.
+> [!NOTE]
+> The mariadb has a number of tags, and of note is `latest`, as the latest stable version, and `lts`, as the last long term support release.
 
 ## Running the container
 
@@ -86,7 +86,7 @@ The mariadb has a number of tags, and of note is `latest`, as the latest stable 
 The environment variables required to use this image involves the setting of the root user password:
 
 ```console
-$ docker run --detach --name some-mariadb --env MARIADB_ROOT_PASSWORD=my-secret-pw mariadb:latest
+$ docker run --detach --name some-mariadb --env MARIADB_ROOT_PASSWORD=my-secret mariadb:latest
 ```
 
 or:

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -76,7 +76,7 @@ The intent is also to maintain high compatibility with MySQL, ensuring a library
 ![logo](https://raw.githubusercontent.com/docker-library/docs/554e4b9aaac2e266b9ab31e9a312cb6f96d69286/mariadb/logo.png)
 
 # How to use this image
-> [!NOTE]
+> [!IMPORTANT]
 > The mariadb has a number of tags, and of note is `latest`, as the latest stable version, and `lts`, as the last long term support release.
 
 ## Running the container
@@ -150,7 +150,7 @@ $ docker run --detach --name some-mariadb --env MARIADB_USER=example-user --env 
 By default, the database running within the container will listen on port 3306. You can expose the container port 3306 to the host port 3306 with the `-p 3306:3306` argument to `docker run`, like the command below:
 
 ```console
-docker run --name some-mariadb -p 3306:3306 mariadb:latest
+$ docker run --name some-mariadb -p 3306:3306 mariadb:latest
 ```
 
 As applications talk to MariaDB, MariaDB needs to start in the same network as the application:


### PR DESCRIPTION
This pull request includes several updates to the `mariadb/README.md` file to improve clarity and provide important warnings and configuration details. The most important changes include the addition of important notes and warnings, updates to example commands and configurations, and the inclusion of port binding instructions.

Documentation improvements:

* Added an important note about the `latest` and `lts` tags for the MariaDB image.
* Updated the example command to set the root user password, changing `my-secret-pw` to `my-secret`.
* Changed the example `docker-compose.yml` to `stack.yml` and added a warning about using root/example as user/password credentials.
* Added a new section on port binding, explaining how to expose the container port 3306 to the host port 3306.
* Updated the example command for running the MariaDB command line client to include the password `example`.
* Changed the example command for using `mariadb-backup` to use the `lts` tag instead of a specific version.