### PR TITLE
Update xwiki docs to link to the xwiki.org documentation

### DIFF
--- a/xwiki/content.md
+++ b/xwiki/content.md
@@ -4,7 +4,7 @@
 
 As an application wiki, XWiki allows for the storing of structured data and the execution of server side script within the wiki interface. Scripting languages including Velocity, Groovy, Python, Ruby and PHP can be written directly into wiki pages using wiki macros. User-created data structures can be defined in wiki documents and instances of those structures can be attached to wiki documents, stored in a database, and queried using either Hibernate query language or XWiki's own query language.
 
-[XWiki.org's extension wiki](https://extensions.xwiki.org) is home to XWiki extensions ranging from [code snippets](https://snippets.xwiki.org) which can be pasted into wiki pages to loadable core modules. Many of XWiki Enterprise's features are provided by extensions which are bundled with it.
+[XWiki.org's extension wiki](https://extensions.xwiki.org) is home to XWiki extensions ranging from [code snippets](https://snippets.xwiki.org) which can be pasted into wiki pages to loadable core modules. Many of XWiki's features are provided by extensions which are bundled with it.
 
 %%LOGO%%
 

--- a/xwiki/content.md
+++ b/xwiki/content.md
@@ -1,13 +1,13 @@
 # What is XWiki
 
-[XWiki](http://xwiki.org) is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
+[XWiki](https://xwiki.org) is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
 
 As an application wiki, XWiki allows for the storing of structured data and the execution of server side script within the wiki interface. Scripting languages including Velocity, Groovy, Python, Ruby and PHP can be written directly into wiki pages using wiki macros. User-created data structures can be defined in wiki documents and instances of those structures can be attached to wiki documents, stored in a database, and queried using either Hibernate query language or XWiki's own query language.
 
-[XWiki.org's extension wiki](http://extensions.xwiki.org) is home to XWiki extensions ranging from [code snippets](http://snippets.xwiki.org) which can be pasted into wiki pages to loadable core modules. Many of XWiki Enterprise's features are provided by extensions which are bundled with it.
+[XWiki.org's extension wiki](https://extensions.xwiki.org) is home to XWiki extensions ranging from [code snippets](https://snippets.xwiki.org) which can be pasted into wiki pages to loadable core modules. Many of XWiki Enterprise's features are provided by extensions which are bundled with it.
 
 %%LOGO%%
 
 # Usage
 
-Please check the [documentation](https://github.com/xwiki-contrib/docker-xwiki/blob/master/README.md) to learn how to use the XWiki Docker images.
+Please check the [documentation](https://www.xwiki.org/xwiki/bin/view/documentation/xs/admin/installation/methods/install-xwiki-docker/) to learn how to use the XWiki Docker images.

--- a/xwiki/get-help.md
+++ b/xwiki/get-help.md
@@ -1,1 +1,1 @@
-[the XWiki Users Mailing List/Forum](http://dev.xwiki.org/xwiki/bin/view/Community/MailingLists) or [the XWiki IRC channel](http://dev.xwiki.org/xwiki/bin/view/Community/IRC)
+[the XWiki Forum](https://dev.xwiki.org/xwiki/bin/view/Community/Discuss) or [the XWiki Chat](https://dev.xwiki.org/xwiki/bin/view/Community/Chat)

--- a/xwiki/issues.md
+++ b/xwiki/issues.md
@@ -1,1 +1,1 @@
-[the XWiki Docker JIRA project](http://jira.xwiki.org/browse/XDOCKER)
+[the XWiki Docker JIRA project](https://jira.xwiki.org/browse/XDOCKER)

--- a/xwiki/license.md
+++ b/xwiki/license.md
@@ -1,3 +1,3 @@
-XWiki is licensed under the [LGPL 2.1](https://github.com/xwiki-contrib/docker-xwiki/blob/master/LICENSE).
+XWiki is licensed under the [LGPL 2.1](https://github.com/xwiki/xwiki-docker/blob/master/LICENSE).
 
-The Dockerfile repository is also licensed under the [LGPL 2.1](https://github.com/xwiki-contrib/docker-xwiki/blob/master/LICENSE).
+The Dockerfile repository is also licensed under the [LGPL 2.1](https://github.com/xwiki/xwiki-docker/blob/master/LICENSE).


### PR DESCRIPTION
The `Usage` section pointed at the source repository's `README.md`, but the XWiki Docker documentation now lives on xwiki.org, so this links to it directly instead of sending readers through the README:

https://www.xwiki.org/xwiki/bin/view/documentation/xs/admin/installation/methods/install-xwiki-docker/

While in there, a few stale links are refreshed:

- `license.md`: the LICENSE links used the old `xwiki-contrib/docker-xwiki` repository name, which now only resolves through a GitHub rename redirect. The repository is `xwiki/xwiki-docker`.
- `get-help.md`: both targets were renamed upstream — `Community/MailingLists` is now `Community/Discuss` and `Community/IRC` is now `Community/Chat`. The mailing lists are no longer used, so only the forum is linked.
- `content.md`, `issues.md`: `http://` to `https://` on the xwiki.org and jira.xwiki.org links.

`github-repo` is deliberately left unchanged so that it stays consistent with the `GitRepo` value in the official-images `library/xwiki` file; both are to be updated together separately.

`README.md` is not included in this PR, per the contribution guidelines. `./markdownfmt.sh -l xwiki` reports no findings.
