### PR TITLE
Remove not needed WiredTiger option

### DIFF
--- a/mongo/content.md
+++ b/mongo/content.md
@@ -77,18 +77,6 @@ To see the full list of possible options, check the MongoDB manual on [`mongod`]
 $ docker run -it --rm %%IMAGE%% --help
 ```
 
-## Setting WiredTiger cache size limits
-
-By default Mongo will set the `wiredTigerCacheSizeGB` to a value proportional to the host's total memory regardless of memory limits you may have imposed on the container. In such an instance you will want to set the cache size to something appropriate, taking into account any other processes you may be running in the container which would also utilize memory.
-
-Taking the examples above you can configure the cache size to use 1.5GB as:
-
-```console
-$ docker run --name some-%%REPO%% -d %%IMAGE%% --wiredTigerCacheSizeGB 1.5
-```
-
-See [the upstream "WiredTiger Options" documentation](https://docs.mongodb.com/manual/reference/program/mongod/#wiredtiger-options) for more details.
-
 ## Using a custom MongoDB configuration file
 
 For a more complicated configuration setup, you can still use the MongoDB configuration file. `mongod` does not read a configuration file by default, so the `--config` option with the path to the configuration file needs to be specified. Create a custom configuration file and put it in the container by either creating a custom Dockerfile `FROM %%IMAGE%%` or mounting it from the host machine to the container. See the MongoDB manual for a full list of [configuration file](https://docs.mongodb.com/manual/reference/configuration-options/) options.


### PR DESCRIPTION
Mongo documentation URL provided in these instructions says:
 

Support for automatic container memory limit detection using cgroups v1 was implemented in https://github.com/mongodb/mongo/commit/fafe4d03edd877e4c022cb3dd714ab1ea6ae4fcd and using cgroups v2 in https://github.com/mongodb/mongo/commit/6bc31230f0cd0de66f02268c5ce0920c4f27effe .

Also, documentation URL provided in these instructions says:

> In some instances, such as when running in a container, the database can have memory constraints that are lower than the total system memory. In such instances, this memory limit, rather than the total system memory, is used as the maximum RAM available.

The patch removes incorrect information about cache size detection.

P.S. I have also filled a ticket with MongoDB Inc. to remove the following contradicting paragraph a bit later in that paragraph:

> If you run [mongod](https://www.mongodb.com/docs/manual/reference/program/mongod/#mongodb-binary-bin.mongod) in a container (for example, lxc, cgroups, Docker, etc.) that does not have access to all of the RAM available in a system, you must set [--wiredTigerCacheSizeGB](https://www.mongodb.com/docs/manual/reference/program/mongod/#std-option-mongod.--wiredTigerCacheSizeGB) to a value less than the amount of RAM available in the container.