### PR TITLE
geonetwork: update compose example Kibana configuration

### DIFF
--- a/geonetwork/compose.yaml
+++ b/geonetwork/compose.yaml
@@ -52,6 +52,7 @@ services:
         -Des.url=http://elasticsearch:9200
         -Des.username=
         -Des.password=
+        -Dkb.url=http://kibana:5601
         -Dgeonetwork.ESFeaturesProxy.targetUri=http://elasticsearch:9200/gn-features/{_}
         -Dgeonetwork.HttpDashboardProxy.targetUri=http://kibana:5601
 
@@ -108,7 +109,6 @@ services:
       ELASTICSEARCH_URL: http://elasticsearch:9200/
       SERVER_BASEPATH: /geonetwork/dashboards
       SERVER_REWRITEBASEPATH: 'false'
-      KIBANA_INDEX: .dashboards
       XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED: 'true'
     depends_on:
       elasticsearch:


### PR DESCRIPTION
Small updates to the GeoNetwork `compose.yaml` example to align it with the reference stack in [geonetwork/docker-geonetwork](https://github.com/geonetwork/docker-geonetwork):

- Add the `kb.url` property to `GN_CONFIG_PROPERTIES` so GeoNetwork points to the Kibana instance.
- Remove the `KIBANA_INDEX` environment variable from the Kibana service, since it is not supported by Kibana 8.