### PR TITLE
Add a `golang:tip` variant section

### DIFF
--- a/golang/variant-tip.md
+++ b/golang/variant-tip.md
@@ -1,0 +1,5 @@
+## `%%IMAGE%%:<version>-tip`
+
+The term "tip" in the Go community is used to refer to the latest development branch ([a leftover convention from previously using `hg` for version control](https://github.com/golang/build/blob/6383021611af0e07cbf0a60222e066662557c796/cmd/coordinator/internal/legacydash/build.go#L313-L314)).
+
+These tags contains builds of Go's latest development branch, and they are updated on a ~weekly cadence.


### PR DESCRIPTION
This describes [the "tip" variant](https://github.com/docker-library/golang/pull/531), but most notably provides a rough estimate for how often it's updated.

(https://github.com/docker-library/golang/issues/464#issuecomment-2730113332)