### PR TITLE
Update JRuby examples to use version 10

### DIFF
--- a/jruby/content.md
+++ b/jruby/content.md
@@ -15,7 +15,7 @@ JRuby leverages the robustness and speed of the JVM while providing the same Rub
 ## Create a `Dockerfile` in your Ruby app project
 
 ```dockerfile
-FROM %%IMAGE%%:9
+FROM %%IMAGE%%:10
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
@@ -44,7 +44,7 @@ $ docker run -it --name my-running-script my-ruby-app
 The above example `Dockerfile` expects a `Gemfile.lock` in your app directory. This `docker run` will help you generate one. Run it in the root of your app, next to the `Gemfile`:
 
 ```console
-$ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app %%IMAGE%%:9 bundle install --system
+$ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app %%IMAGE%%:10 bundle install --system
 ```
 
 ## Run a single Ruby script
@@ -52,5 +52,5 @@ $ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app %%IMAGE%%:9 bundle inst
 For many simple, single file projects, you may find it inconvenient to write a complete `Dockerfile`. In such cases, you can run a Ruby script by using the Ruby Docker image directly:
 
 ```console
-$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:9 jruby your-daemon-or-script.rb
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp %%IMAGE%%:10 jruby your-daemon-or-script.rb
 ```


### PR DESCRIPTION
JRuby 10 has been out since April, so this is rather overdue. Just noticed the docs were still 9 today.