### PR TITLE
Fix issues link to still show all issues and PRs

### DIFF
--- a/.template-helpers/issues.md
+++ b/.template-helpers/issues.md
@@ -1,1 +1,1 @@
-[%%GITHUB-REPO%%/issues](%%GITHUB-REPO%%/issues?q=)
+[%%GITHUB-REPO%%/issues](%%GITHUB-REPO%%/issues?q=is:issue+is:pr)


### PR DESCRIPTION
GitHub inadvertently broke our admitted hack with the "new issues experience" so this restores the intent.

Compare https://github.com/docker-library/golang/issues?q= to https://github.com/docker-library/golang/issues?q=is:issue+is:pr

(and see https://web.archive.org/web/20240330132349/https://github.com/docker-library/golang/issues?q= for how this used to render)