### PR TITLE
MediaWiki example `docker-compose.yml`: remove obsolete "version" attribute

### DIFF
--- a/mediawiki/stack.yml
+++ b/mediawiki/stack.yml
@@ -16,8 +16,7 @@ services:
       # this yaml and uncomment the following line and use compose to restart
       # the mediawiki service
       # - ./LocalSettings.php:/var/www/html/LocalSettings.php
-  # This key also defines the name of the database host used during setup instead of the default "localhost"
-  database:
+  database: # <- This key defines the name of the database during setup
     image: mariadb
     restart: always
     environment:

--- a/mediawiki/stack.yml
+++ b/mediawiki/stack.yml
@@ -2,7 +2,6 @@
 #
 # Access via "http://localhost:8080"
 #   (or "http://$(docker-machine ip):8080" if using docker-machine)
-version: '3'
 services:
   mediawiki:
     image: mediawiki


### PR DESCRIPTION
This PR follows from discussion on https://phabricator.wikimedia.org/T393171 and makes slight formatting improvement following https://phabricator.wikimedia.org/T254405