### PR TITLE
postgres: Fix incorrect shebang in example initialization script

### DIFF
--- a/postgres/content.md
+++ b/postgres/content.md
@@ -132,7 +132,7 @@ If you would like to do additional initialization in an image derived from this 
 For example, to add an additional user and database, add the following to `/docker-entrypoint-initdb.d/init-user-db.sh`:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL


### PR DESCRIPTION
The `/bin/bash` shebang points does not point to the correct path for bash in the container. Because of this, the initialization scripts will not run. Changing to `/usr/bin/env bash` fixes this problem.

Alternatively `/usr/bin/bash` would also work.