### PR TITLE
Add .gitattributes: Ensure Unix line endings for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
On Windows, Git may be configured to checkout LF line endings as CRLF, but this breaks shell scripts.