### PR TITLE
Document `dind` and `cli` variants

### DIFF
--- a/docker/variant-cli.md
+++ b/docker/variant-cli.md
@@ -1,0 +1,3 @@
+## `%%IMAGE%%:<version>-cli`
+
+This image contains the Docker client command line interface (CLI) and Docker CLI plugins like `buildx` and `compose`. This is useful if you need to interact with a remote Docker engine but aren't planning to run the Docker engine in the container.

--- a/docker/variant-dind.md
+++ b/docker/variant-dind.md
@@ -1,0 +1,3 @@
+## `%%IMAGE%%:<version>`, `%%IMAGE%%:<version>-dind`
+
+The default variant is the Docker in Docker variant. It contains the Docker engine as well as the Docker CLI and plugins that are included in the `cli` variant. It is useful for running Docker in Docker and for interacting with a Docker engine via the Docker CLI.

--- a/docker/variant.md
+++ b/docker/variant.md
@@ -1,0 +1,8 @@
+# Image Variants
+
+The `%%IMAGE%%` images come in many flavors, each designed for a specific use case.
+
+**Note:** The `%%IMAGE%%:stable`, `%%IMAGE%%:test`, and related "channel" tags have been deprecated since June 2020 (see [docker-library/docker#179](https://github.com/docker-library/docker/pull/179)) and have not been updated since December 2020 (when Docker 20.10 was released). Suggested alternatives are below. `X` is a placeholder for the version; see the supported tags list for the current set of tags.
+
+-	`%%IMAGE%%:stable` ⏩ `%%IMAGE%%:latest`, `%%IMAGE%%:dind`, `%%IMAGE%%:X`, `%%IMAGE%%:cli`, etc
+-	`%%IMAGE%%:test` ⏩ `%%IMAGE%%:rc`, `%%IMAGE%%:rc-dind`, `%%IMAGE%%:X-rc`, `%%IMAGE%%:rc-cli`, etc (only updated when there is an active pre-release; will not point to the same thing as `latest`)


### PR DESCRIPTION
This also adds a section about https://github.com/docker-library/docker/issues/559

Refs:
- https://github.com/docker-library/docker/pull/179
- https://github.com/docker-library/official-images/pull/9253 was the PR that finally removed the `stable` and `test` aliases