### PR TITLE
photon: Update license link and how to information

### DIFF
--- a/photon/content.md
+++ b/photon/content.md
@@ -10,7 +10,7 @@ See the [FAQ](http://vmware.github.io/photon/assets/files/photon_faqs.pdf) for m
 
 ## How to use these images
 
-Photon OS images are intended for use in the **FROM** field of an application's `Dockerfile`. For example, to use VMware Photon 1.0GA as the base of an image, specify `FROM %%IMAGE%%:1.0GA`.
+Photon OS images are intended for use in the **FROM** field of an application's `Dockerfile`. For example, to use VMware Photon OS 5.0 as the base of an image, specify `FROM %%IMAGE%%:5.0`.
 
 ## Support
 

--- a/photon/license.md
+++ b/photon/license.md
@@ -1,1 +1,1 @@
-View [license information](https://github.com/vmware/photon/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/vmware/photon/blob/5.0/LICENSE.md) for the software contained in this image.


### PR DESCRIPTION
Fix broken license link.
Use photon:5.0 example instead of 1.0GA.