### PR TITLE
MySQL: update readme; complete initializing a fresh instance paragraph

### DIFF
--- a/mysql/content.md
+++ b/mysql/content.md
@@ -134,7 +134,7 @@ Currently, this is only supported for `MYSQL_ROOT_PASSWORD`, `MYSQL_ROOT_HOST`, 
 
 # Initializing a fresh instance
 
-When a container is started for the first time, a new database with the specified name will be created and initialized with the provided configuration variables. Furthermore, it will execute files with extensions `.sh`, `.sql` and `.sql.gz` that are found in `/docker-entrypoint-initdb.d`. Files will be executed in alphabetical order. You can easily populate your `%%IMAGE%%` services by [mounting a SQL dump into that directory](https://docs.docker.com/storage/bind-mounts/) and provide [custom images](https://docs.docker.com/reference/dockerfile/) with contributed data. SQL files will be imported by default to the database specified by the `MYSQL_DATABASE` variable.
+When a container is started for the first time, a new database with the specified name will be created and initialized with the provided configuration variables. Furthermore, it will execute files with extensions `.sh`, `.sql`, `.sql.gz`, `.sql.bz2`, `.sql.xz` and `.sql.zst` that are found in `/docker-entrypoint-initdb.d`. Files will be executed in alphabetical order. `.sh` files without file execute permission are sourced rather than executed. You can easily populate your `%%IMAGE%%` services by [mounting a SQL dump into that directory](https://docs.docker.com/storage/bind-mounts/) and provide [custom images](https://docs.docker.com/reference/dockerfile/) with contributed data. SQL files will be imported by default to the database specified by the `MYSQL_DATABASE` variable.
 
 # Caveats
 


### PR DESCRIPTION
Completes and clarifies the “Initializing a fresh instance” section in mysql/content.md to accurately document how initialization files are discovered and executed by the image.

### What changed
Expanded the paragraph to explicitly document:

- Supported file extensions in "/docker-entrypoint-initdb.d": .sh, .sql, .sql.gz, .sql.bz2, .sql.xz, .sql.zst.
- Shell script handling: .sh without execute permission are sourced; executable .sh are run.

### Rationale
The previous text was incomplete/ambiguous about which files run and sourcing vs executing .sh files.
This aligns the docs with the actual behavior in the [entrypoint](https://github.com/docker-library/mysql/blob/3eee88bcaf4066ecef9edce0879053ce0dc3374b/8.4/docker-entrypoint.sh#L56) and aligns with the wording used in the `mariadb` image.

### Impact
Docs-only change