### PR TITLE
Correct examples in 'Changing DocumentRoot'

### DIFF
--- a/php/variant-apache.md
+++ b/php/variant-apache.md
@@ -33,8 +33,8 @@ FROM %%IMAGE%%:7.1-apache
 
 ENV APACHE_DOCUMENT_ROOT /path/to/new/root
 
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
-RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+RUN sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf
+RUN sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 ```
 
 A similar technique could be employed for other Apache configuration options.


### PR DESCRIPTION
Replace single quotes with double quotes so that the variable is replaced