### PR TITLE
eclipse-mosquitto: document actual image tags

### DIFF
--- a/eclipse-mosquitto/content.md
+++ b/eclipse-mosquitto/content.md
@@ -62,3 +62,13 @@ For example, if you use port 1883 and port 8080:
 ```console
 $ docker run -it -p 1883:1883 -p 8080:8080 -v "$PWD/mosquitto/config:/mosquitto/config" %%IMAGE%%
 ```
+
+# Image tags
+
+The supported-tags list at the top of this page is authoritative. Official `%%IMAGE%%` images are Alpine-based. Tag naming does **not** follow a generic "plain version" vs "version-alpine" split:
+
+-	**2.1.x:** tags such as `2.1.2-alpine`, `2.1-alpine`, `alpine`, `2`, and `latest` all refer to the current Alpine 2.1 image. There is no separate non-Alpine `2.1` tag.
+-	**2.0.x (OpenSSL):** tags such as `2.0.22`, `2.0.22-openssl`, `2.0`, `2.0-openssl`, `2-openssl`, and `openssl` refer to the Alpine 2.0 OpenSSL image (TLS-PSK and related OpenSSL features). Prefer an explicit `2.0*` / `*-openssl` tag if you need this line; do not assume `openssl` alone means "latest Mosquitto".
+-	**1.6.x (OpenSSL):** tags such as `1.6.15-openssl` and `1.6-openssl` refer to the Alpine 1.6 OpenSSL image.
+
+If you are unsure which tag to use for current Mosquitto, prefer `latest` or a pinned `2.1*-alpine` tag from the supported-tags list.


### PR DESCRIPTION
### Summary
Hub’s auto-generated Image Variants section implied a generic plain / `-alpine` split (`<version>` was stripped as HTML), and did not document the `openssl` tags. Official Mosquitto images are Alpine-based; `-openssl` marks the 2.0 / 1.6 OpenSSL line.

- Empty `variant-alpine.md` suppresses the misleading shared Alpine boilerplate
- `content.md` adds an Image tags section matching published supported tags

Related: eclipse-mosquitto/mosquitto#3690 / https://github.com/eclipse-mosquitto/mosquitto/pull/3694

### Validation
- Checked against `library/eclipse-mosquitto` supported tags
- Follows empty-`variant-*.md` pattern used elsewhere in this repo

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project contributor terms; AI output was not pasted unreviewed.