### PR TITLE
docs: close Oracular

### DIFF
--- a/ubuntu/content.md
+++ b/ubuntu/content.md
@@ -38,6 +38,5 @@ The tarballs published by Canonical, referenced by `dist-*` tags in https://git.
 
 -	[Jammy](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/jammy/ubuntu-oci)
 -	[Noble](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/noble/ubuntu-oci)
--	[Oracular](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/oracular/ubuntu-oci)
 -	[Plucky](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/plucky/ubuntu-oci)
 -	[Questing](https://launchpad.net/~cloud-images-release-managers/+livefs/ubuntu/questing/ubuntu-oci)


### PR DESCRIPTION
Oracular has reached EOL on July 10: https://fridge.ubuntu.com/2025/07/10/ubuntu-24-10-oracular-oriole-reached-end-of-life-on-10th-july-2025/