### PR TITLE
Update docs for ghost

### DIFF
--- a/ghost/compose.yaml
+++ b/ghost/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   ghost:
-    image: ghost:5-alpine
+    image: ghost:6-alpine
     restart: always
     ports:
       - 8080:2368

--- a/ghost/github-repo
+++ b/ghost/github-repo
@@ -1,1 +1,1 @@
-https://github.com/docker-library/ghost
+https://github.com/TryGhost/docker-library-ghost

--- a/ghost/maintainer.md
+++ b/ghost/maintainer.md
@@ -1,1 +1,1 @@
-../.common-templates/maintainer-community.md
+[Ghost Foundation](https://ghost.org)


### PR DESCRIPTION
Ran `./update.sh ghost` locally and for me it would remove the section of README.md on image variants, not sure if that's a quirk of my local setup or something I forgot to update, flagging it here in case that's a known issue