### PR TITLE
Update `push.pl` runtime to Perl 5.40 and Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.39-bookworm
+FROM perl:5.40-trixie
 
 RUN set -eux; \
 	apt-get update; \
@@ -7,7 +7,7 @@ RUN set -eux; \
 # https://bugs.debian.org/763056 - SVG rendering in ImageMagick looks awful unless it can use inkscape to render (or RSVG, which is explicitly not compiled into the Debian package??)
 		inkscape \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean
 
 # secure by default ♥ (thanks to sri!)
 ENV PERL_CPANM_OPT --verbose --mirror https://cpan.metacpan.org


### PR DESCRIPTION
Mostly trying to update to Trixie and that required to move to a supported version of Perl like 5.40 which is probably good since 5.39 is unmaintained/unsupported. Unfortunately, the Dockerfile fails to build when switched to Perl 5.42 (failing tests in EV).

I haven't yet tested this like https://github.com/docker-library/docs/pull/2466.