### PR TITLE
chore(influxdb): include notice for tag switch-over

### DIFF
--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -1,3 +1,7 @@
+# Notice
+
+On February 3, 2026, the latest tag for InfluxDB will point to InfluxDB 3 Core. To avoid unexpected upgrades, use specific version tags in your deployments.
+
 # What is InfluxDB?
 
 %%LOGO%%


### PR DESCRIPTION
This adds a warning for when we plan to switch `influxdb:latest` from `2.X OSS` to `3.X Core (OSS)`.