### PR TITLE
Rocky Linux: Adding note on where to find the latest versions

### DIFF
--- a/rockylinux/deprecated.md
+++ b/rockylinux/deprecated.md
@@ -1,0 +1,3 @@
+# IMPORTANT NOTE
+
+The Docker team maintains official images. For the most up-to-date container images, please refer to the [Rocky Linux Docker Hub repository](https://hub.docker.com/r/rockylinux/rockylinux).


### PR DESCRIPTION
Rocky Linux users are finding the diff between Docker official images and Rocky Linux images confusing. I spoke with @tianon yesterday about this problem and it seems like oci-import will ease the burden for creating official images.

It's going to take us some time to re-factor, though. Adding a note to help folks find the latest images on the rockylinux/rockylinux page will help reduce confusion between the two. I'm happy to tune the language here, if needed.