### PR TITLE
registry: use v3 in example

### DIFF
--- a/registry/content.md
+++ b/registry/content.md
@@ -7,7 +7,7 @@ This image contains an implementation of the OCI Distribution spec. See [github.
 ## Run a local registry: Quick Version
 
 ```console
-$ docker run -d -p 5000:5000 --restart always --name registry %%IMAGE%%:2
+$ docker run -d -p 5000:5000 --restart always --name registry %%IMAGE%%:3
 ```
 
 Now, use it from within Docker:


### PR DESCRIPTION
- relates to https://github.com/distribution/distribution-library-image/pull/191#pullrequestreview-3005118644
- relates to https://github.com/docker-library/official-images/pull/18771
- relates to https://github.com/docker-library/official-images/pull/19201

Registry v2 reached EOL, so update the example to use v3.