### PR TITLE
amazonlinux: add Amazon Linux 2027 (Preview)

### DIFF
--- a/amazonlinux/content.md
+++ b/amazonlinux/content.md
@@ -6,17 +6,30 @@ The Amazon Linux container image contains a minimal set of packages. To install 
 
 Supported major versions of Amazon Linux:
 
+-	[Amazon Linux 2027](https://aws.amazon.com/linux/amazon-linux-2027/) (Preview)
 -	[Amazon Linux 2023](https://aws.amazon.com/linux/amazon-linux-2023/) (recommended, latest)
 
 Amazon Linux 2 reached end of life on June 30, 2026 (see [AL2 FAQs](https://aws.amazon.com/amazon-linux-2/faqs/)). Amazon Linux AMI (AL1) reached end of life on December 31, 2023. Please migrate to Amazon Linux 2023.
 
 For information on security updates for Amazon Linux, please refer to:
 
+-	[Amazon Linux 2027 Security Advisories](https://alas.aws.amazon.com/alas2027.html)
 -	[Amazon Linux 2023 Security Advisories](https://alas.aws.amazon.com/alas2023.html)
 
 Note that Docker Hub's vulnerability scanning for Amazon Linux is currently based on RPM versions, which does not reflect the state of backported patches for vulnerabilities.
 
 %%LOGO%%
+
+## What is Amazon Linux 2027 (Preview)?
+
+Amazon Linux 2027 is the next generation of Amazon Linux from Amazon Web Services (AWS). AL2027 is the successor to Amazon Linux 2023. It is currently available for preview and is intended for evaluation and testing only; it is not recommended for production workloads. By default, AL2027 instances do not automatically receive any updates, including critical and important security updates.
+
+-	Amazon Linux 2027: https://aws.amazon.com/linux/amazon-linux-2027/
+-	2027 Release Notes: https://docs.aws.amazon.com/linux/al2027/release-notes/relnotes.html
+-	FAQs: https://aws.amazon.com/linux/amazon-linux-2027/#ams%23rt-groupable-faqc9%23pattern-data
+-	Comparison with AL2023: https://docs.aws.amazon.com/linux/al2027/ug/compare-with-al2023.html
+-	User Guide: https://docs.aws.amazon.com/linux/al2027/ug/what-is-amazon-linux-2027.html
+-	GitHub Issues: https://github.com/amazonlinux/amazon-linux-2027/issues
 
 ## What is Amazon Linux 2023?
 
@@ -25,6 +38,7 @@ Note that Docker Hub's vulnerability scanning for Amazon Linux is currently base
 -	FAQs: https://aws.amazon.com/linux/amazon-linux-2023/faqs/
 -	What's New: https://aws.amazon.com/about-aws/whats-new/2023/03/amazon-linux-2023/
 -	User Guide: https://docs.aws.amazon.com/linux/al2023/ug/what-is-amazon-linux.html
+-	GitHub Issues: https://github.com/amazonlinux/amazon-linux-2023/issues
 
 ## Where can I run Amazon Linux container images?
 
@@ -40,7 +54,6 @@ Similar to the Amazon Linux images for AWS EC2 and on-premises use, Amazon Linux
 
 ## What support is available for Amazon Linux outside AWS?
 
--	GitHub Issues: https://github.com/amazonlinux/amazon-linux-2023/issues
 -	Documentation: https://docs.aws.amazon.com/linux/
 -	Paid Support from AWS: https://aws.amazon.com/premiumsupport/
 
@@ -49,6 +62,10 @@ Similar to the Amazon Linux images for AWS EC2 and on-premises use, Amazon Linux
 Yes; Amazon Linux 2023 receives ongoing security and maintenance updates. Amazon Linux 2 reached end of life on June 30, 2026, and Amazon Linux AMI (AL1) reached end of life on December 31, 2023. Please migrate to Amazon Linux 2023.
 
 ## FAQs
+
+### Amazon Linux 2027 (Preview)
+
+-	FAQs: https://aws.amazon.com/linux/amazon-linux-2027/#ams%23rt-groupable-faqc9%23pattern-data
 
 ### Amazon Linux 2023
 


### PR DESCRIPTION
- Add Amazon Linux 2027 (Preview) to the supported versions list
- Add a "What is Amazon Linux 2027 (Preview)?" section (landing, release notes, FAQs, comparison with AL2023, user guide, GitHub Issues)
- Add Amazon Linux 2027 Security Advisories (ALAS 2027)
- Add an AL2027 (Preview) FAQs entry
- Move the per-version GitHub Issues link into the AL2027 and AL2023 sections (was a single AL2023 link in the global support section)

Ref: docker-library/official-images#22198