### PR TITLE
Add PeakURL docs

### DIFF
--- a/peakurl/README-short.txt
+++ b/peakurl/README-short.txt
@@ -1,0 +1,1 @@
+PeakURL is a self-hosted URL shortener and branded links platform.

--- a/peakurl/compose.yaml
+++ b/peakurl/compose.yaml
@@ -1,0 +1,46 @@
+name: peakurl
+services:
+  peakurl:
+    image: peakurl
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - 8080:80
+    environment:
+      APACHE_SERVER_NAME: example.com
+      PEAKURL_INSTALL_DB_HOST_DEFAULT: db
+      PEAKURL_INSTALL_DB_PORT_DEFAULT: '3306'
+      PEAKURL_INSTALL_DB_NAME_DEFAULT: peakurl
+      PEAKURL_INSTALL_DB_USER_DEFAULT: peakurl
+      PEAKURL_INSTALL_DB_PASSWORD_DEFAULT: change-this-password
+    volumes:
+      - peakurl:/var/www/html
+
+  db:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: peakurl
+      MYSQL_USER: peakurl
+      MYSQL_PASSWORD: change-this-password
+      MYSQL_ROOT_PASSWORD: change-this-root-password
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-name-resolve
+    volumes:
+      - mysql:/var/lib/mysql
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - mysqladmin ping -h 127.0.0.1 -p$$MYSQL_ROOT_PASSWORD --silent
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+volumes:
+  peakurl:
+  mysql:

--- a/peakurl/content.md
+++ b/peakurl/content.md
@@ -1,0 +1,121 @@
+# What is PeakURL?
+
+PeakURL is a self-hosted URL shortener and branded links platform. It lets you create short links on your own domain, manage them from a web dashboard, and keep your link data under your own control.
+
+> [PeakURL/PeakURL](https://github.com/PeakURL/PeakURL)
+
+%%LOGO%%
+
+Use an exact version tag when you want a repeatable deployment.
+
+# How to use this image
+
+## Start a `%%IMAGE%%` server instance
+
+PeakURL needs a MySQL-compatible database. The examples below use `mysql:8.4`.
+
+Create a network:
+
+```bash
+docker network create peakurl
+```
+
+Start MySQL:
+
+```bash
+docker run -d \
+    --name peakurl-db \
+    --network peakurl \
+    --env MYSQL_DATABASE=peakurl \
+    --env MYSQL_USER=peakurl \
+    --env MYSQL_PASSWORD=change-this-password \
+    --env MYSQL_ROOT_PASSWORD=change-this-root-password \
+    --volume peakurl-db:/var/lib/mysql \
+    mysql:8.4 \
+    --character-set-server=utf8mb4 \
+    --collation-server=utf8mb4_unicode_ci \
+    --skip-name-resolve
+```
+
+Then start PeakURL:
+
+```bash
+docker run -d \
+    --name some-%%REPO%% \
+    --network peakurl \
+    --publish 8080:80 \
+    --env APACHE_SERVER_NAME=example.com \
+    --env PEAKURL_INSTALL_DB_HOST_DEFAULT=peakurl-db \
+    --env PEAKURL_INSTALL_DB_PORT_DEFAULT=3306 \
+    --env PEAKURL_INSTALL_DB_NAME_DEFAULT=peakurl \
+    --env PEAKURL_INSTALL_DB_USER_DEFAULT=peakurl \
+    --env PEAKURL_INSTALL_DB_PASSWORD_DEFAULT=change-this-password \
+    --volume peakurl-data:/var/www/html \
+    %%IMAGE%%
+```
+
+Then open `http://localhost:8080/setup-config.php` and finish the installer.
+
+## Environment variables
+
+The image keeps configuration intentionally small. Most application setup is completed through the PeakURL web installer.
+
+The main environment variables exposed by this image are:
+
+### `APACHE_SERVER_NAME`
+
+Optional Apache `ServerName` value, usually set to your public domain.
+
+Example:
+
+```bash
+--env APACHE_SERVER_NAME=example.com
+```
+
+### `PEAKURL_INSTALL_DB_HOST_DEFAULT`
+
+Default database host shown in the installer. Usually the database container name on the Docker network.
+
+### `PEAKURL_INSTALL_DB_PORT_DEFAULT`
+
+Default database port shown in the installer.
+
+### `PEAKURL_INSTALL_DB_NAME_DEFAULT`
+
+Default database name shown in the installer.
+
+### `PEAKURL_INSTALL_DB_USER_DEFAULT`
+
+Default database username shown in the installer.
+
+### `PEAKURL_INSTALL_DB_PASSWORD_DEFAULT`
+
+Default database password shown in the installer.
+
+## %%COMPOSE%%
+
+Run `docker compose up -d`, wait for the services to become ready, and then open `http://localhost:8080/setup-config.php`.
+
+If you already run Nginx, Apache, Traefik, or another reverse proxy on the host, publish the container on a localhost-only port instead and proxy your public domain to that port.
+
+## Persistent data
+
+Mount `/var/www/html` if you want PeakURL files to persist outside the container.
+
+On first startup, this image copies the bundled PeakURL release package into `/var/www/html` and then runs directly from that path. This keeps the folder layout the same as the upstream release ZIP.
+
+Mount `/var/lib/mysql` on the database container as well if you want database data to persist.
+
+## Reverse proxy and TLS
+
+PeakURL serves plain HTTP inside the container. TLS should be terminated by your reverse proxy or load balancer.
+
+Typical setups place the container behind Nginx, Apache, Traefik, or another proxy that forwards requests to the published container port.
+
+## Updating
+
+To update the container runtime itself, pull the newer image tag and recreate the container.
+
+PeakURL can also update its own application files from the dashboard. If `/var/www/html` is mounted, those dashboard updates persist across container restarts because the full app tree lives in the mounted volume.
+
+Pulling a newer image updates the PHP/Apache runtime and container packaging, but it does not overwrite application files already present in a persisted `/var/www/html` volume.

--- a/peakurl/github-repo
+++ b/peakurl/github-repo
@@ -1,0 +1,1 @@
+https://github.com/PeakURL/containers

--- a/peakurl/license.md
+++ b/peakurl/license.md
@@ -1,0 +1,1 @@
+PeakURL is distributed under the [MIT License](https://github.com/PeakURL/PeakURL/blob/main/LICENSE).

--- a/peakurl/logo.svg
+++ b/peakurl/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 96" role="img" aria-labelledby="title desc">
+  <title id="title">PeakURL</title>
+  <desc id="desc">PeakURL wordmark with link icon</desc>
+  <rect x="0" y="0" width="96" height="96" rx="22" fill="#2b3040"/>
+  <g fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" transform="translate(14 14)">
+    <path d="M28 40a18 18 0 0 0 27.14 1.94l10.8-10.8a18 18 0 0 0-25.46-25.46L34.3 11.86"/>
+    <path d="M40 28a18 18 0 0 0-27.14-1.94l-10.8 10.8a18 18 0 0 0 25.46 25.46l6.16-6.16"/>
+  </g>
+  <text x="120" y="59" fill="#2b3040" font-family="Arial, Helvetica, sans-serif" font-size="38" font-weight="700">PeakURL</text>
+</svg>

--- a/peakurl/maintainer.md
+++ b/peakurl/maintainer.md
@@ -1,0 +1,1 @@
+[PeakURL](%%GITHUB-REPO%%)

--- a/peakurl/metadata.json
+++ b/peakurl/metadata.json
@@ -1,0 +1,8 @@
+{
+  "hub": {
+    "categories": [
+      "content-management-system",
+      "web-analytics"
+    ]
+  }
+}


### PR DESCRIPTION
This adds the initial `peakurl/` docs payload for a proposed Docker Official Image.

PeakURL is an upstream-maintained, MIT-licensed, self-hosted URL shortener and branded links platform.

Included here:
- `README-short.txt`
- `content.md`
- `compose.yaml`
- `github-repo`
- `license.md`
- `maintainer.md`
- `metadata.json`
- `logo.svg`

Notes:
- the docs are written for the proposed official image name `peakurl`
- the content matches the current upstream container behavior from `PeakURL/containers`
- the app is intended to run with an external MySQL container and optional reverse-proxy TLS termination
- the image stores the full app tree in `/var/www/html`, so the docs explicitly explain how dashboard updates and image updates interact

Upstream repos:
- image repo: https://github.com/PeakURL/containers
- application repo: https://github.com/PeakURL/PeakURL
