### PR TITLE
Officially deprecate SATOSA for inactivity

### DIFF
--- a/satosa/README-short.txt
+++ b/satosa/README-short.txt
@@ -1,1 +1,1 @@
-SATOSA translates between authentication protocols such as SAML2, OpenID Connect, and OAuth2.
+DEPRECATED; SATOSA translates between auth protocols such as SAML2, OpenID Connect, and OAuth2.

--- a/satosa/deprecated.md
+++ b/satosa/deprecated.md
@@ -1,0 +1,1 @@
+This image is deprecated due to maintainer inactivity (last updated Dec 2023; [docker-library/official-images#15964](https://github.com/docker-library/official-images/pull/15964)).


### PR DESCRIPTION
See:

- https://github.com/docker-library/official-images/pull/15964#issuecomment-2741871173
- https://github.com/docker-library/official-images/pull/16594
- https://github.com/docker-library/official-images/pull/17307
- https://github.com/docker-library/official-images/pull/17382
- https://github.com/IdentityPython/satosa-docker/issues/11

To be explicitly clear, we'd be happy to bring this back / "cancel" this deprecation, but it will require re-commitment and updates to the image.