### PR TITLE
chore: remove core tag switch-over notice

### DIFF
--- a/influxdb/content.md
+++ b/influxdb/content.md
@@ -1,7 +1,3 @@
-# Notice
-
-On September 15, 2026, the latest tag for InfluxDB will point to InfluxDB 3 Core. To avoid unexpected upgrades, use specific version tags in your deployments.
-
 # What is InfluxDB?
 
 %%LOGO%%


### PR DESCRIPTION
The plans for switching over the tag automatically has changed. So, we're postponing this until we have a clear switch-over date.