### PR TITLE
ArangoDB: Revert server language change

### DIFF
--- a/arangodb/content.md
+++ b/arangodb/content.md
@@ -49,9 +49,7 @@ docker inspect --format '{{ .NetworkSettings.IPAddress }}' arangodb-instance
 
 When using Docker, you need to specify the language you want to initialize the server to on the first run in one of the following ways:
 
--	From v3.12.2 onward: Append the `--icu-language` startup option to the end of the Docker command, like `docker run ... %%IMAGE%% --icu-language sv` for a Swedish locale.
-
--	Set the environment variable `LANG` to a locale in the `docker run` command, e.g. `-e LANG=sv`.
+-	Set the environment variable `LANG` to a locale in the `docker run` command, e.g. `-e LANG=sv` for a Swedish locale.
 
 -	Use an `arangod.conf` configuration file that sets a language and mount it into the container. For example, create a configuration file on your host system in which you set `icu-language = sv` at the top (before any `[section]`) and then mount the file over the default configuration file like `docker run -v /your-host-path/arangod.conf:/etc/arangodb3/arangod.conf ...`.
 


### PR DESCRIPTION
Sorry, I need to partially revert #2587. It turns out that forwarding of parameters to the init script is implemented in ArangoDB's images but not the Docker-built ones, which use a different script.