### PR TITLE
Add small plone deprecation notice

### DIFF
--- a/plone/README-short.txt
+++ b/plone/README-short.txt
@@ -1,1 +1,1 @@
-Plone is a free and open source content management system built on top of Zope.
+DEPRECATED; Plone is a free and open source content management system built on top of Zope.

--- a/plone/deprecated.md
+++ b/plone/deprecated.md
@@ -1,0 +1,5 @@
+All versions of Plone contained in this repository are no longer supported.
+
+It is strongly recommended to migrate to the latest available Plone version. See https://plone.org/download/release-schedule for details.
+
+For documentation about installing Plone 6 using Docker, see https://6.docs.plone.org/install/containers/index.html


### PR DESCRIPTION
This is a simplified alternative to https://github.com/docker-library/docs/pull/2479, now that the status/plan is more clear and straightforward.

cc @avoinea @pnicolli @svx @demarant @Petchesi-Iulian @valipod ([`plone` image maintainers](https://github.com/docker-library/official-images/blob/f92e06ed2ca17b53991ae04fb61ede874e3965db/library/plone#L1-L6))

Closes #2479