### PR TITLE
docs: update readme from mariadb with port binding, tags, remove double spaces and informations

### DIFF
--- a/mariadb/content.md
+++ b/mariadb/content.md
@@ -8,7 +8,8 @@ The intent is also to maintain high compatibility with MySQL, ensuring a library
 
 # How to use this image
 
-The %%IMAGE%% has a number of tags, and of note is `latest`, as the latest stable version, and `lts`, as the last long term support release.
+> [!IMPORTANT]
+> The %%IMAGE%% has a number of tags, and of note is `latest`, as the latest stable version, and `lts`, as the last long term support release.
 
 ## Running the container
 
@@ -17,26 +18,26 @@ The %%IMAGE%% has a number of tags, and of note is `latest`, as the latest stabl
 The environment variables required to use this image involves the setting of the root user password:
 
 ```console
-$ docker run --detach --name some-%%REPO%% --env MARIADB_ROOT_PASSWORD=my-secret-pw  %%IMAGE%%:latest
+$ docker run --detach --name some-%%REPO%% --env MARIADB_ROOT_PASSWORD=my-secret-pw %%IMAGE%%:latest
 ```
 
 or:
 
 ```console
-$ docker run --detach --name some-%%REPO%% --env MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1  %%IMAGE%%:latest
+$ docker run --detach --name some-%%REPO%% --env MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 %%IMAGE%%:latest
 ```
 
 or:
 
 ```console
-$ docker run --detach --name some-%%REPO%% --env MARIADB_RANDOM_ROOT_PASSWORD=1  %%IMAGE%%:latest
+$ docker run --detach --name some-%%REPO%% --env MARIADB_RANDOM_ROOT_PASSWORD=1 %%IMAGE%%:latest
 ```
 
 ... where the container logs will contain the generated root password.
 
 ## %%STACK%%
 
-Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker-compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
+Run `docker stack deploy -c stack.yml %%REPO%%` (or `docker compose -f stack.yml up`), wait for it to initialize completely, and visit `http://swarm-ip:8080`, `http://localhost:8080`, or `http://host-ip:8080` (as appropriate).
 
 ### Start a `%%IMAGE%%` server instance with user, password and database
 
@@ -45,7 +46,15 @@ Starting a MariaDB instance with a user, password, and a database:
 ```console
 $ docker run --detach --name some-%%REPO%% --env MARIADB_USER=example-user --env MARIADB_PASSWORD=my_cool_secret --env MARIADB_DATABASE=exmple-database --env MARIADB_ROOT_PASSWORD=my-secret-pw  %%IMAGE%%:latest
 ```
+#### Configuration
 
+##### Port binding
+
+By default, the database running within the container will listen on port 3306. You can expose the container port 3306 to the host port 3306 with the `-p 3306:3306` argument to `docker run`, like the command below:
+
+```console
+$ docker run --name some-mariadb -p 3306:3306 mariadb:latest
+```
 ### Start a `%%IMAGE%%` server instance in a network
 
 As applications talk to MariaDB, MariaDB needs to start in the same network as the application:

--- a/mariadb/stack.yml
+++ b/mariadb/stack.yml
@@ -3,7 +3,7 @@
 services:
 
   db:
-    image: mariadb:latest
+    image: mariadb:11.7-ubi
     restart: always
     environment:
       MARIADB_ROOT_PASSWORD: example

--- a/mariadb/stack.yml
+++ b/mariadb/stack.yml
@@ -1,16 +1,17 @@
 # Use root/example as user/password credentials
-version: '3.1'
 
 services:
 
   db:
-    image: mariadb
+    image: mariadb:latest
     restart: always
     environment:
       MARIADB_ROOT_PASSWORD: example
+    ports:
+      - 3306:3306
 
   adminer:
-    image: adminer
+    image: adminer:4.17.1
     restart: always
     ports:
       - 8080:8080


### PR DESCRIPTION
This pull request includes updates to the `mariadb` documentation and configuration files to improve clarity and compatibility, as well as to specify versions for certain images.

Documentation improvements:

* [`mariadb/content.md`](diffhunk://#diff-e7ab7ccc549c315a1512ce8cfc184a2be06cf7011b83d7d9a8bc87f2b5b28702L11-R12): Added an important note about the `%%IMAGE%%` tags to highlight the `latest` and `lts` versions.
* [`mariadb/content.md`](diffhunk://#diff-e7ab7ccc549c315a1512ce8cfc184a2be06cf7011b83d7d9a8bc87f2b5b28702L39-R40): Updated the Docker compose command to use `docker compose` instead of `docker-compose` for consistency with the latest Docker CLI.
* [`mariadb/content.md`](diffhunk://#diff-e7ab7ccc549c315a1512ce8cfc184a2be06cf7011b83d7d9a8bc87f2b5b28702R49-R57): Added a section on port binding to explain how to expose the container port to the host port using the `-p` argument in the `docker run` command.

Configuration updates:

* [`mariadb/stack.yml`](diffhunk://#diff-86280722e23a1fe81d693e9f423077a4fb84ff951eea7663544c75f54960ba1fL2-R14): Specified the image versions for `mariadb` and `adminer` to ensure consistency and compatibility. The `mariadb` image is updated to `11.7-ubi` and `adminer` to `4.17.1`.
* Remove docker compose version on file header - the docker compose version is ***obsolete***