### PR TITLE
Gradle: Transfer the `gradle` image to Gradle

### DIFF
--- a/gradle/github-repo
+++ b/gradle/github-repo
@@ -1,1 +1,1 @@
-https://github.com/keeganwitt/docker-gradle
+https://github.com/gradle/docker-gradle

--- a/gradle/maintainer.md
+++ b/gradle/maintainer.md
@@ -1,1 +1,1 @@
-[Keegan Witt (of the Groovy Project)](%%GITHUB-REPO%%), [with the Gradle Project's approval](https://discuss.gradle.org/t/official-docker-images/21159/8)
+[Gradle, Inc.](%%GITHUB-REPO%%)


### PR DESCRIPTION
Moving the repository and updating to official maintainers from Gradle.